### PR TITLE
feat: Add Docker-based multi-platform cross build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+target/
+dist/
+.git/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-aws-sdk-rust = "0.1.42"
 clap = { version = "4.5.60", features = ["derive"] }
 crossterm = "0.29.0"
 ratatui = "0.30.0"

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,55 @@
+FROM rust:1.87-bookworm
+
+# Install cross-compilation toolchains
+#   - x86_64-unknown-linux-gnu    : native (no extra packages needed)
+#   - aarch64-unknown-linux-gnu   : gcc-aarch64-linux-gnu
+#   - x86_64-pc-windows-gnu       : gcc-mingw-w64-x86-64
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        gcc-aarch64-linux-gnu \
+        gcc-mingw-w64-x86-64 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add Rust cross-compilation targets
+RUN rustup target add \
+        aarch64-unknown-linux-gnu \
+        x86_64-pc-windows-gnu
+
+# Configure Cargo linkers for each cross target
+RUN mkdir -p /root/.cargo && printf '\
+[target.aarch64-unknown-linux-gnu]\n\
+linker = "aarch64-linux-gnu-gcc"\n\
+\n\
+[target.x86_64-pc-windows-gnu]\n\
+linker = "x86_64-w64-mingw32-gcc"\n\
+' >> /root/.cargo/config.toml
+
+WORKDIR /src
+COPY . .
+
+# Embedded build script:
+#   1. Read APP_NAME and VERSION from Cargo.toml
+#   2. Build for each target
+#   3. Copy artefacts to /output (volume-mounted from host)
+CMD set -e && \
+    APP_NAME=$(grep '^name' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/') && \
+    VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/') && \
+    echo "==> Building ${APP_NAME} v${VERSION}" && \
+    \
+    echo "--- [1/3] x86_64-unknown-linux-gnu ---" && \
+    cargo build --release --target x86_64-unknown-linux-gnu && \
+    \
+    echo "--- [2/3] aarch64-unknown-linux-gnu ---" && \
+    CC=aarch64-linux-gnu-gcc \
+    cargo build --release --target aarch64-unknown-linux-gnu && \
+    \
+    echo "--- [3/3] x86_64-pc-windows-gnu ---" && \
+    CC=x86_64-w64-mingw32-gcc \
+    cargo build --release --target x86_64-pc-windows-gnu && \
+    \
+    mkdir -p /output && \
+    cp target/x86_64-unknown-linux-gnu/release/${APP_NAME}   /output/${APP_NAME}-${VERSION}-linux-amd64 && \
+    cp target/aarch64-unknown-linux-gnu/release/${APP_NAME}  /output/${APP_NAME}-${VERSION}-linux-arm64 && \
+    cp target/x86_64-pc-windows-gnu/release/${APP_NAME}.exe  /output/${APP_NAME}-${VERSION}-windows-amd64.exe && \
+    \
+    echo "==> Build complete. Artefacts in /output:" && \
+    ls -lh /output/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,162 @@
+APP_NAME := unic
+VERSION  := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+DIST_DIR := dist
+
+# Docker settings
+DOCKER_IMAGE := unic-builder
+DOCKER_TAG   := latest
+
+# Build targets
+TARGET_DARWIN_AMD64  := x86_64-apple-darwin
+TARGET_DARWIN_ARM64  := aarch64-apple-darwin
+TARGET_LINUX_AMD64   := x86_64-unknown-linux-gnu
+TARGET_LINUX_ARM64   := aarch64-unknown-linux-gnu
+TARGET_WINDOWS_AMD64 := x86_64-pc-windows-gnu
+
+.PHONY: all clean setup build \
+        build-darwin build-darwin-amd64 build-darwin-arm64 \
+        build-linux build-linux-amd64 build-linux-arm64 \
+        build-windows \
+        archive \
+        docker-builder docker-build docker-build-all
+
+## Default: build for the current platform
+all: build
+
+## Build for current platform (debug)
+build:
+	cargo build
+
+## Build for current platform (release)
+release:
+	cargo build --release
+
+## Install cross-compilation targets via rustup
+setup:
+	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+	source $$HOME/.cargo/env
+	rustup target add $(TARGET_DARWIN_AMD64)
+	rustup target add $(TARGET_DARWIN_ARM64)
+	rustup target add $(TARGET_LINUX_AMD64)
+	rustup target add $(TARGET_LINUX_ARM64)
+	rustup target add $(TARGET_WINDOWS_AMD64)
+	@echo ""
+	@echo "=== Additional dependencies ==="
+	@echo "Linux cross-compile (from macOS):"
+	@echo "  brew install filosottile/musl-cross/musl-cross  # for musl"
+	@echo "  brew install messense/macos-cross-toolchains/x86_64-unknown-linux-gnu"
+	@echo "  brew install messense/macos-cross-toolchains/aarch64-unknown-linux-gnu"
+	@echo ""
+	@echo "Windows cross-compile (from macOS):"
+	@echo "  brew install mingw-w64"
+
+## ── Darwin ──────────────────────────────────────────────
+
+build-darwin: build-darwin-amd64 build-darwin-arm64
+
+build-darwin-amd64:
+	cargo build --release --target $(TARGET_DARWIN_AMD64)
+	@mkdir -p $(DIST_DIR)
+	cp target/$(TARGET_DARWIN_AMD64)/release/$(APP_NAME) \
+	   $(DIST_DIR)/$(APP_NAME)-$(VERSION)-darwin-amd64
+
+build-darwin-arm64:
+	cargo build --release --target $(TARGET_DARWIN_ARM64)
+	@mkdir -p $(DIST_DIR)
+	cp target/$(TARGET_DARWIN_ARM64)/release/$(APP_NAME) \
+	   $(DIST_DIR)/$(APP_NAME)-$(VERSION)-darwin-arm64
+
+## ── Linux ───────────────────────────────────────────────
+
+build-linux: build-linux-amd64 build-linux-arm64
+
+build-linux-amd64:
+	CC=x86_64-unknown-linux-gnu-gcc \
+	cargo build --release --target $(TARGET_LINUX_AMD64)
+	@mkdir -p $(DIST_DIR)
+	cp target/$(TARGET_LINUX_AMD64)/release/$(APP_NAME) \
+	   $(DIST_DIR)/$(APP_NAME)-$(VERSION)-linux-amd64
+
+build-linux-arm64:
+	CC=aarch64-unknown-linux-gnu-gcc \
+	cargo build --release --target $(TARGET_LINUX_ARM64)
+	@mkdir -p $(DIST_DIR)
+	cp target/$(TARGET_LINUX_ARM64)/release/$(APP_NAME) \
+	   $(DIST_DIR)/$(APP_NAME)-$(VERSION)-linux-arm64
+
+## ── Windows ─────────────────────────────────────────────
+
+build-windows:
+	CC=x86_64-w64-mingw32-gcc \
+	cargo build --release --target $(TARGET_WINDOWS_AMD64)
+	@mkdir -p $(DIST_DIR)
+	cp target/$(TARGET_WINDOWS_AMD64)/release/$(APP_NAME).exe \
+	   $(DIST_DIR)/$(APP_NAME)-$(VERSION)-windows-amd64.exe
+
+## ── All platforms ───────────────────────────────────────
+
+build-all: build-darwin build-linux build-windows
+
+## ── Archive (tar.gz / zip) ──────────────────────────────
+
+archive: build-all
+	@cd $(DIST_DIR) && \
+	for f in *-darwin-* *-linux-*; do \
+		[ -f "$$f" ] && tar czf "$$f.tar.gz" "$$f" && echo "Created $$f.tar.gz"; \
+	done; \
+	for f in *.exe; do \
+		[ -f "$$f" ] && zip "$$f.zip" "$$f" && echo "Created $$f.zip"; \
+	done
+
+## ── Clean ───────────────────────────────────────────────
+
+clean:
+	cargo clean
+	rm -rf $(DIST_DIR)
+
+## ── Docker builds ─────────────────────────────────────
+
+## Build the Docker builder image
+docker-builder:
+	docker build -f Dockerfile.build -t $(DOCKER_IMAGE):$(DOCKER_TAG) .
+
+## Build Linux + Windows via Docker (results → dist/)
+docker-build: docker-builder
+	@mkdir -p $(DIST_DIR)
+	docker run --rm \
+		-v $(CURDIR)/$(DIST_DIR):/output \
+		$(DOCKER_IMAGE):$(DOCKER_TAG)
+
+## Build all platforms: Docker (Linux + Windows) + native macOS
+docker-build-all: docker-build build-darwin
+	@echo "All platform builds complete. Check $(DIST_DIR)/"
+
+## ── Help ────────────────────────────────────────────────
+
+help:
+	@echo "Usage: make <target>"
+	@echo ""
+	@echo "Targets:"
+	@echo "  build              Build for current platform (debug)"
+	@echo "  release            Build for current platform (release)"
+	@echo "  setup              Install cross-compilation targets & show deps"
+	@echo ""
+	@echo "  build-darwin       Build for macOS (amd64 + arm64)"
+	@echo "  build-darwin-amd64 Build for macOS Intel"
+	@echo "  build-darwin-arm64 Build for macOS Apple Silicon"
+	@echo ""
+	@echo "  build-linux        Build for Linux (amd64 + arm64)"
+	@echo "  build-linux-amd64  Build for Linux x86_64"
+	@echo "  build-linux-arm64  Build for Linux aarch64"
+	@echo ""
+	@echo "  build-windows      Build for Windows x86_64"
+	@echo ""
+	@echo "  build-all          Build for all platforms"
+	@echo "  archive            Build all + create tar.gz/zip archives"
+	@echo ""
+	@echo "  docker-builder     Build the Docker builder image"
+	@echo "  docker-build       Build Linux + Windows via Docker (→ dist/)"
+	@echo "  docker-build-all   Docker build + native macOS build"
+	@echo ""
+	@echo "  clean              Remove build artifacts"
+	@echo "  help               Show this help"


### PR DESCRIPTION
## Summary
- Docker 기반 멀티 플랫폼 크로스 빌드 환경 구성 (`Dockerfile.build`, `.dockerignore`, `Makefile` 타겟 추가)
- Linux (amd64/arm64) + Windows (amd64) 바이너리를 Docker 컨테이너에서 빌드하여 `dist/`로 출력
- 현재 Rust 1.93+에서 빌드 불가능한 `aws-sdk-rust v0.1.42` 의존성 제거 (미사용 상태)

## Changes
| 파일 | 변경 |
|------|------|
| `Dockerfile.build` | 신규 - `rust:1.87-bookworm` 기반 크로스 컴파일 빌드 이미지 |
| `.dockerignore` | 신규 - `target/`, `dist/`, `.git/` 제외 |
| `Makefile` | 신규 - `docker-builder`, `docker-build`, `docker-build-all` 타겟 추가 |
| `Cargo.toml` | 수정 - 호환 불가 `aws-sdk-rust` 의존성 제거 |

## Usage
```bash
# Linux + Windows 바이너리 빌드 (Docker)
make docker-build

# 전체 플랫폼 빌드 (Docker + 네이티브 macOS)
make docker-build-all
```

## Test plan
- [ ] `make docker-build` 실행 → `dist/`에 Linux/Windows 바이너리 생성 확인
- [ ] `file dist/unic-*` 로 각 바이너리 아키텍처 검증
- [ ] `make docker-build-all` 로 macOS 포함 전체 빌드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)