### PR TITLE
feat: configure GoReleaser for binary release on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,32 @@
+version: 2
+
+builds:
+  - main: ./cmd/unic
+    binary: unic
+    ldflags:
+      - -s -w
+      - -X unic/internal/cli.Version={{.Version}}
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+
+archives:
+  - format: binary
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "^chore:"


### PR DESCRIPTION
## Summary

Closes #17

## Changes

- : archive format → `binary`, name template `{project}-{os}-{arch}` (matches Makefile convention), removed Homebrew tap section
- `.github/workflows/release.yml`: GitHub Actions workflow triggered on `v*` tag push, runs GoReleaser and uploads binaries to GitHub Release

## Artifacts on release

```
unic-darwin-amd64
unic-darwin-arm64
unic-linux-amd64
unic-linux-arm64
unic-windows-amd64
```