### PR TITLE
docs: 오픈소스 기본 문서 및 한/영 템플릿 정비

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,61 @@
+---
+name: "버그 제보 / Bug report"
+about: "재현 가능한 버그를 제보합니다 / Report a reproducible bug"
+title: "[Bug] "
+labels: bug
+assignees: ""
+---
+
+## 한국어
+
+### 요약
+
+버그를 명확히 설명해주세요.
+
+### 재현 방법
+
+1.
+2.
+3.
+
+### 기대 동작
+
+원래 어떻게 동작해야 하는지 작성해주세요.
+
+### 실제 동작
+
+실제로 어떤 문제가 발생했는지 작성해주세요.
+
+### 환경 정보
+
+- OS:
+- 버전/커밋:
+- 추가 맥락:
+
+---
+
+## English
+
+### Summary
+
+Describe the bug clearly.
+
+### Steps to Reproduce
+
+1.
+2.
+3.
+
+### Expected Behavior
+
+What should happen.
+
+### Actual Behavior
+
+What actually happened.
+
+### Environment
+
+- OS:
+- Version/Commit:
+- Additional context:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,45 @@
+---
+name: "기능 제안 / Feature request"
+about: "프로젝트 개선 아이디어를 제안합니다 / Suggest an idea for this project"
+title: "[Feature] "
+labels: enhancement
+assignees: ""
+---
+
+## 한국어
+
+### 해결하려는 문제
+
+어떤 문제를 해결하고 싶은지 작성해주세요.
+
+### 제안하는 해결 방법
+
+아이디어를 설명해주세요.
+
+### 고려한 대안
+
+검토했던 다른 접근이 있으면 작성해주세요.
+
+### 추가 맥락
+
+관련 링크나 참고자료가 있으면 첨부해주세요.
+
+---
+
+## English
+
+### Problem
+
+What problem are you trying to solve?
+
+### Proposed Solution
+
+Describe your idea.
+
+### Alternatives Considered
+
+Other approaches you considered.
+
+### Additional Context
+
+Any extra details or links.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+## 한국어
+
+### 변경 요약
+
+무엇을 왜 변경했는지 작성해주세요.
+
+### 관련 이슈
+
+Closes #
+
+### 검증 방법
+
+어떻게 테스트/검증했는지 작성해주세요.
+
+### 체크리스트
+
+- [ ] 변경 범위가 명확하다
+- [ ] 문서를 업데이트했다(필요한 경우)
+- [ ] 테스트/검증 절차를 포함했다
+- [ ] 호환성 깨짐(Breaking change)을 명시했다
+
+---
+
+## English
+
+### Summary
+
+What changed and why?
+
+### Related Issues
+
+Closes #
+
+### Validation
+
+Describe how you tested this change.
+
+### Checklist
+
+- [ ] Scope is focused
+- [ ] Docs updated (if needed)
+- [ ] Tests/validation included
+- [ ] Breaking changes documented

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,148 @@
+# Code of Conduct / 행동 강령
+
+## 한국어 안내
+
+이 프로젝트는 Contributor Covenant 2.1을 행동 강령으로 채택합니다.
+
+- 본 문서의 공식 기준은 아래 English 원문입니다.
+- 한국어 안내는 이해를 돕기 위한 요약이며, 해석 충돌 시 English 원문이 우선합니다.
+- 위반 신고는 프로젝트에서 지정한 행동 강령 연락 채널로 제출해주세요.
+
+핵심 원칙 요약:
+
+- 모든 참여자를 존중하고, 혐오/괴롭힘/모욕적 언행을 금지합니다.
+- 건설적인 피드백과 책임 있는 커뮤니케이션을 지향합니다.
+- 위반 발생 시 운영진은 경고, 일시적 제한, 영구 제한 등의 조치를 취할 수 있습니다.
+
+---
+
+## English (Official Text)
+
+## Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by Mozilla's code of conduct
+enforcement ladder.
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to unic / unic 기여 가이드
+
+## 한국어
+
+기여에 관심 가져주셔서 감사합니다.
+
+### 시작 전에
+
+- 새 이슈를 만들기 전에 기존 이슈를 먼저 검색해주세요.
+- 범위가 큰 변경은 먼저 이슈로 논의해주세요.
+
+### 개발 워크플로우
+
+1. `main`에서 포크하거나 브랜치를 생성합니다.
+2. 목적이 명확한 브랜치를 사용합니다: `feat/...`, `fix/...`, `docs/...`.
+3. 커밋은 작고 설명 가능하게 유지합니다.
+4. 변경 배경과 검증 내용을 포함해 Pull Request를 생성합니다.
+
+### Pull Request 체크리스트
+
+- [ ] 변경 범위가 명확하고 문서화되어 있다.
+- [ ] 기존 동작을 깨지 않는다.
+- [ ] 테스트 또는 검증 절차가 포함되어 있다.
+- [ ] 관련 이슈를 연결했다(있는 경우).
+
+### 커밋 메시지 스타일
+
+명확한 커밋 메시지를 사용해주세요. Conventional Commits를 권장합니다.
+
+- `feat: add ...`
+- `fix: resolve ...`
+- `docs: update ...`
+
+### 행동 강령
+
+프로젝트 참여 시 [Code of Conduct](CODE_OF_CONDUCT.md)를 준수해야 합니다.
+
+---
+
+## English
+
+Thanks for your interest in contributing.
+
+### Before You Start
+
+- Search existing issues before opening a new one.
+- For larger changes, open an issue first to discuss scope.
+
+### Development Workflow
+
+1. Fork or branch from `main`.
+2. Create a focused branch: `feat/...`, `fix/...`, `docs/...`.
+3. Keep commits small and descriptive.
+4. Open a Pull Request with context and testing notes.
+
+### Pull Request Checklist
+
+- [ ] The change is scoped and documented.
+- [ ] Existing behavior is not broken.
+- [ ] Tests or validation steps are included.
+- [ ] Related issue is linked (if any).
+
+### Commit Message Style
+
+Use clear commit messages. Conventional Commits are recommended:
+
+- `feat: add ...`
+- `fix: resolve ...`
+- `docs: update ...`
+
+### Code of Conduct
+
+By participating, you agree to follow the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# unic
+
+## 한국어
+
+`unic` 프로젝트의 오픈소스 저장소입니다.
+
+### 라이선스
+
+이 프로젝트는 [LICENSE](LICENSE) 조건을 따릅니다.
+
+### 커뮤니티 가이드
+
+- 행동 강령: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- 기여 가이드: [CONTRIBUTING.md](CONTRIBUTING.md)
+- 보안 정책: [SECURITY.md](SECURITY.md)
+
+### 시작하기
+
+현재 저장소는 초기 구성(bootstrap) 단계입니다.
+
+1. 저장소를 클론합니다.
+2. 기능 브랜치를 생성합니다.
+3. PR 템플릿에 맞춰 Pull Request를 생성합니다.
+
+### 메인테이너
+
+- 메인테이너 정보를 여기에 추가하세요.
+
+---
+
+## English
+
+Open-source repository for the `unic` project.
+
+### License
+
+This project is licensed under the terms in [LICENSE](LICENSE).
+
+### Community Standards
+
+- Code of Conduct: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- Contributing Guide: [CONTRIBUTING.md](CONTRIBUTING.md)
+- Security Policy: [SECURITY.md](SECURITY.md)
+
+### Getting Started
+
+This repository is currently in bootstrap stage.
+
+1. Clone the repository.
+2. Create a feature branch.
+3. Open a Pull Request using the PR template.
+
+### Maintainers
+
+- Add maintainers here.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy / 보안 정책
+
+## 한국어
+
+### 취약점 제보
+
+보안 취약점은 공개 이슈로 등록하지 말아주세요.
+
+반드시 비공개 채널(프로젝트 보안 담당 메일)로 제보해주세요.
+
+제보 시 아래 정보를 포함해주세요.
+
+- 영향받는 버전 또는 커밋
+- 재현 단계 또는 PoC
+- 영향도(Impact)
+- 가능한 경우 수정 제안
+
+### 응답 목표
+
+- 1차 응답: 영업일 기준 3일 이내
+- 상태 업데이트: 영업일 기준 7일 이내
+
+---
+
+## English
+
+### Reporting a Vulnerability
+
+Please do not report security vulnerabilities in public issues.
+
+Instead, report privately via the project's security contact email.
+
+Please include:
+
+- Affected version/commit
+- Reproduction steps or proof of concept
+- Impact assessment
+- Suggested fix (if available)
+
+### Response Timeline
+
+- Initial response target: within 3 business days
+- Status update target: within 7 business days


### PR DESCRIPTION
## Summary
- add open-source community documents (README, CODE_OF_CONDUCT, CONTRIBUTING, SECURITY)
- add GitHub issue templates and PR template
- convert docs and templates to Korean/English bilingual format

## Notes
- contact emails are intentionally omitted per maintainer preference

## Validation
-  verified markdown files and template structure locally