### PR TITLE
fix: Use non-blocking event polling for TUI quit handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 use cli::Cli;
 use crossterm::{
     ExecutableCommand,
-    event::{self, Event, KeyCode, KeyEventKind},
+    event::{self, Event, KeyCode},
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use ratatui::{Terminal, backend::CrosstermBackend};
@@ -31,10 +31,8 @@ async fn main() -> io::Result<()> {
     while !app.should_quit {
         terminal.draw(|f| tui::render(f, &app))?;
 
-        // Block and wait for a keypress
-        if let Event::Key(key) = event::read()? {
-            // Only trigger on key press (ignores key release events on Windows)
-            if key.kind == KeyEventKind::Press {
+        if event::poll(std::time::Duration::from_millis(100))? {
+            if let Event::Key(key) = event::read()? {
                 match key.code {
                     KeyCode::Char('q') => app.quit(),
                     _ => {}


### PR DESCRIPTION
## Summary
- TUI에서 `q` 키 입력 시 종료되지 않는 버그 수정
- blocking `event::read()` → `event::poll()` + `event::read()` non-blocking 방식으로 변경
- macOS에서 정상 동작하지 않는 `KeyEventKind::Press` 체크 제거

## Test plan
- [x] TUI 실행 후 `q` 키 입력으로 정상 종료 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)