### PR TITLE
ci: Add GitHub Actions workflows for PR test and build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,16 @@
+name: Build
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  build:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test


### PR DESCRIPTION
## Summary
- PR이 열리거나 업데이트될 때 `cargo test`를 실행하는 CI 워크플로우 추가
- PR이 머지될 때 `cargo build --release`를 실행하는 Build 워크플로우 추가

## 추가된 파일
- `.github/workflows/ci.yml` — PR opened/synchronize/reopened 시 테스트 실행
- `.github/workflows/build.yml` — PR merged 시 릴리즈 빌드 실행

## Test plan
- [ ] PR 생성 시 CI 워크플로우가 트리거되어 `cargo test` 실행 확인
- [ ] PR 머지 시 Build 워크플로우가 트리거되어 `cargo build --release` 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)