### PR TITLE
chore: update docs and add unic-bot workflow

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1,0 +1,50 @@
+name: unic-bot
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  handle-command:
+    if: contains(github.event.comment.body, '@unic-bot')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Handle bot command
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.comment.body;
+            const commenter = context.payload.comment.user.login;
+            const issue = context.issue.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Extract command after "@unic-bot:"
+            const match = body.match(/@unic-bot:\s*(.+)/i);
+            if (!match) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issue,
+                body: `@${commenter} I didn't understand that. Usage: \`@unic-bot: <command>\`\n\nAvailable commands:\n- \`assign me\` — assign this issue to yourself`,
+              });
+              return;
+            }
+
+            const command = match[1].trim().toLowerCase();
+
+            if (command === 'assign me') {
+              await github.rest.issues.addAssignees({
+                owner, repo, issue_number: issue,
+                assignees: [commenter],
+              });
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issue,
+                body: `@${commenter} has been assigned to this issue.`,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issue,
+                body: `@${commenter} Unknown command: \`${command}\`\n\nAvailable commands:\n- \`assign me\` — assign this issue to yourself`,
+              });
+            }

--- a/.kiro/docs/architecture-en.md
+++ b/.kiro/docs/architecture-en.md
@@ -12,7 +12,7 @@ It manages authentication contexts via `~/.config/unic/config.yaml` and provides
 | Language | Go | 1.22+ |
 | TUI | Bubbletea + Lipgloss + Bubbles | latest |
 | CLI | Cobra | latest |
-| AWS | aws-sdk-go-v2 (ec2, sts) | latest |
+| AWS | aws-sdk-go-v2 (ec2, ssm, sts) | latest |
 | Config | gopkg.in/yaml.v3 | 0.9 |
 | Concurrency | goroutines + errgroup | stdlib |
 | Error | fmt.Errorf / errors | stdlib |
@@ -44,9 +44,10 @@ It manages authentication contexts via `~/.config/unic/config.yaml` and provides
     │  ┌──────────────────────────┐     │
     │  │ ServiceList              │     │
     │  │  └─ FeatureList          │     │
+    │  │      ├─ InstanceList     │     │
     │  │      └─ VpcList          │     │
     │  │          └─ SubnetList   │     │
-    │  │              └─ Result   │     │
+    │  │              └─ Detail   │     │
     │  └──────────────────────────┘     │
     └──────────────────┬────────────────┘
                        │
@@ -59,12 +60,13 @@ It manages authentication contexts via `~/.config/unic/config.yaml` and provides
     ┌──────────────────▼────────────────┐
     │  internal/services/aws/ (API)     │
     │  AwsRepository                    │
+    │  ├─ repository.go (client init)   │
+    │  ├─ ec2.go   (EC2 instances)      │
+    │  ├─ ec2_model.go (EC2Instance)    │
     │  ├─ vpc.go   (VPC/Subnet/IP)      │
-    │  ├─ rds.go   (not implemented)    │
-    │  ├─ iam.go   (not implemented)    │
-    │  ├─ ssm.go   (not implemented)    │
-    │  ├─ ipcalc.go (CIDR calculation)  │
-    │  └─ env.go   (env var handling)   │
+    │  ├─ vpc_model.go (VPC, Subnet)    │
+    │  ├─ ssm.go   (session mgmt)       │
+    │  └─ ssm_exec.go (plugin exec)     │
     └───────────────────────────────────┘
 ```
 
@@ -123,11 +125,14 @@ Screens are managed as a stack of Bubbletea `Model` implementations:
 
 | Screen | Description | Data Source |
 |--------|-------------|-------------|
-| ServiceList | AWS service list | `catalog.ListServices()` |
-| FeatureList | Features for the selected service | `catalog.ListFeatures()` |
-| VpcList | VPC list | `AwsRepository.ListVpcs()` |
-| SubnetList | Subnet list | `AwsRepository.ListSubnets()` |
-| ResultView | Scrollable result display | Per-feature API results |
+| ServiceList | AWS service list | `domain.Catalog()` |
+| FeatureList | Features for the selected service | `domain.Catalog()` |
+| InstanceList | SSM-eligible EC2 instances (with filter) | `AwsRepository.ListRunningInstances()` |
+| VPCList | VPC list | `AwsRepository.ListVPCs()` |
+| SubnetList | Subnets for selected VPC | `AwsRepository.ListSubnets()` |
+| SubnetDetail | Available IPs in selected subnet | `AwsRepository.ListAvailableIPs()` |
+| Loading | Loading indicator | — |
+| Error | Error display | — |
 
 ### Key Bindings
 
@@ -135,44 +140,42 @@ Screens are managed as a stack of Bubbletea `Model` implementations:
 |-----|--------|
 | `j` / `↓` | Move down |
 | `k` / `↑` | Move up |
-| `g` / `Home` | Scroll to top |
-| `G` / `End` | Scroll to bottom |
 | `Enter` | Select (next screen) |
-| `Backspace` / `Esc` / `←` | Previous screen |
-| `r` | Refresh current screen |
-| `q` | Quit |
+| `Esc` / `q` | Previous screen |
+| `H` | Go to home (service list) |
+| `/` | Toggle filter (instance list, IP list) |
+| `q` (on service list) | Quit |
 
 ## CLI Subcommands
 
 ```
 unic                          # Enter TUI mode
-unic --context dev-sso        # Enter TUI with a specific context
 unic --profile my-profile     # Use a specific profile
 unic --region ap-northeast-2  # Use a specific region
 
-unic context list             # List configured contexts
-unic context current          # Print current context
-unic context use [name]       # Switch context (interactive selection if name omitted)
+unic init                     # Create default config file
+unic init --force             # Overwrite existing config file
 ```
 
 ## Currently Implemented Features
 
 | Service | Feature | Status |
 |---------|---------|--------|
-| VPC | RemainPrivateIP (subnet available IP query) | ✅ Implemented |
+| EC2 | SSM Session Manager (connect to EC2 instances) | ✅ Implemented |
+| VPC | VPC Browser (VPCs → subnets → available IPs) | ✅ Implemented |
 | RDS | ListDBInstances | 🚧 Coming Soon |
 | Route53 | ListHostedZones | 🚧 Coming Soon |
 | IAM | ListUsers | 🚧 Coming Soon |
 
 ## New Feature Addition Checklist
 
-1. `internal/domain/model.go` → Add constant to `AwsService` / `FeatureKind` types
-2. `internal/domain/catalog.go` → Add mapping in `ListServices()` / `ListFeatures()`
-3. `internal/services/aws/` → Create new file, add `AwsRepository` method
-4. `internal/app/actions.go` → Add new `FeatureKind` branch in screen transition
-5. If needed: `internal/app/screens.go` → Add new screen model
+1. `internal/domain/model.go` → Add `AwsService` and `FeatureKind` string constants
+2. `internal/domain/catalog.go` → Add `Service` entry in `Catalog()`
+3. `internal/services/aws/` → Create new file with `AwsRepository` method + model file
+4. `internal/services/aws/repository.go` → Add client interface and field to `AwsRepository`
+5. `internal/app/app.go` → Add new screen constant and feature handling in `Update()`
 6. If needed: `go.mod` → Add new AWS SDK module via `go get`
-7. Write tests
+7. Write tests with mock client
 
 ## Build & Run
 

--- a/.kiro/docs/architecture.md
+++ b/.kiro/docs/architecture.md
@@ -12,7 +12,7 @@ UNIC(Unified Infrastructure Console)은 AWS 리소스를 터미널에서 탐색�
 | 언어 | Go | 1.22+ |
 | TUI | Bubbletea + Lipgloss + Bubbles | latest |
 | CLI | Cobra | latest |
-| AWS | aws-sdk-go-v2 (ec2, sts) | latest |
+| AWS | aws-sdk-go-v2 (ec2, ssm, sts) | latest |
 | 설정 | gopkg.in/yaml.v3 | 0.9 |
 | 동시성 | goroutines + errgroup | stdlib |
 | 에러 | fmt.Errorf / errors | stdlib |
@@ -44,9 +44,10 @@ UNIC(Unified Infrastructure Console)은 AWS 리소스를 터미널에서 탐색�
     │  ┌──────────────────────────┐     │
     │  │ ServiceList              │     │
     │  │  └─ FeatureList          │     │
+    │  │      ├─ InstanceList     │     │
     │  │      └─ VpcList          │     │
     │  │          └─ SubnetList   │     │
-    │  │              └─ Result   │     │
+    │  │              └─ Detail   │     │
     │  └──────────────────────────┘     │
     └──────────────────┬────────────────┘
                        │
@@ -59,12 +60,13 @@ UNIC(Unified Infrastructure Console)은 AWS 리소스를 터미널에서 탐색�
     ┌──────────────────▼────────────────┐
     │  internal/services/aws/ (API 호출) │
     │  AwsRepository                    │
+    │  ├─ repository.go (클라이언트 초기화) │
+    │  ├─ ec2.go   (EC2 인스턴스)        │
+    │  ├─ ec2_model.go (EC2Instance)    │
     │  ├─ vpc.go   (VPC/Subnet/IP)      │
-    │  ├─ rds.go   (미구현)              │
-    │  ├─ iam.go   (미구현)              │
-    │  ├─ ssm.go   (미구현)              │
-    │  ├─ ipcalc.go (CIDR 계산)         │
-    │  └─ env.go   (환경변수 처리)       │
+    │  ├─ vpc_model.go (VPC, Subnet)    │
+    │  ├─ ssm.go   (세션 관리)           │
+    │  └─ ssm_exec.go (플러그인 실행)    │
     └───────────────────────────────────┘
 ```
 
@@ -123,11 +125,14 @@ config.yaml 로드
 
 | 화면 | 설명 | 데이터 소스 |
 |------|------|------------|
-| ServiceList | AWS 서비스 목록 | `catalog.ListServices()` |
-| FeatureList | 선택한 서비스의 기능 목록 | `catalog.ListFeatures()` |
-| VpcList | VPC 목록 | `AwsRepository.ListVpcs()` |
-| SubnetList | Subnet 목록 | `AwsRepository.ListSubnets()` |
-| ResultView | 결과 표시 (스크롤 가능) | 각 기능별 API 결과 |
+| ServiceList | AWS 서비스 목록 | `domain.Catalog()` |
+| FeatureList | 선택한 서비스의 기능 목록 | `domain.Catalog()` |
+| InstanceList | SSM 대상 EC2 인스턴스 (필터 지원) | `AwsRepository.ListRunningInstances()` |
+| VPCList | VPC 목록 | `AwsRepository.ListVPCs()` |
+| SubnetList | 선택한 VPC의 서브넷 목록 | `AwsRepository.ListSubnets()` |
+| SubnetDetail | 선택한 서브넷의 가용 IP | `AwsRepository.ListAvailableIPs()` |
+| Loading | 로딩 표시 | — |
+| Error | 에러 표시 | — |
 
 ### 키 바인딩
 
@@ -135,44 +140,42 @@ config.yaml 로드
 |----|------|
 | `j` / `↓` | 아래로 이동 |
 | `k` / `↑` | 위로 이동 |
-| `g` / `Home` | 맨 위로 |
-| `G` / `End` | 맨 아래로 |
 | `Enter` | 선택 (다음 화면) |
-| `Backspace` / `Esc` / `←` | 이전 화면 |
-| `r` | 현재 화면 새로고침 |
-| `q` | 종료 |
+| `Esc` / `q` | 이전 화면 |
+| `H` | 홈 (서비스 목록)으로 이동 |
+| `/` | 필터 토글 (인스턴스 목록, IP 목록) |
+| `q` (서비스 목록에서) | 종료 |
 
 ## CLI 서브커맨드
 
 ```
 unic                          # TUI 모드 진입
-unic --context dev-sso        # 특정 컨텍스트로 TUI 진입
 unic --profile my-profile     # 특정 프로파일 사용
 unic --region ap-northeast-2  # 특정 리전 사용
 
-unic context list             # 컨텍스트 목록 출력
-unic context current          # 현재 컨텍스트 출력
-unic context use [name]       # 컨텍스트 전환 (이름 생략 시 대화형 선택)
+unic init                     # 기본 설정 파일 생성
+unic init --force             # 기존 설정 파일 덮어쓰기
 ```
 
 ## 현재 구현된 기능
 
 | 서비스 | 기능 | 상태 |
 |--------|------|------|
-| VPC | RemainPrivateIP (서브넷 가용 IP 조회) | ✅ 구현 완료 |
+| EC2 | SSM Session Manager (EC2 인스턴스 접속) | ✅ 구현 완료 |
+| VPC | VPC Browser (VPC → 서브넷 → 가용 IP) | ✅ 구현 완료 |
 | RDS | ListDBInstances | 🚧 Coming Soon |
 | Route53 | ListHostedZones | 🚧 Coming Soon |
 | IAM | ListUsers | 🚧 Coming Soon |
 
 ## 새 기능 추가 체크리스트
 
-1. `internal/domain/model.go` → `AwsService` / `FeatureKind` 타입에 상수 추가
-2. `internal/domain/catalog.go` → `ListServices()` / `ListFeatures()` 매핑 추가
-3. `internal/services/aws/` → 새 파일 생성, `AwsRepository` 메서드 추가
-4. `internal/app/actions.go` → 화면 전환에서 새 `FeatureKind` 분기 추가
-5. 필요 시 `internal/app/screens.go` → 새 화면 모델 추가
+1. `internal/domain/model.go` → `AwsService`, `FeatureKind` 문자열 상수 추가
+2. `internal/domain/catalog.go` → `Catalog()`에 `Service` 항목 추가
+3. `internal/services/aws/` → 새 파일 생성, `AwsRepository` 메서드 + 모델 파일 추가
+4. `internal/services/aws/repository.go` → 클라이언트 인터페이스 및 `AwsRepository` 필드 추가
+5. `internal/app/app.go` → 새 화면 상수 및 `Update()`에서 기능 처리 추가
 6. 필요 시 `go.mod` → `go get`으로 새 AWS SDK 모듈 추가
-7. 테스트 작성
+7. mock 클라이언트로 테스트 작성
 
 ## 빌드 및 실행
 

--- a/.kiro/steering/coding-conventions-en.md
+++ b/.kiro/steering/coding-conventions-en.md
@@ -7,55 +7,49 @@ inclusion: auto
 ## Module Structure Principles
 
 - `internal/domain/` must not depend on the AWS SDK. It defines pure business models only.
-- `internal/services/aws/` handles actual AWS API calls. Add methods to the `AwsRepository` struct.
-- `internal/app/` is the Bubbletea TUI application. Screens are managed via the Bubbletea `Model` interface.
-- `internal/auth/` contains authentication logic only. It does not couple directly with the TUI.
-- `internal/tui/` holds reusable Bubbletea components and Lipgloss styles.
+- `internal/services/aws/` handles actual AWS API calls. Add methods to the `AwsRepository` struct. Uses interface-based clients for testability.
+- `internal/app/` is the Bubbletea TUI application. Contains all screens, navigation, styles, and rendering in `app.go`.
 - `internal/cli/` defines Cobra commands and flag parsing.
 
 ## How to Add a New AWS Service
 
 ### Step 1: Register the Domain Model
 
-Add a new constant to the `AwsService` type in `internal/domain/model.go`:
+Add new constants to `internal/domain/model.go`:
 ```go
-type AwsService int
+type AwsService string
 
 const (
-    ServiceVpc AwsService = iota
-    ServiceRds
-    ServiceRoute53
-    ServiceIam
-    ServiceNewService // add here
+    ServiceEC2 AwsService = "EC2"
+    ServiceVPC AwsService = "VPC"
+    ServiceNewService AwsService = "NewService" // add here
+)
+
+type FeatureKind string
+
+const (
+    FeatureSSMSession FeatureKind = "SSM Sessions Manager"
+    FeatureVPCBrowser FeatureKind = "VPC Browser"
+    FeatureNewFeature FeatureKind = "New Feature" // add here
 )
 ```
-
-Update the `Label()` and `String()` methods accordingly.
 
 ### Step 2: Register in the Feature Catalog
 
-Add a feature constant to `internal/domain/model.go`:
+Add the service with its features in `internal/domain/catalog.go`:
 ```go
-type FeatureKind int
-
-const (
-    FeatureRemainPrivateIp FeatureKind = iota
-    FeatureListDbInstances
-    FeatureNewFeature // add here
-)
-```
-
-Add the service-to-feature mapping in `internal/domain/catalog.go`:
-```go
-func ListServices() []AwsService {
-    return []AwsService{..., ServiceNewService}
-}
-
-func ListFeatures(service AwsService) []FeatureKind {
-    switch service {
-    ...
-    case ServiceNewService:
-        return []FeatureKind{FeatureNewFeature}
+func Catalog() []Service {
+    return []Service{
+        // ... existing services ...
+        {
+            Name: ServiceNewService,
+            Features: []Feature{
+                {
+                    Kind:        FeatureNewFeature,
+                    Description: "Description of the new feature",
+                },
+            },
+        },
     }
 }
 ```
@@ -74,50 +68,60 @@ Add any required AWS SDK modules to `go.mod` via `go get`.
 
 ### Step 4: Wire Up the TUI Screen
 
-Add a new `FeatureKind` branch in the screen transition logic in `internal/app/actions.go`:
+Add a new screen constant and handle the feature in the `Update()` method of `internal/app/app.go`:
 ```go
-case FeatureNewFeature:
-    items, err := repo.ListNewResources(ctx)
-    if err != nil {
-        return newErrorScreen("Load Failed", err)
-    }
-    return newResultScreen(items)
+const (
+    screenNewFeature screen = iota + ... // add new screen
+)
 ```
 
-If an intermediate selection screen is needed, create a new Bubbletea model implementing `tea.Model` in `internal/app/`.
-
-### Step 5: Add a New SDK Client (if needed)
-
-Add a new client field to `AwsRepository`:
+Handle the feature selection in the feature list's `Enter` key handler, and add a `tea.Cmd` function to load data asynchronously:
 ```go
-type AwsRepository struct {
-    ec2Client    *ec2.Client
-    newClient    *newsvc.Client // add here
-    // ...
+func (m Model) loadNewResources() tea.Msg {
+    items, err := m.repo.ListNewResources(context.Background())
+    if err != nil {
+        return errMsg{err: err}
+    }
+    return newResourcesLoadedMsg{items: items}
 }
 ```
 
-Initialize it in the constructor function.
+### Step 5: Add a New SDK Client (if needed)
 
-## Authentication Branching Logic
+Add a new client interface and field to `AwsRepository` in `repository.go`:
+```go
+type NewServiceClientAPI interface {
+    // methods needed from the SDK client
+}
 
-The core function is `ApplyContextSideEffects` in `internal/auth/auth.go`:
-- `RoleArn` present → STS AssumeRole (`sts.go`)
-- SSO profile → run `aws sso login` (`sso.go`)
-- Otherwise → set profile-based env vars
+type AwsRepository struct {
+    EC2Client EC2ClientAPI
+    SSMClient SSMClientAPI
+    NewClient NewServiceClientAPI // add here
+    Region    string
+    Profile   string
+}
+```
+
+Initialize it in `NewAwsRepository()`. Add a compile-time interface check:
+```go
+var _ NewServiceClientAPI = (*newsvc.Client)(nil)
+```
 
 ## TUI Screen Structure
 
-Screens use the Bubbletea `Model` interface with a stack-based navigation pattern:
-- `Enter` → push a new model onto the stack
-- `Backspace/Esc` → pop to return to the previous model
-- `r` → send a refresh message to the current model
+Screens are represented as `screen` integer constants in `internal/app/app.go`. Navigation uses a state-machine pattern:
+- `Enter` → transition to the next screen based on current selection
+- `Esc` / `q` → return to the previous screen
+- `H` → return to the service list from any screen
+- `/` → toggle filter input on supported screens (instance list, IP list)
 
 ## Writing Tests
 
-- Tests that call `AwsRepository` use a test configuration or mock clients
+- Tests that call `AwsRepository` use mock clients implementing the `*ClientAPI` interfaces (e.g., `EC2ClientAPI`, `SSMClientAPI`)
 - File system tests are isolated with `t.TempDir()`
 - Internal functions accept path parameters to allow test-path injection instead of real paths
+- Compile-time interface checks ensure mock clients satisfy the required interfaces
 
 ## Adding CLI Subcommands
 

--- a/.kiro/steering/coding-conventions.md
+++ b/.kiro/steering/coding-conventions.md
@@ -7,55 +7,49 @@ inclusion: auto
 ## 모듈 구조 원칙
 
 - `internal/domain/` 은 AWS SDK에 의존하지 않는다. 순수 비즈니스 모델만 정의한다.
-- `internal/services/aws/` 는 실제 AWS API 호출을 담당한다. `AwsRepository` 구조체에 메서드를 추가하는 방식이다.
-- `internal/app/` 은 Bubbletea TUI 애플리케이션이다. Bubbletea `Model` 인터페이스로 화면을 관리한다.
-- `internal/auth/` 는 인증 관련 로직만 담는다. TUI와 직접 결합하지 않는다.
-- `internal/tui/` 는 재사용 가능한 Bubbletea 컴포넌트와 Lipgloss 스타일을 담는다.
+- `internal/services/aws/` 는 실제 AWS API 호출을 담당한다. `AwsRepository` 구조체에 메서드를 추가하는 방식이다. 테스트 가능성을 위해 인터페이스 기반 클라이언트를 사용한다.
+- `internal/app/` 은 Bubbletea TUI 애플리케이션이다. 모든 화면, 네비게이션, 스타일, 렌더링이 `app.go`에 포함되어 있다.
 - `internal/cli/` 는 Cobra 커맨드와 플래그 파싱을 정의한다.
 
 ## 새로운 AWS 서비스 추가 방법
 
 ### 1단계: 도메인 모델 등록
 
-`internal/domain/model.go`의 `AwsService` 타입에 새 상수를 추가한다:
+`internal/domain/model.go`에 새 상수를 추가한다:
 ```go
-type AwsService int
+type AwsService string
 
 const (
-    ServiceVpc AwsService = iota
-    ServiceRds
-    ServiceRoute53
-    ServiceIam
-    ServiceNewService // 추가
+    ServiceEC2 AwsService = "EC2"
+    ServiceVPC AwsService = "VPC"
+    ServiceNewService AwsService = "NewService" // 추가
+)
+
+type FeatureKind string
+
+const (
+    FeatureSSMSession FeatureKind = "SSM Sessions Manager"
+    FeatureVPCBrowser FeatureKind = "VPC Browser"
+    FeatureNewFeature FeatureKind = "New Feature" // 추가
 )
 ```
-
-`Label()` 과 `String()` 메서드도 함께 업데이트한다.
 
 ### 2단계: 기능 카탈로그 등록
 
-`internal/domain/model.go`에 기능 상수를 추가한다:
+`internal/domain/catalog.go`에서 서비스와 기능을 추가한다:
 ```go
-type FeatureKind int
-
-const (
-    FeatureRemainPrivateIp FeatureKind = iota
-    FeatureListDbInstances
-    FeatureNewFeature // 추가
-)
-```
-
-`internal/domain/catalog.go`에서 서비스-기능 매핑을 추가한다:
-```go
-func ListServices() []AwsService {
-    return []AwsService{..., ServiceNewService}
-}
-
-func ListFeatures(service AwsService) []FeatureKind {
-    switch service {
-    ...
-    case ServiceNewService:
-        return []FeatureKind{FeatureNewFeature}
+func Catalog() []Service {
+    return []Service{
+        // ... 기존 서비스 ...
+        {
+            Name: ServiceNewService,
+            Features: []Feature{
+                {
+                    Kind:        FeatureNewFeature,
+                    Description: "새 기능 설명",
+                },
+            },
+        },
     }
 }
 ```
@@ -74,50 +68,60 @@ func (r *AwsRepository) ListNewResources(ctx context.Context) ([]ResourceItem, e
 
 ### 4단계: TUI 화면 연결
 
-`internal/app/actions.go`의 화면 전환 로직에서 새 `FeatureKind` 분기를 추가한다:
+`internal/app/app.go`에서 새 화면 상수를 추가하고, `Update()` 메서드에서 기능을 처리한다:
 ```go
-case FeatureNewFeature:
-    items, err := repo.ListNewResources(ctx)
-    if err != nil {
-        return newErrorScreen("Load Failed", err)
-    }
-    return newResultScreen(items)
+const (
+    screenNewFeature screen = iota + ... // 새 화면 추가
+)
 ```
 
-중간 선택 화면이 필요하면 `internal/app/`에 `tea.Model`을 구현하는 새 Bubbletea 모델을 생성한다.
-
-### 5단계: 필요시 새 SDK 클라이언트 추가
-
-`AwsRepository`에 새 클라이언트 필드를 추가한다:
+기능 선택 시 비동기 데이터 로딩을 위한 `tea.Cmd` 함수를 추가한다:
 ```go
-type AwsRepository struct {
-    ec2Client    *ec2.Client
-    newClient    *newsvc.Client // 추가
-    // ...
+func (m Model) loadNewResources() tea.Msg {
+    items, err := m.repo.ListNewResources(context.Background())
+    if err != nil {
+        return errMsg{err: err}
+    }
+    return newResourcesLoadedMsg{items: items}
 }
 ```
 
-생성자 함수에서 초기화한다.
+### 5단계: 필요시 새 SDK 클라이언트 추가
 
-## 인증 방식 분기 로직
+`repository.go`에 새 클라이언트 인터페이스와 `AwsRepository` 필드를 추가한다:
+```go
+type NewServiceClientAPI interface {
+    // SDK 클라이언트에서 필요한 메서드
+}
 
-`internal/auth/auth.go`의 `ApplyContextSideEffects`가 핵심이다:
-- `RoleArn` 존재 → STS AssumeRole (`sts.go`)
-- SSO profile → `aws sso login` 실행 (`sso.go`)
-- 그 외 → profile 기반 환경변수 설정
+type AwsRepository struct {
+    EC2Client EC2ClientAPI
+    SSMClient SSMClientAPI
+    NewClient NewServiceClientAPI // 추가
+    Region    string
+    Profile   string
+}
+```
+
+`NewAwsRepository()`에서 초기화하고, 컴파일 타임 인터페이스 체크를 추가한다:
+```go
+var _ NewServiceClientAPI = (*newsvc.Client)(nil)
+```
 
 ## TUI 화면 구조
 
-화면은 Bubbletea `Model` 인터페이스를 사용하며 스택 기반 네비게이션 패턴을 따른다:
-- `Enter` → 새 모델을 스택에 push
-- `Backspace/Esc` → pop으로 이전 모델 복귀
-- `r` → 현재 모델에 refresh 메시지 전송
+화면은 `internal/app/app.go`에서 `screen` 정수 상수로 표현된다. 상태 머신 패턴의 네비게이션을 사용한다:
+- `Enter` → 현재 선택에 따라 다음 화면으로 전환
+- `Esc` / `q` → 이전 화면으로 복귀
+- `H` → 어느 화면에서든 서비스 목록으로 복귀
+- `/` → 지원되는 화면에서 필터 입력 토글 (인스턴스 목록, IP 목록)
 
 ## 테스트 작성
 
-- `AwsRepository`를 호출하는 테스트는 테스트 설정 또는 mock 클라이언트를 사용한다
+- `AwsRepository`를 호출하는 테스트는 `*ClientAPI` 인터페이스를 구현하는 mock 클라이언트를 사용한다 (예: `EC2ClientAPI`, `SSMClientAPI`)
 - 파일 시스템 관련 테스트는 `t.TempDir()`로 격리한다
 - 내부 함수는 실제 경로 대신 테스트용 경로를 주입할 수 있게 경로 파라미터를 받는다
+- 컴파일 타임 인터페이스 체크로 mock 클라이언트가 필요한 인터페이스를 만족하는지 보장한다
 
 ## CLI 서브커맨드 추가
 

--- a/.kiro/steering/project-overview-en.md
+++ b/.kiro/steering/project-overview-en.md
@@ -11,7 +11,7 @@ UNIC is a Go-based TUI (Terminal User Interface) tool for browsing and managing 
 - Language: Go (1.22+)
 - TUI Framework: Bubbletea + Lipgloss + Bubbles
 - CLI Parser: Cobra
-- AWS SDK: aws-sdk-go-v2 (ec2, sts, config, credentials)
+- AWS SDK: aws-sdk-go-v2 (ec2, ssm, sts)
 - Config: gopkg.in/yaml.v3 (YAML-based)
 - Concurrency: goroutines + errgroup
 - Error Handling: fmt.Errorf wrapping / standard errors package
@@ -60,39 +60,30 @@ cmd/
 
 internal/
 ├── cli/                     # Cobra-based CLI definitions
-│   ├── root.go              # Root command, global flags
-│   └── context.go           # Context subcommands
+│   ├── root.go              # Root command, global flags (--profile, --region)
+│   └── init.go              # unic init subcommand
 ├── config/                  # Load/save ~/.config/unic/config.yaml
 │   └── config.go
-├── auth/                    # SSO/STS authentication logic
-│   ├── auth.go              # ApplyContextSideEffects (auth branching)
-│   ├── sso.go               # Run aws sso login
-│   ├── sts.go               # STS AssumeRole
-│   ├── aws_files.go         # ~/.aws/config & credentials file management
-│   └── session_env.go       # Env var setup + session.env file generation
 ├── domain/                  # Business domain models
-│   ├── catalog.go           # Service/feature catalog definitions
-│   └── model.go             # AwsService, FeatureKind, ResourceItem, etc.
+│   ├── model.go             # AwsService, FeatureKind, Service, Feature
+│   └── catalog.go           # Service/feature catalog (Catalog())
 ├── app/                     # Bubbletea TUI application
-│   ├── app.go               # Root model, initialization, key handling
-│   ├── screens.go           # Screen types and navigation stack
-│   ├── actions.go           # Screen transition logic
-│   └── navigation.go        # Cursor movement, scrolling
-├── tui/                     # Reusable Bubbletea components
-│   ├── components.go        # Filterable list, dialog, spinner, etc.
-│   └── styles.go            # Lipgloss style definitions
+│   └── app.go               # Root model, screens, navigation, rendering
 └── services/                # AWS API call implementations
     └── aws/
-        ├── repository.go    # AwsRepository (client initialization)
+        ├── repository.go    # AwsRepository (EC2/SSM client initialization)
+        ├── ec2.go           # EC2 instance listing (SSM-managed)
+        ├── ec2_model.go     # EC2Instance model
         ├── vpc.go           # VPC/Subnet/IP queries
-        ├── rds.go           # RDS (not yet implemented)
-        ├── iam.go           # IAM (not yet implemented)
-        ├── ssm.go           # SSM (not yet implemented)
-        ├── env.go           # Env var reading + debug lines
-        ├── ipcalc.go        # CIDR-based available IP calculation
-        └── model.go         # SubnetIpAvailability
+        ├── vpc_model.go     # VPC, Subnet models
+        ├── ssm.go           # SSM session start/terminate
+        └── ssm_exec.go      # session-manager-plugin subprocess execution
 
+.goreleaser.yaml             # Release configuration
 go.mod
 go.sum
 Makefile
 ```
+
+> **Note**: `internal/auth/` and `internal/tui/` are planned but not yet implemented.
+> TUI screens, navigation, and styles are currently consolidated in `internal/app/app.go`.

--- a/.kiro/steering/project-overview.md
+++ b/.kiro/steering/project-overview.md
@@ -11,7 +11,7 @@ UNIC은 Go 기반 TUI(Terminal User Interface) 도구로, AWS 리소스를 탐�
 - 언어: Go (1.22+)
 - TUI 프레임워크: Bubbletea + Lipgloss + Bubbles
 - CLI 파서: Cobra
-- AWS SDK: aws-sdk-go-v2 (ec2, sts, config, credentials)
+- AWS SDK: aws-sdk-go-v2 (ec2, ssm, sts)
 - 설정 파일: gopkg.in/yaml.v3 (YAML 기반)
 - 동시성: goroutines + errgroup
 - 에러 처리: fmt.Errorf 래핑 / 표준 errors 패키지
@@ -60,39 +60,30 @@ cmd/
 
 internal/
 ├── cli/                     # Cobra 기반 CLI 정의
-│   ├── root.go              # 루트 커맨드, 글로벌 플래그
-│   └── context.go           # Context 서브커맨드
+│   ├── root.go              # 루트 커맨드, 글로벌 플래그 (--profile, --region)
+│   └── init.go              # unic init 서브커맨드
 ├── config/                  # ~/.config/unic/config.yaml 로드/저장
 │   └── config.go
-├── auth/                    # SSO/STS 인증 로직
-│   ├── auth.go              # ApplyContextSideEffects (인증 분기)
-│   ├── sso.go               # aws sso login 실행
-│   ├── sts.go               # STS AssumeRole
-│   ├── aws_files.go         # ~/.aws/config, credentials 파일 관리
-│   └── session_env.go       # 환경변수 설정 + session.env 파일 생성
 ├── domain/                  # 비즈니스 도메인 모델
-│   ├── catalog.go           # 서비스/기능 카탈로그 정의
-│   └── model.go             # AwsService, FeatureKind, ResourceItem 등
+│   ├── model.go             # AwsService, FeatureKind, Service, Feature
+│   └── catalog.go           # 서비스/기능 카탈로그 (Catalog())
 ├── app/                     # Bubbletea TUI 애플리케이션
-│   ├── app.go               # 루트 모델, 초기화, 키 핸들링
-│   ├── screens.go           # 화면 타입 및 네비게이션 스택
-│   ├── actions.go           # 화면 전환 로직
-│   └── navigation.go        # 커서 이동, 스크롤
-├── tui/                     # 재사용 가능한 Bubbletea 컴포넌트
-│   ├── components.go        # 필터 리스트, 다이얼로그, 스피너 등
-│   └── styles.go            # Lipgloss 스타일 정의
+│   └── app.go               # 루트 모델, 화면, 네비게이션, 렌더링
 └── services/                # AWS API 호출 구현
     └── aws/
-        ├── repository.go    # AwsRepository (클라이언트 초기화)
+        ├── repository.go    # AwsRepository (EC2/SSM 클라이언트 초기화)
+        ├── ec2.go           # EC2 인스턴스 목록 (SSM 관리 대상)
+        ├── ec2_model.go     # EC2Instance 모델
         ├── vpc.go           # VPC/Subnet/IP 조회
-        ├── rds.go           # RDS (미구현)
-        ├── iam.go           # IAM (미구현)
-        ├── ssm.go           # SSM (미구현)
-        ├── env.go           # 환경변수 읽기 + 디버그 라인
-        ├── ipcalc.go        # CIDR 기반 가용 IP 계산
-        └── model.go         # SubnetIpAvailability
+        ├── vpc_model.go     # VPC, Subnet 모델
+        ├── ssm.go           # SSM 세션 시작/종료
+        └── ssm_exec.go      # session-manager-plugin 서브프로세스 실행
 
+.goreleaser.yaml             # 릴리스 설정
 go.mod
 go.sum
 Makefile
 ```
+
+> **참고**: `internal/auth/`와 `internal/tui/`는 계획되어 있지만 아직 구현되지 않았다.
+> TUI 화면, 네비게이션, 스타일은 현재 `internal/app/app.go`에 통합되어 있다.

--- a/PLAN.md
+++ b/PLAN.md
@@ -16,40 +16,33 @@ unic/
 │   └── main.go               # Entry point
 ├── internal/
 │   ├── cli/                   # Cobra command definitions
-│   ├── auth/                  # Login / credential management
-│   │   ├── auth.go            # Unified credential provider logic
-│   │   ├── saml.go            # Okta SAML federation
-│   │   ├── sso.go             # IAM Identity Center
-│   │   ├── iam.go             # Access Key / Secret Key
-│   │   └── sts.go             # Assume Role, role chaining
-│   ├── services/              # AWS service modules
-│   │   └── aws/
-│   │       ├── vpc.go
-│   │       ├── rds.go
-│   │       ├── iam.go
-│   │       ├── ssm.go
-│   │       ├── ec2.go
-│   │       ├── r53.go
-│   │       ├── cloudwatch_logs.go
-│   │       └── cloudwatch_metrics.go
-│   ├── app/                   # Bubbletea TUI application
-│   │   ├── app.go             # Root model
-│   │   ├── screens.go         # Screen navigation stack
-│   │   ├── actions.go         # Screen transitions
-│   │   └── navigation.go      # Cursor/scroll
-│   ├── tui/                   # Reusable Bubbletea components
-│   │   ├── components.go      # Lists, dialogs, spinners
-│   │   └── styles.go          # Lipgloss styles
+│   │   ├── root.go            # Root command, global flags
+│   │   └── init.go            # unic init subcommand
+│   ├── config/                # Profile / account / region management
+│   │   └── config.go
 │   ├── domain/                # Pure business models
-│   │   ├── model.go
-│   │   └── catalog.go
-│   └── config/                # Profile / account / region management
-│       └── config.go
+│   │   ├── model.go           # AwsService, FeatureKind, Service, Feature
+│   │   └── catalog.go         # Service/feature catalog
+│   ├── app/                   # Bubbletea TUI application
+│   │   └── app.go             # Root model, screens, navigation, rendering
+│   └── services/              # AWS service modules
+│       └── aws/
+│           ├── repository.go  # AwsRepository (client initialization)
+│           ├── ec2.go         # EC2 instance listing (SSM-managed)
+│           ├── ec2_model.go   # EC2Instance model
+│           ├── vpc.go         # VPC/Subnet/IP queries
+│           ├── vpc_model.go   # VPC, Subnet models
+│           ├── ssm.go         # SSM session start/terminate
+│           └── ssm_exec.go    # session-manager-plugin subprocess
 ├── go.mod
 ├── go.sum
 ├── Makefile
+├── .goreleaser.yaml
 └── PLAN.md
 ```
+
+> **Note**: `internal/auth/` and `internal/tui/` are planned but not yet implemented.
+> The TUI screens, navigation, and styles are currently consolidated in `internal/app/app.go`.
 
 ---
 
@@ -67,19 +60,21 @@ unic/
 
 ## Milestones
 
-### M1 — Core Foundation
+### M1 — Core Foundation ✅
 
-**M1.1 — Config & Profile Management**
+**M1.1 — Config & Profile Management** ✅
 - Read/write `~/.aws/config` and `~/.aws/credentials` (shared with AWS CLI)
 - unic app config at `~/.config/unic/config.yaml` (UI prefs, default profile)
 - Multi-account profile support
 - CLI flags: `--profile <name>`, `--region <region>`
+- `unic init` command for config file creation
 
-**M1.2 — TUI Shell**
+**M1.2 — TUI Shell** ✅
 - Main menu: service list navigation
 - Screen router with back navigation stack (Bubbletea model stack)
 - Shared layout: header (profile / region / account), body, footer (keybindings)
-- Reusable components: filterable list, confirmation dialog, notification bar, loading spinner
+- Reusable components: filterable list, loading spinner, error display
+- 8 screens: ServiceList, FeatureList, InstanceList, VPCList, SubnetList, SubnetDetail, Loading, Error
 
 ---
 
@@ -112,7 +107,7 @@ unic/
 
 ### M3 — AWS Services
 
-**M3.1 — VPC**
+**M3.1 — VPC** ✅
 - List VPCs → subnets → show available IP count per subnet
 - Reachability Analysis: create/run `NetworkInsights` path, display results
 
@@ -126,7 +121,7 @@ unic/
 - List access keys, show key age/status
 - Rotate: create new key → display once → deactivate old (with confirmation)
 
-**M3.4 — Systems Manager (Sessions Manager)**
+**M3.4 — Systems Manager (Sessions Manager)** ✅
 - List SSM-eligible EC2 instances (agent status check)
 - Select instance → open interactive session
 - Implementation: suspend Bubbletea program → spawn `session-manager-plugin` process → resume on exit
@@ -171,9 +166,9 @@ unic/
 - Debug log file (`~/.config/unic/logs/`)
 - `--verbose` flag
 
-**M4.3 — Distribution**
-- GitHub Actions CI/CD
-- Prebuilt binaries (Linux, macOS, Windows)
+**M4.3 — Distribution** 🟡
+- GitHub Actions CI/CD ✅
+- Prebuilt binaries (Linux, macOS, Windows) ✅ (GoReleaser configured)
 - Homebrew formula
 - Install script
 
@@ -189,10 +184,10 @@ M1.1 → M1.2 → M2.1 → M2.2 → M2.3 → M2.4
                                   M4.1 → M4.2 → M4.3
 ```
 
-- M1 + M2 are sequential — prerequisites for everything else
+- M1 is complete; M2 is deferred (relying on AWS SDK default credential chain)
 - M3 services are independent of each other, build in any order
-- M3.4 (SSM Sessions) has highest complexity (TUI ↔ child process handoff) — consider doing last in M3
-- M4 after all features are functional
+- M3.1 (VPC) and M3.4 (SSM Sessions) are complete
+- M4.3 (Distribution) is partially done (GoReleaser + GitHub Actions)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -27,50 +27,47 @@ go build -o unic ./cmd/unic
 # Enter TUI mode
 unic
 
-# Specify context/profile/region
-unic --context dev-sso
+# Specify profile/region
 unic --profile my-profile
 unic --region ap-northeast-2
 
-# Context management
-unic context list              # List contexts
-unic context current           # Show current context
-unic context use [name]        # Switch context
+# Initialize config file
+unic init                      # Create default config
+unic init --force              # Overwrite existing config
 ```
 
 ## Configuration
 
-`~/.config/unic/config.yaml` (auto-generated on first run)
+`~/.config/unic/config.yaml` (created via `unic init` or auto-generated on first run)
 
 ```yaml
-version: 1
-current: dev-sso
+# Simple format
+default_profile: my-profile
+default_region: ap-northeast-2
+```
 
-defaults:
-  region: us-east-1
+```yaml
+# Context-based format
+current: dev-sso
 
 contexts:
   - name: dev-sso
     profile: dev-sso
+    region: ap-northeast-2
 
   - name: prod-admin
-    profile: base-user
-    role_arn: arn:aws:iam::111111111111:role/AdministratorAccess
+    profile: prod-admin
+    region: us-east-1
 ```
 
-## Authentication Methods
-
-| Method | Condition | Behavior |
-|--------|-----------|----------|
-| STS AssumeRole | `role_arn` is set | Issue temporary credentials via STS |
-| SSO | Profile has `sso_session` | Run `aws sso login` |
-| Profile | Otherwise | Set AWS profile env vars |
+**Priority**: CLI flags (`--profile`, `--region`) > context settings > config defaults > hardcoded defaults (`us-east-1`)
 
 ## Currently Implemented Features
 
 | Service | Feature | Status |
 |---------|---------|--------|
-| VPC | RemainPrivateIP (subnet available IP query) | ✅ Implemented |
+| EC2 | SSM Session Manager (connect to EC2 instances) | ✅ Implemented |
+| VPC | VPC Browser (VPCs → subnets → available IPs) | ✅ Implemented |
 | RDS | ListDBInstances | 🚧 Coming Soon |
 | Route53 | ListHostedZones | 🚧 Coming Soon |
 | IAM | ListUsers | 🚧 Coming Soon |
@@ -81,10 +78,10 @@ contexts:
 |-----|--------|
 | `j`/`k` or `↑`/`↓` | Navigate |
 | `Enter` | Select |
-| `Backspace`/`Esc` | Go back |
-| `r` | Refresh |
-| `g`/`G` | Top/Bottom |
-| `q` | Quit |
+| `Esc`/`q` | Go back |
+| `H` | Go to home (service list) |
+| `/` | Filter (instances, IPs) |
+| `q` (on service list) | Quit |
 
 ## Documentation
 
@@ -93,6 +90,14 @@ contexts:
 ## License
 
 This project is licensed under the terms in [LICENSE](LICENSE).
+
+## Issue Bot
+
+Comment on any issue to interact with `@unic-bot`:
+
+| Command | Action |
+|---------|--------|
+| `@unic-bot: assign me` | Assign the issue to yourself |
 
 ## Community Standards
 

--- a/TICKET.md
+++ b/TICKET.md
@@ -1,44 +1,45 @@
-# Current Ticket: UNIC-2
+# Current Ticket: UNIC-3
 
-## TUI Shell
+## Add RDS ListDBInstances Support
 
 **Status**: Not Started
-**Milestone**: M1.2
-**Priority**: Highest
+**Milestone**: M3.2
+**Priority**: High
 
 ---
 
 ### Summary
 
-Implement a Ratatui + Crossterm TUI shell that serves as the interactive foundation for all AWS service modules.
+Add support for listing RDS DB instances in the TUI.
 
 ### Tasks
 
-- [ ] Implement screen router with back navigation stack (`src/tui/router.rs`)
-- [ ] Build main menu view with service list navigation (`src/tui/views/`)
-- [ ] Create shared layout: header (profile/region/account), body, footer (keybindings)
-- [ ] Build reusable widgets: filterable list, confirmation dialog, notification bar, loading spinner (`src/tui/widgets/`)
+- [ ] Add `ServiceRDS` constant to `AwsService` in `internal/domain/model.go`
+- [ ] Add `FeatureListDBInstances` constant to `FeatureKind` in `internal/domain/model.go`
+- [ ] Register RDS service and feature in `internal/domain/catalog.go`
+- [ ] Implement `AwsRepository.ListDBInstances()` in `internal/services/aws/rds.go`
+- [ ] Add RDS model types in `internal/services/aws/rds_model.go`
+- [ ] Add RDS client interface and initialization in `internal/services/aws/repository.go`
+- [ ] Add screen transition for RDS feature in `internal/app/app.go`
+- [ ] Add `rds` SDK dependency in `go.mod`
+- [ ] Write tests
 
 ### Acceptance Criteria
 
-- Main menu displays a navigable list of services
-- Screen router supports push/pop navigation with back key
-- Header shows current profile, region, and account info
-- Footer displays context-sensitive keybindings
-- Reusable widgets work across different views
-
-### Tech Notes
-
-- Prerequisite: M1.1 (Config & Profile Management) is complete
-- All auth (M2) and service modules (M3) will be built on top of this TUI shell
-- Dependencies: `ratatui`, `crossterm` (already in Cargo.toml)
-
-### Files
-
-- `src/tui/router.rs` — screen navigation
-- `src/tui/views/` — per-service TUI screens
-- `src/tui/widgets/` — reusable components
+- RDS appears as a selectable service in the TUI service list
+- Selecting "ListDBInstances" shows a list of RDS instances with identifier, engine, status, endpoint, and instance class
+- Loading and error states work correctly
+- Tests cover the RDS listing logic with mock clients
 
 ### Related Issue
 
-Closes #4
+Closes #12
+
+---
+
+## Previous Tickets
+
+| Ticket | Title | Status |
+|--------|-------|--------|
+| UNIC-1 | Config & Profile Management (M1.1) | ✅ Done |
+| UNIC-2 | TUI Shell (M1.2) | ✅ Done |


### PR DESCRIPTION
### Summary

Update all project documentation (10 files) to match the current implemented state after the Rust→Go migration. Add `@unic-bot` GitHub Actions workflow for issue self-assignment via comments.

**Docs updated:**
- README.md — fixed CLI usage, feature table, key bindings, config examples
- PLAN.md — added completion status markers to milestones, updated file tree
- TICKET.md — replaced completed UNIC-2 with new UNIC-3 (RDS)
- Architecture docs (EN + KR) — updated diagrams, screens, services, CLI commands
- Project overview docs (EN + KR) — replaced file tree with actual structure
- Coding conventions docs (EN + KR) — fixed code examples to match real types/patterns

**Bot workflow:**
- Trigger: comment `@unic-bot: assign me` on any issue
- Extensible command parser for future commands

### Related Issues

N/A

### Validation

- CI should pass (no code changes)
- Bot can be tested by commenting `@unic-bot: assign me` on any issue after merge

### Checklist

- [x] Scope is focused
- [x] Docs updated (if needed)
- [x] Tests/validation included
- [ ] Breaking changes documented