### PR TITLE
Docs/add project docs and english only

### DIFF
--- a/.kiro/docs/architecture-en.md
+++ b/.kiro/docs/architecture-en.md
@@ -1,0 +1,186 @@
+# UNIC Architecture Document
+
+## Overview
+
+UNIC (Unified Infrastructure Console) is a Rust TUI tool for browsing AWS resources in the terminal.
+It manages authentication contexts via `~/.config/unic/config.yaml` and provides drill-down exploration of AWS services registered in the catalog.
+
+## Tech Stack
+
+| Area | Technology | Version |
+|------|-----------|---------|
+| Language | Rust | Edition 2024 |
+| TUI | ratatui + crossterm | 0.30 / 0.29 |
+| CLI | clap (derive) | 4.5 |
+| AWS | aws-sdk-ec2, aws-sdk-sts | 1.183 / 1.99 |
+| Config | serde_yaml | 0.9 |
+| Async | tokio | 1.49 |
+| Error | anyhow | 1.0 |
+
+## Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────┐
+│                     main.rs                         │
+│  CLI parsing (clap) → subcommand branch or TUI      │
+└──────────┬──────────────────────┬───────────────────┘
+           │                      │
+    ┌──────▼──────┐        ┌──────▼──────┐
+    │  CLI Mode   │        │  TUI Mode   │
+    │  (context)  │        │  (ratatui)  │
+    └──────┬──────┘        └──────┬──────┘
+           │                      │
+    ┌──────▼──────────────────────▼──────┐
+    │              auth/                 │
+    │  config.yaml → SSO or STS branch   │
+    │  ┌─────────┐  ┌─────────┐         │
+    │  │ sso.rs  │  │ sts.rs  │         │
+    │  └─────────┘  └─────────┘         │
+    └──────────────────┬────────────────┘
+                       │
+    ┌──────────────────▼────────────────┐
+    │        app/ (state machine)       │
+    │  Stack-based screen navigation    │
+    │  ┌──────────────────────────┐     │
+    │  │ ServiceList              │     │
+    │  │  └─ FeatureList          │     │
+    │  │      └─ VpcList          │     │
+    │  │          └─ SubnetList   │     │
+    │  │              └─ Result   │     │
+    │  └──────────────────────────┘     │
+    └──────────────────┬────────────────┘
+                       │
+    ┌──────────────────▼────────────────┐
+    │       domain/ (pure models)       │
+    │  catalog.rs: service/feature reg  │
+    │  model.rs: AwsService, FeatureKind│
+    └──────────────────┬────────────────┘
+                       │
+    ┌──────────────────▼────────────────┐
+    │     services/aws/ (API calls)     │
+    │  AwsRepository                    │
+    │  ├─ vpc.rs   (VPC/Subnet/IP)      │
+    │  ├─ rds.rs   (not implemented)    │
+    │  ├─ iam.rs   (not implemented)    │
+    │  ├─ ssm.rs   (not implemented)    │
+    │  ├─ ipcalc.rs (CIDR calculation)  │
+    │  └─ env.rs   (env var handling)   │
+    └───────────────────────────────────┘
+```
+
+## Authentication Flow Details
+
+### Config File Structure (`~/.config/unic/config.yaml`)
+
+```yaml
+version: 1
+current: dev-sso        # Currently active context
+
+defaults:
+  region: us-east-1     # Default when context has no region
+
+contexts:
+  - name: dev-sso       # SSO-based
+    profile: dev-sso
+
+  - name: prod-admin    # STS AssumeRole-based
+    profile: base-user
+    role_arn: arn:aws:iam::111111111111:role/AdministratorAccess
+    external_id: optional-id
+```
+
+### Authentication Branching Logic (`auth/mod.rs`)
+
+```
+Load config.yaml
+    │
+    ├─ role_arn present?
+    │   ├─ YES → Prepare ~/.aws/credentials
+    │   │        → If SSO profile, run aws sso login
+    │   │        → Call STS AssumeRole
+    │   │        → Generate session.env file
+    │   │
+    │   └─ NO → Is it an SSO profile?
+    │       ├─ YES → Run aws sso login
+    │       │        → Set profile env vars
+    │       │
+    │       └─ NO → Set profile env vars only
+```
+
+### SSO Profile Detection
+
+A profile is identified as SSO if its section in `~/.aws/config` or `~/.aws/config.origin` contains a `sso_session` or `sso_start_url` key.
+
+### Credentials File Management
+
+- For STS: if credentials file is missing, restore from backup
+- For SSO: move credentials to backup before SSO login
+- On SSO failure: restore credentials from backup
+
+## TUI Screen Structure
+
+Screens are managed as a `Vec<Screen>` stack:
+
+| Screen | Description | Data Source |
+|--------|-------------|-------------|
+| ServiceList | AWS service list | `catalog::list_services()` |
+| FeatureList | Features for the selected service | `catalog::list_features()` |
+| VpcList | VPC list | `AwsRepository::list_vpcs()` |
+| SubnetList | Subnet list | `AwsRepository::list_subnets()` |
+| ResultView | Scrollable result display | Per-feature API results |
+
+### Key Bindings
+
+| Key | Action |
+|-----|--------|
+| `j` / `↓` | Move down |
+| `k` / `↑` | Move up |
+| `g` / `Home` | Scroll to top |
+| `G` / `End` | Scroll to bottom |
+| `Enter` | Select (next screen) |
+| `Backspace` / `Esc` / `←` | Previous screen |
+| `r` | Refresh current screen |
+| `q` | Quit |
+
+## CLI Subcommands
+
+```
+unic                          # Enter TUI mode
+unic --context dev-sso        # Enter TUI with a specific context
+unic --profile my-profile     # Use a specific profile
+unic --region ap-northeast-2  # Use a specific region
+
+unic context list             # List configured contexts
+unic context current          # Print current context
+unic context use [name]       # Switch context (interactive selection if name omitted)
+```
+
+## Currently Implemented Features
+
+| Service | Feature | Status |
+|---------|---------|--------|
+| VPC | RemainPrivateIP (subnet available IP query) | ✅ Implemented |
+| RDS | ListDBInstances | 🚧 Coming Soon |
+| Route53 | ListHostedZones | 🚧 Coming Soon |
+| IAM | ListUsers | 🚧 Coming Soon |
+
+## New Feature Addition Checklist
+
+1. `src/domain/model.rs` → Add variant to `AwsService` / `FeatureKind` enums
+2. `src/domain/catalog.rs` → Add mapping in `list_services()` / `list_features()`
+3. `src/services/aws/` → Create new file, add `AwsRepository` impl
+4. `src/services/aws/mod.rs` → Register the module
+5. `src/app/actions.rs` → Add new `FeatureKind` branch in `enter()`
+6. If needed: `src/app/types.rs` → Add new `Screen` enum variant
+7. If needed: `Cargo.toml` → Add new AWS SDK crate
+8. Write tests
+
+## Build & Run
+
+```bash
+cargo build --release     # Release build
+cargo run                 # Development run
+cargo test                # Run tests
+```
+
+Docker builds are also supported (see `Dockerfile.build`).

--- a/.kiro/docs/architecture.md
+++ b/.kiro/docs/architecture.md
@@ -1,0 +1,186 @@
+# UNIC 아키텍처 문서
+
+## 개요
+
+UNIC(Unified Infrastructure Console)은 AWS 리소스를 터미널에서 탐색하는 Rust TUI 도구이다.
+`~/.config/unic/config.yaml` 설정 파일을 기반으로 인증 컨텍스트를 관리하고, 카탈로그에 등록된 AWS 서비스를 drill-down 방식으로 탐색한다.
+
+## 기술 스택
+
+| 영역 | 기술 | 버전 |
+|------|------|------|
+| 언어 | Rust | Edition 2024 |
+| TUI | ratatui + crossterm | 0.30 / 0.29 |
+| CLI | clap (derive) | 4.5 |
+| AWS | aws-sdk-ec2, aws-sdk-sts | 1.183 / 1.99 |
+| 설정 | serde_yaml | 0.9 |
+| 비동기 | tokio | 1.49 |
+| 에러 | anyhow | 1.0 |
+
+## 아키텍처 다이어그램
+
+```
+┌─────────────────────────────────────────────────────┐
+│                     main.rs                         │
+│  CLI 파싱 (clap) → subcommand 분기 or TUI 진입      │
+└──────────┬──────────────────────┬───────────────────┘
+           │                      │
+    ┌──────▼──────┐        ┌──────▼──────┐
+    │  CLI Mode   │        │  TUI Mode   │
+    │  (context)  │        │  (ratatui)  │
+    └──────┬──────┘        └──────┬──────┘
+           │                      │
+    ┌──────▼──────────────────────▼──────┐
+    │              auth/                 │
+    │  config.yaml → SSO or STS 분기     │
+    │  ┌─────────┐  ┌─────────┐         │
+    │  │ sso.rs  │  │ sts.rs  │         │
+    │  └─────────┘  └─────────┘         │
+    └──────────────────┬────────────────┘
+                       │
+    ┌──────────────────▼────────────────┐
+    │           app/ (상태 머신)          │
+    │  Screen 스택 기반 네비게이션        │
+    │  ┌──────────────────────────┐     │
+    │  │ ServiceList              │     │
+    │  │  └─ FeatureList          │     │
+    │  │      └─ VpcList          │     │
+    │  │          └─ SubnetList   │     │
+    │  │              └─ Result   │     │
+    │  └──────────────────────────┘     │
+    └──────────────────┬────────────────┘
+                       │
+    ┌──────────────────▼────────────────┐
+    │         domain/ (순수 모델)         │
+    │  catalog.rs: 서비스/기능 등록       │
+    │  model.rs: AwsService, FeatureKind│
+    └──────────────────┬────────────────┘
+                       │
+    ┌──────────────────▼────────────────┐
+    │       services/aws/ (API 호출)     │
+    │  AwsRepository                    │
+    │  ├─ vpc.rs   (VPC/Subnet/IP)      │
+    │  ├─ rds.rs   (미구현)              │
+    │  ├─ iam.rs   (미구현)              │
+    │  ├─ ssm.rs   (미구현)              │
+    │  ├─ ipcalc.rs (CIDR 계산)         │
+    │  └─ env.rs   (환경변수 처리)       │
+    └───────────────────────────────────┘
+```
+
+## 인증 흐름 상세
+
+### 설정 파일 구조 (`~/.config/unic/config.yaml`)
+
+```yaml
+version: 1
+current: dev-sso        # 현재 활성 컨텍스트
+
+defaults:
+  region: us-east-1     # 컨텍스트에 region이 없을 때 기본값
+
+contexts:
+  - name: dev-sso       # SSO 방식
+    profile: dev-sso
+
+  - name: prod-admin    # STS AssumeRole 방식
+    profile: base-user
+    role_arn: arn:aws:iam::111111111111:role/AdministratorAccess
+    external_id: optional-id
+```
+
+### 인증 분기 로직 (`auth/mod.rs`)
+
+```
+config.yaml 로드
+    │
+    ├─ role_arn 존재?
+    │   ├─ YES → ~/.aws/credentials 준비
+    │   │        → SSO profile이면 aws sso login 실행
+    │   │        → STS AssumeRole 호출
+    │   │        → session.env 파일 생성
+    │   │
+    │   └─ NO → SSO profile인가?
+    │       ├─ YES → aws sso login 실행
+    │       │        → profile 환경변수 설정
+    │       │
+    │       └─ NO → profile 환경변수만 설정
+```
+
+### SSO 프로파일 판별
+
+`~/.aws/config` 또는 `~/.aws/config.origin`에서 해당 profile 섹션에 `sso_session` 또는 `sso_start_url` 키가 있으면 SSO로 판별한다.
+
+### credentials 파일 관리
+
+- STS 사용 시: credentials가 없으면 backup에서 복원
+- SSO 사용 시: credentials를 backup으로 이동 후 SSO 로그인
+- SSO 실패 시: backup에서 credentials 복원
+
+## TUI 화면 구조
+
+화면은 `Vec<Screen>` 스택으로 관리된다:
+
+| 화면 | 설명 | 데이터 소스 |
+|------|------|------------|
+| ServiceList | AWS 서비스 목록 | `catalog::list_services()` |
+| FeatureList | 선택한 서비스의 기능 목록 | `catalog::list_features()` |
+| VpcList | VPC 목록 | `AwsRepository::list_vpcs()` |
+| SubnetList | Subnet 목록 | `AwsRepository::list_subnets()` |
+| ResultView | 결과 표시 (스크롤 가능) | 각 기능별 API 결과 |
+
+### 키 바인딩
+
+| 키 | 동작 |
+|----|------|
+| `j` / `↓` | 아래로 이동 |
+| `k` / `↑` | 위로 이동 |
+| `g` / `Home` | 맨 위로 |
+| `G` / `End` | 맨 아래로 |
+| `Enter` | 선택 (다음 화면) |
+| `Backspace` / `Esc` / `←` | 이전 화면 |
+| `r` | 현재 화면 새로고침 |
+| `q` | 종료 |
+
+## CLI 서브커맨드
+
+```
+unic                          # TUI 모드 진입
+unic --context dev-sso        # 특정 컨텍스트로 TUI 진입
+unic --profile my-profile     # 특정 프로파일 사용
+unic --region ap-northeast-2  # 특정 리전 사용
+
+unic context list             # 컨텍스트 목록 출력
+unic context current          # 현재 컨텍스트 출력
+unic context use [name]       # 컨텍스트 전환 (이름 생략 시 대화형 선택)
+```
+
+## 현재 구현된 기능
+
+| 서비스 | 기능 | 상태 |
+|--------|------|------|
+| VPC | RemainPrivateIP (서브넷 가용 IP 조회) | ✅ 구현 완료 |
+| RDS | ListDBInstances | 🚧 Coming Soon |
+| Route53 | ListHostedZones | 🚧 Coming Soon |
+| IAM | ListUsers | 🚧 Coming Soon |
+
+## 새 기능 추가 체크리스트
+
+1. `src/domain/model.rs` → `AwsService` / `FeatureKind` enum에 variant 추가
+2. `src/domain/catalog.rs` → `list_services()` / `list_features()` 매핑 추가
+3. `src/services/aws/` → 새 파일 생성, `AwsRepository` impl 추가
+4. `src/services/aws/mod.rs` → 모듈 등록
+5. `src/app/actions.rs` → `enter()` 에서 새 FeatureKind 분기 추가
+6. 필요 시 `src/app/types.rs` → `Screen` enum에 새 화면 variant 추가
+7. 필요 시 `Cargo.toml` → 새 AWS SDK crate 추가
+8. 테스트 작성
+
+## 빌드 및 실행
+
+```bash
+cargo build --release     # 릴리스 빌드
+cargo run                 # 개발 실행
+cargo test                # 테스트
+```
+
+Docker 빌드도 지원한다 (`Dockerfile.build` 참조).

--- a/.kiro/steering/coding-conventions-en.md
+++ b/.kiro/steering/coding-conventions-en.md
@@ -1,0 +1,128 @@
+---
+inclusion: auto
+---
+
+# UNIC Coding Conventions & Feature Addition Guide
+
+## Module Structure Principles
+
+- `domain/` must not depend on the AWS SDK. It defines pure business models only.
+- `services/aws/` handles actual AWS API calls. Add methods to `AwsRepository`.
+- `app/` is the TUI state machine. Screens are managed via the `Screen` enum.
+- `auth/` contains authentication logic only. It does not couple directly with the TUI.
+
+## How to Add a New AWS Service
+
+### Step 1: Register the Domain Model
+
+Add a new variant to the `AwsService` enum in `src/domain/model.rs`:
+```rust
+pub enum AwsService {
+    Vpc,
+    Rds,
+    Route53,
+    Iam,
+    NewService, // add here
+}
+```
+
+Update `label()` and the `Display` impl accordingly.
+
+### Step 2: Register in the Feature Catalog
+
+Add a feature to the `FeatureKind` enum in `src/domain/model.rs`:
+```rust
+pub enum FeatureKind {
+    RemainPrivateIp,
+    ListDbInstances,
+    NewFeature, // add here
+}
+```
+
+Add the service-to-feature mapping in `src/domain/catalog.rs`:
+```rust
+pub fn list_services() -> Vec<AwsService> {
+    vec![..., AwsService::NewService]
+}
+
+pub fn list_features(service: AwsService) -> Vec<FeatureKind> {
+    match service {
+        ...
+        AwsService::NewService => vec![FeatureKind::NewFeature],
+    }
+}
+```
+
+### Step 3: Implement the AWS API
+
+Create a new file under `src/services/aws/` and implement methods on `AwsRepository`:
+```rust
+// src/services/aws/new_service.rs
+impl AwsRepository {
+    pub async fn list_new_resources(&self) -> Result<Vec<ResourceItem>> {
+        // AWS SDK calls
+    }
+}
+```
+
+Register the module in `src/services/aws/mod.rs`.
+
+Add any required AWS SDK crates to `Cargo.toml`.
+
+### Step 4: Wire Up the TUI Screen
+
+Add a new `FeatureKind` branch in the `enter()` method of `src/app/actions.rs`:
+```rust
+FeatureKind::NewFeature => {
+    match self.fetch_new_resources().await {
+        Ok(items) => Some(Screen::ResultView { ... }),
+        Err(err) => Some(error_screen("Load Failed", &err)),
+    }
+}
+```
+
+If an intermediate selection screen is needed, add a new variant to the `Screen` enum in `src/app/types.rs`.
+
+### Step 5: Add a New SDK Client (if needed)
+
+Add a new client field to `AwsRepository`:
+```rust
+pub struct AwsRepository {
+    pub(super) ec2: Client,
+    pub(super) new_client: NewClient, // add here
+    ...
+}
+```
+
+## Authentication Branching Logic
+
+The core function is `apply_context_side_effects` in `src/auth/mod.rs`:
+- `role_arn` present → STS AssumeRole (`sts.rs`)
+- SSO profile → run `aws sso login` (`sso.rs`)
+- Otherwise → set profile-based env vars
+
+## TUI Screen Structure
+
+Screens are stack-based (`Vec<Screen>`):
+- `Enter` → push a new screen
+- `Backspace/Esc` → pop to return to the previous screen
+- `r` → refresh the current screen
+
+## Writing Tests
+
+- Tests that call `AwsRepository` directly use `RepositoryState::Test`
+- File system tests are isolated with `tempfile::TempDir`
+- `_in` suffix function pattern: internal functions accept a path parameter to allow test-path injection instead of real paths
+
+## Adding CLI Subcommands
+
+Define subcommands in `src/cli/cli.rs` using clap derive macros:
+```rust
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    Context { ... },
+    NewCommand { ... }, // add here
+}
+```
+
+Handle the new command in the match block in `src/main.rs`.

--- a/.kiro/steering/coding-conventions.md
+++ b/.kiro/steering/coding-conventions.md
@@ -1,0 +1,128 @@
+---
+inclusion: auto
+---
+
+# UNIC 코딩 컨벤션 및 기능 추가 가이드
+
+## 모듈 구조 원칙
+
+- `domain/` 은 AWS SDK에 의존하지 않는다. 순수 비즈니스 모델만 정의한다.
+- `services/aws/` 는 실제 AWS API 호출을 담당한다. `AwsRepository`에 메서드를 추가하는 방식이다.
+- `app/` 은 TUI 상태 머신이다. `Screen` enum으로 화면을 관리한다.
+- `auth/` 는 인증 관련 로직만 담는다. TUI와 직접 결합하지 않는다.
+
+## 새로운 AWS 서비스 추가 방법
+
+### 1단계: 도메인 모델 등록
+
+`src/domain/model.rs`의 `AwsService` enum에 새 variant를 추가한다:
+```rust
+pub enum AwsService {
+    Vpc,
+    Rds,
+    Route53,
+    Iam,
+    NewService, // 추가
+}
+```
+
+`label()` 과 `Display` impl도 함께 업데이트한다.
+
+### 2단계: 기능 카탈로그 등록
+
+`src/domain/model.rs`의 `FeatureKind` enum에 기능을 추가한다:
+```rust
+pub enum FeatureKind {
+    RemainPrivateIp,
+    ListDbInstances,
+    NewFeature, // 추가
+}
+```
+
+`src/domain/catalog.rs`에서 서비스-기능 매핑을 추가한다:
+```rust
+pub fn list_services() -> Vec<AwsService> {
+    vec![..., AwsService::NewService]
+}
+
+pub fn list_features(service: AwsService) -> Vec<FeatureKind> {
+    match service {
+        ...
+        AwsService::NewService => vec![FeatureKind::NewFeature],
+    }
+}
+```
+
+### 3단계: AWS API 구현
+
+`src/services/aws/` 에 새 파일을 만들고 `AwsRepository`에 메서드를 구현한다:
+```rust
+// src/services/aws/new_service.rs
+impl AwsRepository {
+    pub async fn list_new_resources(&self) -> Result<Vec<ResourceItem>> {
+        // AWS SDK 호출
+    }
+}
+```
+
+`src/services/aws/mod.rs`에 모듈을 등록한다.
+
+필요한 AWS SDK crate가 있으면 `Cargo.toml`에 추가한다.
+
+### 4단계: TUI 화면 연결
+
+`src/app/actions.rs`의 `enter()` 메서드에서 새 `FeatureKind` 분기를 추가한다:
+```rust
+FeatureKind::NewFeature => {
+    match self.fetch_new_resources().await {
+        Ok(items) => Some(Screen::ResultView { ... }),
+        Err(err) => Some(error_screen("Load Failed", &err)),
+    }
+}
+```
+
+중간 선택 화면이 필요하면 `src/app/types.rs`의 `Screen` enum에 새 variant를 추가한다.
+
+### 5단계: 필요시 새 SDK 클라이언트 추가
+
+`AwsRepository`에 새 클라이언트 필드를 추가한다:
+```rust
+pub struct AwsRepository {
+    pub(super) ec2: Client,
+    pub(super) new_client: NewClient, // 추가
+    ...
+}
+```
+
+## 인증 방식 분기 로직
+
+`src/auth/mod.rs`의 `apply_context_side_effects`가 핵심이다:
+- `role_arn` 존재 → STS AssumeRole (`sts.rs`)
+- SSO profile → `aws sso login` 실행 (`sso.rs`)
+- 그 외 → profile 기반 환경변수 설정
+
+## TUI 화면 구조
+
+화면은 스택 기반이다 (`Vec<Screen>`):
+- `Enter` → 새 화면을 push
+- `Backspace/Esc` → pop으로 이전 화면 복귀
+- `r` → 현재 화면 refresh
+
+## 테스트 작성
+
+- `AwsRepository`를 직접 호출하는 테스트는 `RepositoryState::Test`를 사용한다
+- 파일 시스템 관련 테스트는 `tempfile::TempDir`로 격리한다
+- `_in` 접미사 함수 패턴: 실제 경로 대신 테스트용 경로를 주입할 수 있게 내부 함수를 분리한다
+
+## CLI 서브커맨드 추가
+
+`src/cli/cli.rs`에서 clap derive 매크로로 정의한다:
+```rust
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    Context { ... },
+    NewCommand { ... }, // 추가
+}
+```
+
+`src/main.rs`의 match 분기에서 처리한다.

--- a/.kiro/steering/project-overview-en.md
+++ b/.kiro/steering/project-overview-en.md
@@ -1,0 +1,88 @@
+---
+inclusion: auto
+---
+
+# UNIC Project Overview
+
+UNIC is a Rust-based TUI (Terminal User Interface) tool for browsing and managing AWS resources via a CLI/TUI application.
+
+## Tech Stack
+
+- Language: Rust (Edition 2024)
+- TUI Framework: ratatui 0.30 + crossterm 0.29
+- CLI Parser: clap 4.5 (derive mode)
+- AWS SDK: aws-sdk-ec2, aws-sdk-sts, aws-config, aws-credential-types
+- Config: serde + serde_yaml (YAML-based)
+- Async Runtime: tokio (macros, rt-multi-thread)
+- Error Handling: anyhow
+- Testing: tempfile (dev-dependency)
+
+## Config File Location
+
+`~/.config/unic/config.yaml`
+
+```yaml
+version: 1
+current: dev-sso
+
+defaults:
+  region: us-east-1
+
+contexts:
+  - name: dev-sso
+    profile: dev-sso
+
+  - name: prod-admin
+    profile: base-user
+    role_arn: arn:aws:iam::111111111111:role/AdministratorAccess
+    external_id: optional-external-id
+```
+
+## Authentication Flow
+
+1. Load context from config.yaml
+2. If `role_arn` is present, authenticate via STS AssumeRole
+3. If `role_arn` is absent and the profile is an SSO profile, run `aws sso login`
+4. Otherwise, use profile-based authentication
+
+## Execution Flow
+
+1. Parse CLI arguments → if a subcommand exists, handle it and exit
+2. If no subcommand, enter TUI mode
+3. In TUI, drill down: service catalog → feature selection → resource browsing
+
+## Project Structure
+
+```
+src/
+├── main.rs          # Entry point, CLI parsing + TUI loop
+├── lib.rs           # config module re-export (for external crate use)
+├── config/          # Load/save ~/.config/unic/config.yaml
+├── cli/             # clap-based CLI definitions
+├── auth/            # SSO/STS authentication logic
+│   ├── mod.rs       # apply_context_side_effects (auth branching)
+│   ├── sso.rs       # Run aws sso login
+│   ├── sts.rs       # STS AssumeRole
+│   ├── aws_files.rs # ~/.aws/config & credentials file management
+│   └── session_env.rs # Env var setup + session.env file generation
+├── domain/          # Business domain models
+│   ├── catalog.rs   # Service/feature catalog definitions
+│   └── model.rs     # AwsService, FeatureKind, ResourceItem, etc.
+├── app/             # TUI application state management
+│   ├── mod.rs       # App struct, initialization, key handling
+│   ├── types.rs     # Screen, MenuState, ViewMode types
+│   ├── actions.rs   # enter/refresh screen transition logic
+│   └── navigation.rs # Cursor movement, scrolling
+├── tui/             # ratatui rendering
+│   └── tui.rs       # render function
+└── services/        # AWS API call implementations
+    └── aws/
+        ├── repository.rs # AwsRepository (EC2 Client initialization)
+        ├── vpc.rs        # VPC/Subnet/IP queries
+        ├── rds.rs        # RDS (not yet implemented)
+        ├── iam.rs        # IAM (not yet implemented)
+        ├── ssm.rs        # SSM (not yet implemented)
+        ├── env.rs        # Env var reading + debug lines
+        ├── ipcalc.rs     # CIDR-based available IP calculation
+        └── model.rs      # SubnetIpAvailability
+```

--- a/.kiro/steering/project-overview.md
+++ b/.kiro/steering/project-overview.md
@@ -1,0 +1,88 @@
+---
+inclusion: auto
+---
+
+# UNIC 프로젝트 개요
+
+UNIC은 Rust 기반 TUI(Terminal User Interface) 도구로, AWS 리소스를 탐색하고 관리하기 위한 CLI/TUI 애플리케이션이다.
+
+## 기술 스택
+
+- 언어: Rust (Edition 2024)
+- TUI 프레임워크: ratatui 0.30 + crossterm 0.29
+- CLI 파서: clap 4.5 (derive 모드)
+- AWS SDK: aws-sdk-ec2, aws-sdk-sts, aws-config, aws-credential-types
+- 설정 파일: serde + serde_yaml (YAML 기반)
+- 비동기 런타임: tokio (macros, rt-multi-thread)
+- 에러 처리: anyhow
+- 테스트: tempfile (dev-dependency)
+
+## 설정 파일 위치
+
+`~/.config/unic/config.yaml`
+
+```yaml
+version: 1
+current: dev-sso
+
+defaults:
+  region: us-east-1
+
+contexts:
+  - name: dev-sso
+    profile: dev-sso
+
+  - name: prod-admin
+    profile: base-user
+    role_arn: arn:aws:iam::111111111111:role/AdministratorAccess
+    external_id: optional-external-id
+```
+
+## 인증 흐름
+
+1. config.yaml에서 context를 로드한다
+2. `role_arn`이 있으면 STS AssumeRole 방식으로 인증한다
+3. `role_arn`이 없고 profile이 SSO profile이면 `aws sso login`을 실행한다
+4. 그 외에는 profile 기반 인증을 사용한다
+
+## 실행 흐름
+
+1. CLI 인자 파싱 → subcommand가 있으면 처리 후 종료
+2. subcommand가 없으면 TUI 모드 진입
+3. TUI에서 서비스 목록(catalog) → 기능 선택 → 리소스 탐색 순서로 drill-down
+
+## 프로젝트 구조
+
+```
+src/
+├── main.rs          # 진입점, CLI 파싱 + TUI 루프
+├── lib.rs           # config 모듈 re-export (외부 crate용)
+├── config/          # ~/.config/unic/config.yaml 로드/저장
+├── cli/             # clap 기반 CLI 정의
+├── auth/            # SSO/STS 인증 로직
+│   ├── mod.rs       # apply_context_side_effects (인증 분기)
+│   ├── sso.rs       # aws sso login 실행
+│   ├── sts.rs       # STS AssumeRole
+│   ├── aws_files.rs # ~/.aws/config, credentials 파일 관리
+│   └── session_env.rs # 환경변수 설정 + session.env 파일 생성
+├── domain/          # 비즈니스 도메인 모델
+│   ├── catalog.rs   # 서비스/기능 카탈로그 정의
+│   └── model.rs     # AwsService, FeatureKind, ResourceItem 등
+├── app/             # TUI 애플리케이션 상태 관리
+│   ├── mod.rs       # App 구조체, 초기화, 키 핸들링
+│   ├── types.rs     # Screen, MenuState, ViewMode 등 타입
+│   ├── actions.rs   # enter/refresh 등 화면 전환 로직
+│   └── navigation.rs # 커서 이동, 스크롤
+├── tui/             # ratatui 렌더링
+│   └── tui.rs       # render 함수
+└── services/        # AWS API 호출 구현
+    └── aws/
+        ├── repository.rs # AwsRepository (EC2 Client 초기화)
+        ├── vpc.rs        # VPC/Subnet/IP 조회
+        ├── rds.rs        # RDS (미구현)
+        ├── iam.rs        # IAM (미구현)
+        ├── ssm.rs        # SSM (미구현)
+        ├── env.rs        # 환경변수 읽기 + 디버그 라인
+        ├── ipcalc.rs     # CIDR 기반 가용 IP 계산
+        └── model.rs      # SubnetIpAvailability
+```

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,24 +1,4 @@
-# Code of Conduct / 행동 강령
-
-## 한국어 안내
-
-이 프로젝트는 Contributor Covenant 2.1을 행동 강령으로 채택합니다.
-
-- 본 문서의 공식 기준은 아래 English 원문입니다.
-- 한국어 안내는 이해를 돕기 위한 요약이며, 해석 충돌 시 English 원문이 우선합니다.
-- 위반 신고는 프로젝트에서 지정한 행동 강령 연락 채널로 제출해주세요.
-
-핵심 원칙 요약:
-
-- 모든 참여자를 존중하고, 혐오/괴롭힘/모욕적 언행을 금지합니다.
-- 건설적인 피드백과 책임 있는 커뮤니케이션을 지향합니다.
-- 위반 발생 시 운영진은 경고, 일시적 제한, 영구 제한 등의 조치를 취할 수 있습니다.
-
----
-
-## English (Official Text)
-
-## Contributor Covenant Code of Conduct
+# Contributor Covenant Code of Conduct
 
 ## Our Pledge
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,66 +1,27 @@
-# Contributing to unic / unic 기여 가이드
-
-## 한국어
-
-기여에 관심 가져주셔서 감사합니다.
-
-### 시작 전에
-
-- 새 이슈를 만들기 전에 기존 이슈를 먼저 검색해주세요.
-- 범위가 큰 변경은 먼저 이슈로 논의해주세요.
-
-### 개발 워크플로우
-
-1. `main`에서 포크하거나 브랜치를 생성합니다.
-2. 목적이 명확한 브랜치를 사용합니다: `feat/...`, `fix/...`, `docs/...`.
-3. 커밋은 작고 설명 가능하게 유지합니다.
-4. 변경 배경과 검증 내용을 포함해 Pull Request를 생성합니다.
-
-### Pull Request 체크리스트
-
-- [ ] 변경 범위가 명확하고 문서화되어 있다.
-- [ ] 기존 동작을 깨지 않는다.
-- [ ] 테스트 또는 검증 절차가 포함되어 있다.
-- [ ] 관련 이슈를 연결했다(있는 경우).
-
-### 커밋 메시지 스타일
-
-명확한 커밋 메시지를 사용해주세요. Conventional Commits를 권장합니다.
-
-- `feat: add ...`
-- `fix: resolve ...`
-- `docs: update ...`
-
-### 행동 강령
-
-프로젝트 참여 시 [Code of Conduct](CODE_OF_CONDUCT.md)를 준수해야 합니다.
-
----
-
-## English
+# Contributing to unic
 
 Thanks for your interest in contributing.
 
-### Before You Start
+## Before You Start
 
 - Search existing issues before opening a new one.
 - For larger changes, open an issue first to discuss scope.
 
-### Development Workflow
+## Development Workflow
 
 1. Fork or branch from `main`.
 2. Create a focused branch: `feat/...`, `fix/...`, `docs/...`.
 3. Keep commits small and descriptive.
 4. Open a Pull Request with context and testing notes.
 
-### Pull Request Checklist
+## Pull Request Checklist
 
 - [ ] The change is scoped and documented.
 - [ ] Existing behavior is not broken.
 - [ ] Tests or validation steps are included.
 - [ ] Related issue is linked (if any).
 
-### Commit Message Style
+## Commit Message Style
 
 Use clear commit messages. Conventional Commits are recommended:
 
@@ -68,6 +29,6 @@ Use clear commit messages. Conventional Commits are recommended:
 - `fix: resolve ...`
 - `docs: update ...`
 
-### Code of Conduct
+## Code of Conduct
 
 By participating, you agree to follow the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -1,55 +1,105 @@
 # unic
 
-## 한국어
+`unic` is a Rust-based TUI (Terminal User Interface) tool for browsing and managing AWS resources in the terminal.
 
-`unic` 프로젝트의 오픈소스 저장소입니다.
+It manages authentication contexts (SSO or STS AssumeRole) via `~/.config/unic/config.yaml` and provides drill-down exploration of AWS services registered in the catalog.
 
-### 라이선스
+## Tech Stack
 
-이 프로젝트는 [LICENSE](LICENSE) 조건을 따릅니다.
+- Rust (Edition 2024)
+- TUI: ratatui 0.30 + crossterm 0.29
+- CLI: clap 4.5 (derive)
+- AWS SDK: aws-sdk-ec2, aws-sdk-sts
+- Config: serde_yaml
+- Async: tokio
+- Error handling: anyhow
 
-### 커뮤니티 가이드
+## Installation & Build
 
-- 행동 강령: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
-- 기여 가이드: [CONTRIBUTING.md](CONTRIBUTING.md)
-- 보안 정책: [SECURITY.md](SECURITY.md)
+```bash
+git clone <repository-url>
+cargo build --release
+```
 
-### 시작하기
+## Usage
 
-현재 저장소는 초기 구성(bootstrap) 단계입니다.
+```bash
+# Enter TUI mode
+unic
 
-1. 저장소를 클론합니다.
-2. 기능 브랜치를 생성합니다.
-3. PR 템플릿에 맞춰 Pull Request를 생성합니다.
+# Specify context/profile/region
+unic --context dev-sso
+unic --profile my-profile
+unic --region ap-northeast-2
 
-### 메인테이너
+# Context management
+unic context list              # List contexts
+unic context current           # Show current context
+unic context use [name]        # Switch context
+```
 
-- 메인테이너 정보를 여기에 추가하세요.
+## Configuration
 
----
+`~/.config/unic/config.yaml` (auto-generated on first run)
 
-## English
+```yaml
+version: 1
+current: dev-sso
 
-Open-source repository for the `unic` project.
+defaults:
+  region: us-east-1
 
-### License
+contexts:
+  - name: dev-sso
+    profile: dev-sso
+
+  - name: prod-admin
+    profile: base-user
+    role_arn: arn:aws:iam::111111111111:role/AdministratorAccess
+```
+
+## Authentication Methods
+
+| Method | Condition | Behavior |
+|--------|-----------|----------|
+| STS AssumeRole | `role_arn` is set | Issue temporary credentials via STS |
+| SSO | Profile has `sso_session` | Run `aws sso login` |
+| Profile | Otherwise | Set AWS profile env vars |
+
+## Currently Implemented Features
+
+| Service | Feature | Status |
+|---------|---------|--------|
+| VPC | RemainPrivateIP (subnet available IP query) | ✅ Implemented |
+| RDS | ListDBInstances | 🚧 Coming Soon |
+| Route53 | ListHostedZones | 🚧 Coming Soon |
+| IAM | ListUsers | 🚧 Coming Soon |
+
+## TUI Key Bindings
+
+| Key | Action |
+|-----|--------|
+| `j`/`k` or `↑`/`↓` | Navigate |
+| `Enter` | Select |
+| `Backspace`/`Esc` | Go back |
+| `r` | Refresh |
+| `g`/`G` | Top/Bottom |
+| `q` | Quit |
+
+## Documentation
+
+- [Architecture](.kiro/docs/architecture-en.md)
+
+## License
 
 This project is licensed under the terms in [LICENSE](LICENSE).
 
-### Community Standards
+## Community Standards
 
 - Code of Conduct: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
 - Contributing Guide: [CONTRIBUTING.md](CONTRIBUTING.md)
 - Security Policy: [SECURITY.md](SECURITY.md)
 
-### Getting Started
-
-This repository is currently in bootstrap stage.
-
-1. Clone the repository.
-2. Create a feature branch.
-3. Open a Pull Request using the PR template.
-
-### Maintainers
+## Maintainers
 
 - Add maintainers here.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,30 +1,6 @@
-# Security Policy / 보안 정책
+# Security Policy
 
-## 한국어
-
-### 취약점 제보
-
-보안 취약점은 공개 이슈로 등록하지 말아주세요.
-
-반드시 비공개 채널(프로젝트 보안 담당 메일)로 제보해주세요.
-
-제보 시 아래 정보를 포함해주세요.
-
-- 영향받는 버전 또는 커밋
-- 재현 단계 또는 PoC
-- 영향도(Impact)
-- 가능한 경우 수정 제안
-
-### 응답 목표
-
-- 1차 응답: 영업일 기준 3일 이내
-- 상태 업데이트: 영업일 기준 7일 이내
-
----
-
-## English
-
-### Reporting a Vulnerability
+## Reporting a Vulnerability
 
 Please do not report security vulnerabilities in public issues.
 
@@ -37,7 +13,7 @@ Please include:
 - Impact assessment
 - Suggested fix (if available)
 
-### Response Timeline
+## Response Timeline
 
 - Initial response target: within 3 business days
 - Status update target: within 7 business days


### PR DESCRIPTION
## Summary

## Changes

### Kiro Steering Files (auto-included in all Kiro conversations)
- \`.kiro/steering/project-overview.md\` (KR) / \`project-overview-en.md\` (EN) — tech stack, config structure, auth flow, project layout
- \`.kiro/steering/coding-conventions.md\` (KR) / \`coding-conventions-en.md\` (EN) — module principles, 5-step guide for adding new AWS services, test patterns

### Architecture Documentation
- \`.kiro/docs/architecture.md\` (KR) / \`architecture-en.md\` (EN) — full architecture diagram, auth flow details, TUI screen structure, CLI usage, feature checklist

### English-Only Community Files
- \`README.md\` — rewritten with project overview, usage, config example, auth methods table, feature status, key bindings
- \`CODE_OF_CONDUCT.md\` — removed Korean section, kept Contributor Covenant 2.1
- \`CONTRIBUTING.md\` — removed Korean section, kept English workflow guide
- \`SECURITY.md\` — removed Korean section, kept English vulnerability reporting

## Notes
- Steering files use \`inclusion: auto\` so Kiro automatically picks up project context
- Both KR and EN versions are provided for docs to support Korean-speaking contributors
- This PR is based on \`feat/core-refactor\` branch"

### Related Issues

Closes #

### Validation

Describe how you tested this change.

### Checklist

- [ ] Scope is focused
- [ ] Docs updated (if needed)
- [ ] Tests/validation included
- [ ] Breaking changes documented
