### PR TITLE
feat: add RDS browser with start/stop/failover

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,26 +3,32 @@ module unic
 go 1.24.0
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.41.4 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.32.12 // indirect
+	github.com/aws/aws-sdk-go-v2 v1.41.4
+	github.com/aws/aws-sdk-go-v2/config v1.32.12
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.296.0
+	github.com/aws/aws-sdk-go-v2/service/rds v1.116.3
+	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.3
+	github.com/charmbracelet/bubbletea v1.3.10
+	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/spf13/cobra v1.10.2
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.12 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.20 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.296.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.20 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.8 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.9 // indirect
 	github.com/aws/smithy-go v1.24.2 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/charmbracelet/bubbletea v1.3.10 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
@@ -36,10 +42,8 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.3.8 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 h1:5EniKhL
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7/go.mod h1:x0nZssQ3qZSnIcePWLvcoFisRXJzcTVvYpAAdYX8+GI=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.20 h1:2HvVAIq+YqgGotK6EkMf+KIEqTISmTYh5zLpYyeTo1Y=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.20/go.mod h1:V4X406Y666khGa8ghKmphma/7C0DAtEQYhkq9z4vpbk=
+github.com/aws/aws-sdk-go-v2/service/rds v1.116.3 h1:H/ZYZ6QR4EXJAYElI5xkIM/yCz+A4uHIvWpzl+IfJks=
+github.com/aws/aws-sdk-go-v2/service/rds v1.116.3/go.mod h1:QbXW4coAMakHQhf1qhE0eVVCen9gwB/Kvn+HHHKhpGY=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.8 h1:0GFOLzEbOyZABS3PhYfBIx2rNBACYcKty+XGkTgw1ow=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.8/go.mod h1:LXypKvk85AROkKhOG6/YEcHFPoX+prKTowKnVdcaIxE=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.68.3 h1:bBoWhx8lsFLTXintRX64ZBXcmFZbGqUmaPUrjXECqIc=
@@ -74,12 +76,15 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=
+golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
 golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -23,6 +24,9 @@ const (
 	screenVPCList
 	screenSubnetList
 	screenSubnetDetail
+	screenRDSList
+	screenRDSDetail
+	screenRDSConfirm
 	screenLoading
 	screenError
 )
@@ -51,6 +55,25 @@ type errMsg struct {
 
 type ssmSessionDoneMsg struct {
 	err error
+}
+
+type rdsInstancesLoadedMsg struct {
+	instances []awsservice.RDSInstance
+}
+
+type rdsActionDoneMsg struct {
+	action     string
+	instanceID string
+	err        error
+}
+
+type rdsStatusRefreshedMsg struct {
+	instance *awsservice.RDSInstance
+	err      error
+}
+
+type rdsTickMsg struct {
+	instanceID string
 }
 
 // Model is the root Bubbletea model.
@@ -91,6 +114,16 @@ type Model struct {
 	ipScrollOffset int
 	ipFilter       string
 	ipFilterActive bool
+
+	// RDS browser state
+	rdsInstances    []awsservice.RDSInstance
+	filteredRDS     []awsservice.RDSInstance
+	rdsIdx          int
+	rdsFilter       string
+	rdsFilterActive bool
+	selectedRDS     *awsservice.RDSInstance
+	rdsAction       string // "start", "stop", "failover"
+	rdsPolling      bool
 
 	// Error display
 	errMsg string
@@ -150,6 +183,49 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.screen = screenSubnetDetail
 		return m, nil
 
+	case rdsInstancesLoadedMsg:
+		m.rdsInstances = msg.instances
+		m.filteredRDS = msg.instances
+		m.rdsIdx = 0
+		m.screen = screenRDSList
+		return m, nil
+
+	case rdsActionDoneMsg:
+		if msg.err != nil {
+			m.errMsg = msg.err.Error()
+			m.screen = screenError
+			return m, nil
+		}
+		m.rdsPolling = true
+		m.screen = screenRDSDetail
+		return m, m.tickRDSPoll(msg.instanceID)
+
+	case rdsStatusRefreshedMsg:
+		if msg.err != nil {
+			m.rdsPolling = false
+			return m, nil
+		}
+		m.selectedRDS = msg.instance
+		// Update the instance in the list
+		for i, inst := range m.rdsInstances {
+			if inst.DBInstanceID == msg.instance.DBInstanceID {
+				m.rdsInstances[i] = *msg.instance
+				break
+			}
+		}
+		m.applyRDSFilter()
+		if awsservice.IsTransitionalStatus(msg.instance.Status) {
+			return m, m.tickRDSPoll(msg.instance.DBInstanceID)
+		}
+		m.rdsPolling = false
+		return m, nil
+
+	case rdsTickMsg:
+		if m.rdsPolling {
+			return m, m.pollRDSStatus(msg.instanceID)
+		}
+		return m, nil
+
 	case errMsg:
 		m.errMsg = msg.err.Error()
 		m.screen = screenError
@@ -190,6 +266,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateSubnetList(msg)
 		case screenSubnetDetail:
 			return m.updateSubnetDetail(msg)
+		case screenRDSList:
+			return m.updateRDSList(msg)
+		case screenRDSDetail:
+			return m.updateRDSDetail(msg)
+		case screenRDSConfirm:
+			return m.updateRDSConfirm(msg)
 		case screenError:
 			return m.updateError(msg)
 		}
@@ -243,6 +325,9 @@ func (m Model) updateFeatureList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			case domain.FeatureVPCBrowser:
 				m.screen = screenLoading
 				return m, m.loadVPCs()
+			case domain.FeatureRDSBrowser:
+				m.screen = screenLoading
+				return m, m.loadRDSInstances()
 			}
 		}
 	}
@@ -410,6 +495,112 @@ func (m Model) updateError(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m Model) updateRDSList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	key := msg.String()
+
+	if m.rdsFilterActive {
+		switch key {
+		case "esc":
+			m.rdsFilterActive = false
+		case "enter":
+			m.rdsFilterActive = false
+		case "backspace":
+			if len(m.rdsFilter) > 0 {
+				m.rdsFilter = m.rdsFilter[:len(m.rdsFilter)-1]
+				m.applyRDSFilter()
+			}
+		default:
+			if len(key) == 1 {
+				m.rdsFilter += key
+				m.applyRDSFilter()
+			}
+		}
+		return m, nil
+	}
+
+	switch key {
+	case "q", "esc":
+		m.screen = screenFeatureList
+		m.rdsFilter = ""
+		m.filteredRDS = m.rdsInstances
+		m.rdsIdx = 0
+	case "up", "k":
+		if m.rdsIdx > 0 {
+			m.rdsIdx--
+		}
+	case "down", "j":
+		if m.rdsIdx < len(m.filteredRDS)-1 {
+			m.rdsIdx++
+		}
+	case "/":
+		m.rdsFilterActive = true
+	case "enter":
+		if len(m.filteredRDS) > 0 && m.rdsIdx < len(m.filteredRDS) {
+			selected := m.filteredRDS[m.rdsIdx]
+			m.selectedRDS = &selected
+			m.screen = screenRDSDetail
+		}
+	}
+	return m, nil
+}
+
+func (m Model) updateRDSDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "esc":
+		m.rdsPolling = false
+		m.screen = screenRDSList
+	case "s":
+		if m.selectedRDS != nil && m.selectedRDS.CanStart() {
+			m.rdsAction = "start"
+			m.screen = screenRDSConfirm
+		}
+	case "x":
+		if m.selectedRDS != nil && m.selectedRDS.CanStop() {
+			m.rdsAction = "stop"
+			m.screen = screenRDSConfirm
+		}
+	case "f":
+		if m.selectedRDS != nil && m.selectedRDS.CanFailover() {
+			m.rdsAction = "failover"
+			m.screen = screenRDSConfirm
+		}
+	case "r":
+		if m.selectedRDS != nil {
+			return m, m.pollRDSStatus(m.selectedRDS.DBInstanceID)
+		}
+	}
+	return m, nil
+}
+
+func (m Model) updateRDSConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "y", "enter":
+		if m.selectedRDS != nil {
+			m.screen = screenRDSDetail
+			return m, m.executeRDSAction(m.rdsAction, m.selectedRDS.DBInstanceID)
+		}
+	case "n", "esc":
+		m.screen = screenRDSDetail
+	}
+	return m, nil
+}
+
+func (m *Model) applyRDSFilter() {
+	if m.rdsFilter == "" {
+		m.filteredRDS = m.rdsInstances
+	} else {
+		query := strings.ToLower(m.rdsFilter)
+		var result []awsservice.RDSInstance
+		for _, inst := range m.rdsInstances {
+			if strings.Contains(inst.FilterText(), query) {
+				result = append(result, inst)
+			}
+		}
+		m.filteredRDS = result
+	}
+	m.rdsIdx = 0
+}
+
 func (m *Model) applyFilter() {
 	if m.filterInput == "" {
 		m.filtered = m.instances
@@ -514,6 +705,74 @@ func (m Model) loadInstances() tea.Cmd {
 	}
 }
 
+func (m Model) loadRDSInstances() tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		m.awsRepo = repo
+
+		instances, err := repo.ListDBInstances(ctx)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		if len(instances) == 0 {
+			return errMsg{err: fmt.Errorf("no RDS instances found")}
+		}
+		return rdsInstancesLoadedMsg{instances: instances}
+	}
+}
+
+func (m Model) executeRDSAction(action, dbInstanceID string) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		repo := m.awsRepo
+		if repo == nil {
+			var err error
+			repo, err = awsservice.NewAwsRepository(ctx, m.cfg)
+			if err != nil {
+				return rdsActionDoneMsg{action: action, instanceID: dbInstanceID, err: err}
+			}
+		}
+
+		var err error
+		switch action {
+		case "start":
+			err = repo.StartDBInstance(ctx, dbInstanceID)
+		case "stop":
+			err = repo.StopDBInstance(ctx, dbInstanceID)
+		case "failover":
+			err = repo.RebootDBInstance(ctx, dbInstanceID, true)
+		}
+		return rdsActionDoneMsg{action: action, instanceID: dbInstanceID, err: err}
+	}
+}
+
+func (m Model) pollRDSStatus(dbInstanceID string) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		repo := m.awsRepo
+		if repo == nil {
+			var err error
+			repo, err = awsservice.NewAwsRepository(ctx, m.cfg)
+			if err != nil {
+				return rdsStatusRefreshedMsg{err: err}
+			}
+		}
+
+		inst, err := repo.DescribeDBInstance(ctx, dbInstanceID)
+		return rdsStatusRefreshedMsg{instance: inst, err: err}
+	}
+}
+
+func (m Model) tickRDSPoll(dbInstanceID string) tea.Cmd {
+	return tea.Tick(5*time.Second, func(_ time.Time) tea.Msg {
+		return rdsTickMsg{instanceID: dbInstanceID}
+	})
+}
+
 func (m Model) startSSMSession(inst awsservice.EC2Instance) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
@@ -568,6 +827,12 @@ func (m Model) View() string {
 		return m.viewSubnetList()
 	case screenSubnetDetail:
 		return m.viewSubnetDetail()
+	case screenRDSList:
+		return m.viewRDSList()
+	case screenRDSDetail:
+		return m.viewRDSDetail()
+	case screenRDSConfirm:
+		return m.viewRDSConfirm()
 	case screenLoading:
 		return m.viewLoading()
 	case screenError:
@@ -814,5 +1079,148 @@ func (m Model) viewSubnetDetail() string {
 
 	b.WriteString("\n")
 	b.WriteString(dimStyle.Render("↑/↓: scroll • /: filter • esc: back • H: home"))
+	return b.String()
+}
+
+func (m Model) viewRDSList() string {
+	var b strings.Builder
+	b.WriteString(titleStyle.Render("RDS Instances"))
+	b.WriteString("\n")
+
+	// Filter bar
+	if m.rdsFilterActive {
+		b.WriteString(filterStyle.Render(fmt.Sprintf("Filter: %s▏", m.rdsFilter)))
+	} else if m.rdsFilter != "" {
+		b.WriteString(dimStyle.Render(fmt.Sprintf("Filter: %s", m.rdsFilter)))
+	}
+	b.WriteString("\n\n")
+
+	if len(m.filteredRDS) == 0 {
+		b.WriteString(dimStyle.Render("  No matching instances"))
+		b.WriteString("\n")
+	} else {
+		visibleLines := max(m.height-8, 5)
+		start := 0
+		if m.rdsIdx >= visibleLines {
+			start = m.rdsIdx - visibleLines + 1
+		}
+		end := min(start+visibleLines, len(m.filteredRDS))
+
+		for i := start; i < end; i++ {
+			inst := m.filteredRDS[i]
+			cursor := "  "
+			style := normalStyle
+			if i == m.rdsIdx {
+				cursor = "> "
+				style = selectedStyle
+			}
+			b.WriteString(style.Render(fmt.Sprintf("%s%s", cursor, inst.DisplayTitle())))
+			b.WriteString("\n")
+		}
+
+		b.WriteString("\n")
+		b.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d instances", len(m.filteredRDS), len(m.rdsInstances))))
+	}
+
+	b.WriteString("\n")
+	b.WriteString(dimStyle.Render("↑/↓: navigate • /: filter • enter: detail • esc: back • H: home"))
+	return b.String()
+}
+
+func (m Model) viewRDSDetail() string {
+	if m.selectedRDS == nil {
+		return ""
+	}
+	r := m.selectedRDS
+	var b strings.Builder
+	b.WriteString(titleStyle.Render("RDS Instance Detail"))
+	b.WriteString("\n\n")
+
+	b.WriteString(normalStyle.Render(fmt.Sprintf("  Identifier : %s", r.DBInstanceID)))
+	b.WriteString("\n")
+	b.WriteString(normalStyle.Render(fmt.Sprintf("  Engine     : %s %s", r.Engine, r.EngineVersion)))
+	b.WriteString("\n")
+
+	// Color-code status
+	statusStr := r.Status
+	if r.Status == "available" {
+		statusStr = selectedStyle.Render(r.Status)
+	} else if awsservice.IsTransitionalStatus(r.Status) {
+		statusStr = filterStyle.Render(r.Status)
+	} else if r.Status == "stopped" || r.Status == "failed" {
+		statusStr = errorStyle.Render(r.Status)
+	}
+	pollingIndicator := ""
+	if m.rdsPolling {
+		pollingIndicator = filterStyle.Render(" (polling...)")
+	}
+	b.WriteString(fmt.Sprintf("  Status     : %s%s", statusStr, pollingIndicator))
+	b.WriteString("\n")
+
+	b.WriteString(normalStyle.Render(fmt.Sprintf("  Class      : %s", r.InstanceClass)))
+	b.WriteString("\n")
+	multiAZStr := "No"
+	if r.MultiAZ {
+		multiAZStr = "Yes"
+	}
+	b.WriteString(normalStyle.Render(fmt.Sprintf("  Multi-AZ   : %s", multiAZStr)))
+	b.WriteString("\n")
+	b.WriteString(normalStyle.Render(fmt.Sprintf("  Storage    : %d GB", r.StorageGB)))
+	b.WriteString("\n")
+	endpoint := r.Endpoint
+	if endpoint == "" {
+		endpoint = dimStyle.Render("(unavailable)")
+	}
+	b.WriteString(normalStyle.Render(fmt.Sprintf("  Endpoint   : %s", endpoint)))
+	b.WriteString("\n")
+	if r.ClusterID != "" {
+		b.WriteString(normalStyle.Render(fmt.Sprintf("  Cluster    : %s", r.ClusterID)))
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+	b.WriteString(titleStyle.Render("Actions"))
+	b.WriteString("\n")
+	if r.CanStart() {
+		b.WriteString(normalStyle.Render("  [s] Start"))
+		b.WriteString("\n")
+	} else {
+		b.WriteString(dimStyle.Render("  [s] Start"))
+		b.WriteString("\n")
+	}
+	if r.CanStop() {
+		b.WriteString(normalStyle.Render("  [x] Stop"))
+		b.WriteString("\n")
+	} else {
+		b.WriteString(dimStyle.Render("  [x] Stop"))
+		b.WriteString("\n")
+	}
+	if r.CanFailover() {
+		b.WriteString(normalStyle.Render("  [f] Failover"))
+		b.WriteString("\n")
+	} else {
+		b.WriteString(dimStyle.Render("  [f] Failover"))
+		b.WriteString("\n")
+	}
+	b.WriteString(normalStyle.Render("  [r] Refresh"))
+	b.WriteString("\n")
+
+	b.WriteString("\n")
+	b.WriteString(dimStyle.Render("esc: back • H: home"))
+	return b.String()
+}
+
+func (m Model) viewRDSConfirm() string {
+	if m.selectedRDS == nil {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(errorStyle.Render("Confirm Action"))
+	b.WriteString("\n\n")
+	b.WriteString(normalStyle.Render(fmt.Sprintf("  Are you sure you want to %s instance %s?",
+		m.rdsAction, m.selectedRDS.DBInstanceID)))
+	b.WriteString("\n\n")
+	b.WriteString(normalStyle.Render("  [y] Yes  [n] No"))
+	b.WriteString("\n")
 	return b.String()
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -6,6 +6,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"unic/internal/config"
+	"unic/internal/domain"
+	awsservice "unic/internal/services/aws"
 )
 
 func testConfig() *config.Config {
@@ -93,5 +95,283 @@ func TestFeatureListEscGoesBack(t *testing.T) {
 	model := updated.(Model)
 	if model.screen != screenServiceList {
 		t.Errorf("expected service list screen, got %d", model.screen)
+	}
+}
+
+// --- RDS screen tests ---
+
+func TestRDSListNavigation(t *testing.T) {
+	m := New(testConfig())
+	m.screen = screenRDSList
+	m.rdsInstances = []awsservice.RDSInstance{
+		{DBInstanceID: "db-1", Engine: "mysql", Status: "available", InstanceClass: "db.t3.micro"},
+		{DBInstanceID: "db-2", Engine: "postgres", Status: "stopped", InstanceClass: "db.t3.small"},
+	}
+	m.filteredRDS = m.rdsInstances
+
+	// Press down
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	model := updated.(Model)
+	if model.rdsIdx != 1 {
+		t.Errorf("expected rdsIdx 1 after pressing j, got %d", model.rdsIdx)
+	}
+
+	// Press up
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	model = updated.(Model)
+	if model.rdsIdx != 0 {
+		t.Errorf("expected rdsIdx 0 after pressing k, got %d", model.rdsIdx)
+	}
+}
+
+func TestRDSListEnterGoesToDetail(t *testing.T) {
+	m := New(testConfig())
+	m.screen = screenRDSList
+	m.rdsInstances = []awsservice.RDSInstance{
+		{DBInstanceID: "db-1", Engine: "mysql", Status: "available", InstanceClass: "db.t3.micro"},
+	}
+	m.filteredRDS = m.rdsInstances
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model := updated.(Model)
+	if model.screen != screenRDSDetail {
+		t.Errorf("expected RDS detail screen, got %d", model.screen)
+	}
+	if model.selectedRDS == nil {
+		t.Error("selectedRDS should not be nil")
+	}
+}
+
+func TestRDSListEscGoesBack(t *testing.T) {
+	m := New(testConfig())
+	m.screen = screenRDSList
+	m.rdsInstances = []awsservice.RDSInstance{}
+	m.filteredRDS = m.rdsInstances
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	model := updated.(Model)
+	if model.screen != screenFeatureList {
+		t.Errorf("expected feature list screen, got %d", model.screen)
+	}
+}
+
+func TestRDSDetailEscGoesBack(t *testing.T) {
+	m := New(testConfig())
+	m.screen = screenRDSDetail
+	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "available"}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	model := updated.(Model)
+	if model.screen != screenRDSList {
+		t.Errorf("expected RDS list screen, got %d", model.screen)
+	}
+}
+
+func TestRDSDetailStopGoesToConfirm(t *testing.T) {
+	m := New(testConfig())
+	m.screen = screenRDSDetail
+	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "available", ClusterID: ""}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	model := updated.(Model)
+	if model.screen != screenRDSConfirm {
+		t.Errorf("expected confirm screen, got %d", model.screen)
+	}
+	if model.rdsAction != "stop" {
+		t.Errorf("expected action 'stop', got %q", model.rdsAction)
+	}
+}
+
+func TestRDSDetailStartGoesToConfirm(t *testing.T) {
+	m := New(testConfig())
+	m.screen = screenRDSDetail
+	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "stopped"}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	model := updated.(Model)
+	if model.screen != screenRDSConfirm {
+		t.Errorf("expected confirm screen, got %d", model.screen)
+	}
+	if model.rdsAction != "start" {
+		t.Errorf("expected action 'start', got %q", model.rdsAction)
+	}
+}
+
+func TestRDSDetailFailoverGoesToConfirm(t *testing.T) {
+	m := New(testConfig())
+	m.screen = screenRDSDetail
+	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "available", MultiAZ: true}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	model := updated.(Model)
+	if model.screen != screenRDSConfirm {
+		t.Errorf("expected confirm screen, got %d", model.screen)
+	}
+	if model.rdsAction != "failover" {
+		t.Errorf("expected action 'failover', got %q", model.rdsAction)
+	}
+}
+
+func TestRDSDetailNoStopForClusterMember(t *testing.T) {
+	m := New(testConfig())
+	m.screen = screenRDSDetail
+	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "available", ClusterID: "my-cluster"}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	model := updated.(Model)
+	// Should stay on detail screen since CanStop() is false
+	if model.screen != screenRDSDetail {
+		t.Errorf("expected to stay on detail screen, got %d", model.screen)
+	}
+}
+
+func TestRDSConfirmNoGoesBack(t *testing.T) {
+	m := New(testConfig())
+	m.screen = screenRDSConfirm
+	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1"}
+	m.rdsAction = "stop"
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	model := updated.(Model)
+	if model.screen != screenRDSDetail {
+		t.Errorf("expected detail screen after cancel, got %d", model.screen)
+	}
+}
+
+func TestRDSConfirmEscGoesBack(t *testing.T) {
+	m := New(testConfig())
+	m.screen = screenRDSConfirm
+	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1"}
+	m.rdsAction = "stop"
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	model := updated.(Model)
+	if model.screen != screenRDSDetail {
+		t.Errorf("expected detail screen after esc, got %d", model.screen)
+	}
+}
+
+func TestRDSListFilter(t *testing.T) {
+	m := New(testConfig())
+	m.screen = screenRDSList
+	m.rdsInstances = []awsservice.RDSInstance{
+		{DBInstanceID: "prod-db", Engine: "mysql", Status: "available", InstanceClass: "db.t3.micro"},
+		{DBInstanceID: "dev-db", Engine: "postgres", Status: "stopped", InstanceClass: "db.t3.small"},
+	}
+	m.filteredRDS = m.rdsInstances
+
+	// Activate filter
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	model := updated.(Model)
+	if !model.rdsFilterActive {
+		t.Error("filter should be active")
+	}
+
+	// Type 'p', 'r', 'o', 'd'
+	for _, ch := range "prod" {
+		updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{ch}})
+		model = updated.(Model)
+	}
+
+	if len(model.filteredRDS) != 1 {
+		t.Errorf("expected 1 filtered instance, got %d", len(model.filteredRDS))
+	}
+	if model.filteredRDS[0].DBInstanceID != "prod-db" {
+		t.Errorf("expected 'prod-db', got %q", model.filteredRDS[0].DBInstanceID)
+	}
+}
+
+func TestRDSActionDoneMsg_Success(t *testing.T) {
+	m := New(testConfig())
+	m.screen = screenRDSDetail
+	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1"}
+
+	updated, cmd := m.Update(rdsActionDoneMsg{action: "stop", instanceID: "db-1", err: nil})
+	model := updated.(Model)
+	if model.screen != screenRDSDetail {
+		t.Errorf("expected detail screen after action done, got %d", model.screen)
+	}
+	if !model.rdsPolling {
+		t.Error("polling should be active after successful action")
+	}
+	if cmd == nil {
+		t.Error("expected a tick command for polling")
+	}
+}
+
+func TestRDSInstancesLoadedMsg(t *testing.T) {
+	m := New(testConfig())
+	m.screen = screenLoading
+
+	instances := []awsservice.RDSInstance{
+		{DBInstanceID: "db-1", Engine: "mysql"},
+	}
+	updated, _ := m.Update(rdsInstancesLoadedMsg{instances: instances})
+	model := updated.(Model)
+	if model.screen != screenRDSList {
+		t.Errorf("expected RDS list screen, got %d", model.screen)
+	}
+	if len(model.rdsInstances) != 1 {
+		t.Errorf("expected 1 instance, got %d", len(model.rdsInstances))
+	}
+}
+
+func TestFeatureListRDSBrowserGoesToLoading(t *testing.T) {
+	m := New(testConfig())
+	m.screen = screenFeatureList
+	m.features = []domain.Feature{
+		{Kind: domain.FeatureRDSBrowser, Description: "Browse RDS instances"},
+	}
+	m.featIdx = 0
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model := updated.(Model)
+	if model.screen != screenLoading {
+		t.Errorf("expected loading screen, got %d", model.screen)
+	}
+	if cmd == nil {
+		t.Error("expected a command to load RDS instances")
+	}
+}
+
+func TestRDSViewNotEmpty(t *testing.T) {
+	m := New(testConfig())
+	m.screen = screenRDSList
+	m.rdsInstances = []awsservice.RDSInstance{
+		{DBInstanceID: "db-1", Engine: "mysql", Status: "available", InstanceClass: "db.t3.micro", EngineVersion: "8.0"},
+	}
+	m.filteredRDS = m.rdsInstances
+	m.height = 30
+
+	v := m.View()
+	if v == "" {
+		t.Error("RDS list view should not be empty")
+	}
+}
+
+func TestRDSDetailViewNotEmpty(t *testing.T) {
+	m := New(testConfig())
+	m.screen = screenRDSDetail
+	m.selectedRDS = &awsservice.RDSInstance{
+		DBInstanceID: "db-1", Engine: "mysql", EngineVersion: "8.0",
+		Status: "available", InstanceClass: "db.t3.micro", MultiAZ: true, StorageGB: 20,
+		Endpoint: "db-1.abc.us-east-1.rds.amazonaws.com:3306",
+	}
+
+	v := m.View()
+	if v == "" {
+		t.Error("RDS detail view should not be empty")
+	}
+}
+
+func TestRDSConfirmViewNotEmpty(t *testing.T) {
+	m := New(testConfig())
+	m.screen = screenRDSConfirm
+	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1"}
+	m.rdsAction = "stop"
+
+	v := m.View()
+	if v == "" {
+		t.Error("RDS confirm view should not be empty")
 	}
 }

--- a/internal/domain/catalog.go
+++ b/internal/domain/catalog.go
@@ -21,5 +21,14 @@ func Catalog() []Service {
 				},
 			},
 		},
+		{
+			Name: ServiceRDS,
+			Features: []Feature{
+				{
+					Kind:        FeatureRDSBrowser,
+					Description: "Browse RDS instances, start/stop, failover",
+				},
+			},
+		},
 	}
 }

--- a/internal/domain/catalog_test.go
+++ b/internal/domain/catalog_test.go
@@ -50,3 +50,37 @@ func TestAllServicesHaveFeatures(t *testing.T) {
 		}
 	}
 }
+
+func TestCatalogContainsRDS(t *testing.T) {
+	services := Catalog()
+
+	found := false
+	for _, svc := range services {
+		if svc.Name == ServiceRDS {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Error("catalog should contain RDS service")
+	}
+}
+
+func TestRDSHasBrowserFeature(t *testing.T) {
+	services := Catalog()
+
+	for _, svc := range services {
+		if svc.Name == ServiceRDS {
+			for _, feat := range svc.Features {
+				if feat.Kind == FeatureRDSBrowser {
+					return
+				}
+			}
+			t.Error("RDS service should have RDS Browser feature")
+			return
+		}
+	}
+
+	t.Error("RDS service not found in catalog")
+}

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -6,14 +6,16 @@ type AwsService string
 const (
 	ServiceEC2 AwsService = "EC2"
 	ServiceVPC AwsService = "VPC"
+	ServiceRDS AwsService = "RDS"
 )
 
 // FeatureKind represents a specific feature within a service.
 type FeatureKind string
 
 const (
-	FeatureSSMSession FeatureKind = "SSM Sessions Manager"
-	FeatureVPCBrowser FeatureKind = "VPC Browser"
+	FeatureSSMSession  FeatureKind = "SSM Sessions Manager"
+	FeatureVPCBrowser  FeatureKind = "VPC Browser"
+	FeatureRDSBrowser  FeatureKind = "RDS Browser"
 )
 
 // Feature describes a selectable feature under an AWS service.

--- a/internal/services/aws/rds.go
+++ b/internal/services/aws/rds.go
@@ -1,0 +1,104 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+)
+
+// ListDBInstances returns all RDS DB instances in the current account/region.
+func (r *AwsRepository) ListDBInstances(ctx context.Context) ([]RDSInstance, error) {
+	output, err := r.RDSClient.DescribeDBInstances(ctx, &rds.DescribeDBInstancesInput{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe DB instances: %w", err)
+	}
+
+	instances := make([]RDSInstance, 0, len(output.DBInstances))
+	for _, db := range output.DBInstances {
+		inst := RDSInstance{
+			DBInstanceID:  awssdk.ToString(db.DBInstanceIdentifier),
+			Engine:        awssdk.ToString(db.Engine),
+			EngineVersion: awssdk.ToString(db.EngineVersion),
+			Status:        awssdk.ToString(db.DBInstanceStatus),
+			InstanceClass: awssdk.ToString(db.DBInstanceClass),
+			MultiAZ:       awssdk.ToBool(db.MultiAZ),
+			StorageGB:     awssdk.ToInt32(db.AllocatedStorage),
+			ClusterID:     awssdk.ToString(db.DBClusterIdentifier),
+		}
+
+		// Endpoint may be nil for stopped instances
+		if db.Endpoint != nil {
+			inst.Endpoint = fmt.Sprintf("%s:%d", awssdk.ToString(db.Endpoint.Address), awssdk.ToInt32(db.Endpoint.Port))
+		}
+
+		instances = append(instances, inst)
+	}
+	return instances, nil
+}
+
+// DescribeDBInstance returns a single refreshed RDS instance by identifier.
+func (r *AwsRepository) DescribeDBInstance(ctx context.Context, dbInstanceID string) (*RDSInstance, error) {
+	output, err := r.RDSClient.DescribeDBInstances(ctx, &rds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: awssdk.String(dbInstanceID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe DB instance %s: %w", dbInstanceID, err)
+	}
+
+	if len(output.DBInstances) == 0 {
+		return nil, fmt.Errorf("DB instance %s not found", dbInstanceID)
+	}
+
+	db := output.DBInstances[0]
+	inst := &RDSInstance{
+		DBInstanceID:  awssdk.ToString(db.DBInstanceIdentifier),
+		Engine:        awssdk.ToString(db.Engine),
+		EngineVersion: awssdk.ToString(db.EngineVersion),
+		Status:        awssdk.ToString(db.DBInstanceStatus),
+		InstanceClass: awssdk.ToString(db.DBInstanceClass),
+		MultiAZ:       awssdk.ToBool(db.MultiAZ),
+		StorageGB:     awssdk.ToInt32(db.AllocatedStorage),
+		ClusterID:     awssdk.ToString(db.DBClusterIdentifier),
+	}
+	if db.Endpoint != nil {
+		inst.Endpoint = fmt.Sprintf("%s:%d", awssdk.ToString(db.Endpoint.Address), awssdk.ToInt32(db.Endpoint.Port))
+	}
+	return inst, nil
+}
+
+// StopDBInstance stops a running RDS instance.
+func (r *AwsRepository) StopDBInstance(ctx context.Context, dbInstanceID string) error {
+	_, err := r.RDSClient.StopDBInstance(ctx, &rds.StopDBInstanceInput{
+		DBInstanceIdentifier: awssdk.String(dbInstanceID),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to stop DB instance %s: %w", dbInstanceID, err)
+	}
+	return nil
+}
+
+// StartDBInstance starts a stopped RDS instance.
+func (r *AwsRepository) StartDBInstance(ctx context.Context, dbInstanceID string) error {
+	_, err := r.RDSClient.StartDBInstance(ctx, &rds.StartDBInstanceInput{
+		DBInstanceIdentifier: awssdk.String(dbInstanceID),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to start DB instance %s: %w", dbInstanceID, err)
+	}
+	return nil
+}
+
+// RebootDBInstance reboots an RDS instance. If forceFailover is true,
+// a Multi-AZ failover is triggered.
+func (r *AwsRepository) RebootDBInstance(ctx context.Context, dbInstanceID string, forceFailover bool) error {
+	_, err := r.RDSClient.RebootDBInstance(ctx, &rds.RebootDBInstanceInput{
+		DBInstanceIdentifier: awssdk.String(dbInstanceID),
+		ForceFailover:        awssdk.Bool(forceFailover),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to reboot DB instance %s: %w", dbInstanceID, err)
+	}
+	return nil
+}

--- a/internal/services/aws/rds_model.go
+++ b/internal/services/aws/rds_model.go
@@ -1,0 +1,58 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RDSInstance holds essential information about an RDS database instance.
+type RDSInstance struct {
+	DBInstanceID  string
+	Engine        string
+	EngineVersion string
+	Status        string
+	InstanceClass string
+	MultiAZ       bool
+	StorageGB     int32
+	Endpoint      string
+	ClusterID     string
+}
+
+// DisplayTitle returns a formatted string for list display.
+func (r RDSInstance) DisplayTitle() string {
+	return fmt.Sprintf("%s (%s) %s %s [%s]",
+		r.DBInstanceID, r.InstanceClass, r.Engine, r.EngineVersion, r.Status)
+}
+
+// FilterText returns a lowercase string for keyword matching.
+func (r RDSInstance) FilterText() string {
+	return strings.ToLower(fmt.Sprintf("%s %s %s %s %s %s",
+		r.DBInstanceID, r.Engine, r.EngineVersion, r.Status, r.InstanceClass, r.ClusterID))
+}
+
+// CanStop returns true if the instance can be stopped.
+// Aurora cluster members cannot be stopped individually.
+func (r RDSInstance) CanStop() bool {
+	return r.Status == "available" && r.ClusterID == ""
+}
+
+// CanStart returns true if the instance can be started.
+func (r RDSInstance) CanStart() bool {
+	return r.Status == "stopped"
+}
+
+// CanFailover returns true if the instance supports Multi-AZ failover.
+func (r RDSInstance) CanFailover() bool {
+	return r.Status == "available" && r.MultiAZ
+}
+
+// IsTransitionalStatus returns true if the instance is in a transitional state.
+func IsTransitionalStatus(status string) bool {
+	switch status {
+	case "starting", "stopping", "rebooting", "modifying", "backing-up",
+		"configuring-enhanced-monitoring", "maintenance", "renaming",
+		"resetting-master-credentials":
+		return true
+	}
+	return false
+}

--- a/internal/services/aws/rds_test.go
+++ b/internal/services/aws/rds_test.go
@@ -1,0 +1,434 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+)
+
+// mockRDSClient implements RDSClientAPI for testing.
+type mockRDSClient struct {
+	describeDBInstancesFunc func(ctx context.Context, params *rds.DescribeDBInstancesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error)
+	stopDBInstanceFunc      func(ctx context.Context, params *rds.StopDBInstanceInput, optFns ...func(*rds.Options)) (*rds.StopDBInstanceOutput, error)
+	startDBInstanceFunc     func(ctx context.Context, params *rds.StartDBInstanceInput, optFns ...func(*rds.Options)) (*rds.StartDBInstanceOutput, error)
+	rebootDBInstanceFunc    func(ctx context.Context, params *rds.RebootDBInstanceInput, optFns ...func(*rds.Options)) (*rds.RebootDBInstanceOutput, error)
+}
+
+func (m *mockRDSClient) DescribeDBInstances(ctx context.Context, params *rds.DescribeDBInstancesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error) {
+	return m.describeDBInstancesFunc(ctx, params, optFns...)
+}
+
+func (m *mockRDSClient) StopDBInstance(ctx context.Context, params *rds.StopDBInstanceInput, optFns ...func(*rds.Options)) (*rds.StopDBInstanceOutput, error) {
+	if m.stopDBInstanceFunc != nil {
+		return m.stopDBInstanceFunc(ctx, params, optFns...)
+	}
+	return &rds.StopDBInstanceOutput{}, nil
+}
+
+func (m *mockRDSClient) StartDBInstance(ctx context.Context, params *rds.StartDBInstanceInput, optFns ...func(*rds.Options)) (*rds.StartDBInstanceOutput, error) {
+	if m.startDBInstanceFunc != nil {
+		return m.startDBInstanceFunc(ctx, params, optFns...)
+	}
+	return &rds.StartDBInstanceOutput{}, nil
+}
+
+func (m *mockRDSClient) RebootDBInstance(ctx context.Context, params *rds.RebootDBInstanceInput, optFns ...func(*rds.Options)) (*rds.RebootDBInstanceOutput, error) {
+	if m.rebootDBInstanceFunc != nil {
+		return m.rebootDBInstanceFunc(ctx, params, optFns...)
+	}
+	return &rds.RebootDBInstanceOutput{}, nil
+}
+
+// --- ListDBInstances tests ---
+
+func TestListDBInstances_Success(t *testing.T) {
+	mock := &mockRDSClient{
+		describeDBInstancesFunc: func(_ context.Context, _ *rds.DescribeDBInstancesInput, _ ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error) {
+			return &rds.DescribeDBInstancesOutput{
+				DBInstances: []rdstypes.DBInstance{
+					{
+						DBInstanceIdentifier: awssdk.String("my-db"),
+						Engine:               awssdk.String("mysql"),
+						EngineVersion:        awssdk.String("8.0.35"),
+						DBInstanceStatus:     awssdk.String("available"),
+						DBInstanceClass:      awssdk.String("db.t3.micro"),
+						MultiAZ:              awssdk.Bool(true),
+						AllocatedStorage:     awssdk.Int32(20),
+						Endpoint: &rdstypes.Endpoint{
+							Address: awssdk.String("my-db.abc123.us-east-1.rds.amazonaws.com"),
+							Port:    awssdk.Int32(3306),
+						},
+					},
+					{
+						DBInstanceIdentifier: awssdk.String("aurora-inst-1"),
+						Engine:               awssdk.String("aurora-mysql"),
+						EngineVersion:        awssdk.String("8.0.mysql_aurora.3.04.0"),
+						DBInstanceStatus:     awssdk.String("available"),
+						DBInstanceClass:      awssdk.String("db.r6g.large"),
+						MultiAZ:              awssdk.Bool(false),
+						AllocatedStorage:     awssdk.Int32(0),
+						DBClusterIdentifier:  awssdk.String("my-cluster"),
+						Endpoint: &rdstypes.Endpoint{
+							Address: awssdk.String("aurora-inst-1.abc123.us-east-1.rds.amazonaws.com"),
+							Port:    awssdk.Int32(3306),
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	repo := &AwsRepository{RDSClient: mock}
+	instances, err := repo.ListDBInstances(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(instances) != 2 {
+		t.Fatalf("expected 2 instances, got %d", len(instances))
+	}
+
+	inst := instances[0]
+	if inst.DBInstanceID != "my-db" {
+		t.Errorf("expected DBInstanceID 'my-db', got %q", inst.DBInstanceID)
+	}
+	if inst.Engine != "mysql" {
+		t.Errorf("expected Engine 'mysql', got %q", inst.Engine)
+	}
+	if inst.EngineVersion != "8.0.35" {
+		t.Errorf("expected EngineVersion '8.0.35', got %q", inst.EngineVersion)
+	}
+	if inst.Status != "available" {
+		t.Errorf("expected Status 'available', got %q", inst.Status)
+	}
+	if inst.InstanceClass != "db.t3.micro" {
+		t.Errorf("expected InstanceClass 'db.t3.micro', got %q", inst.InstanceClass)
+	}
+	if !inst.MultiAZ {
+		t.Error("expected MultiAZ to be true")
+	}
+	if inst.StorageGB != 20 {
+		t.Errorf("expected StorageGB 20, got %d", inst.StorageGB)
+	}
+	if inst.Endpoint != "my-db.abc123.us-east-1.rds.amazonaws.com:3306" {
+		t.Errorf("unexpected Endpoint: %q", inst.Endpoint)
+	}
+	if inst.ClusterID != "" {
+		t.Errorf("expected empty ClusterID, got %q", inst.ClusterID)
+	}
+
+	aurora := instances[1]
+	if aurora.ClusterID != "my-cluster" {
+		t.Errorf("expected ClusterID 'my-cluster', got %q", aurora.ClusterID)
+	}
+}
+
+func TestListDBInstances_Empty(t *testing.T) {
+	mock := &mockRDSClient{
+		describeDBInstancesFunc: func(_ context.Context, _ *rds.DescribeDBInstancesInput, _ ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error) {
+			return &rds.DescribeDBInstancesOutput{DBInstances: []rdstypes.DBInstance{}}, nil
+		},
+	}
+
+	repo := &AwsRepository{RDSClient: mock}
+	instances, err := repo.ListDBInstances(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(instances) != 0 {
+		t.Errorf("expected empty slice, got %d", len(instances))
+	}
+}
+
+func TestListDBInstances_Error(t *testing.T) {
+	mock := &mockRDSClient{
+		describeDBInstancesFunc: func(_ context.Context, _ *rds.DescribeDBInstancesInput, _ ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error) {
+			return nil, fmt.Errorf("access denied")
+		},
+	}
+
+	repo := &AwsRepository{RDSClient: mock}
+	_, err := repo.ListDBInstances(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestListDBInstances_NilEndpoint(t *testing.T) {
+	mock := &mockRDSClient{
+		describeDBInstancesFunc: func(_ context.Context, _ *rds.DescribeDBInstancesInput, _ ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error) {
+			return &rds.DescribeDBInstancesOutput{
+				DBInstances: []rdstypes.DBInstance{
+					{
+						DBInstanceIdentifier: awssdk.String("stopped-db"),
+						Engine:               awssdk.String("postgres"),
+						EngineVersion:        awssdk.String("15.4"),
+						DBInstanceStatus:     awssdk.String("stopped"),
+						DBInstanceClass:      awssdk.String("db.t3.small"),
+						MultiAZ:              awssdk.Bool(false),
+						AllocatedStorage:     awssdk.Int32(50),
+						Endpoint:             nil,
+					},
+				},
+			}, nil
+		},
+	}
+
+	repo := &AwsRepository{RDSClient: mock}
+	instances, err := repo.ListDBInstances(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(instances) != 1 {
+		t.Fatalf("expected 1 instance, got %d", len(instances))
+	}
+	if instances[0].Endpoint != "" {
+		t.Errorf("expected empty Endpoint for stopped instance, got %q", instances[0].Endpoint)
+	}
+}
+
+// --- DescribeDBInstance tests ---
+
+func TestDescribeDBInstance_Success(t *testing.T) {
+	mock := &mockRDSClient{
+		describeDBInstancesFunc: func(_ context.Context, params *rds.DescribeDBInstancesInput, _ ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error) {
+			if awssdk.ToString(params.DBInstanceIdentifier) != "my-db" {
+				t.Errorf("expected identifier 'my-db', got %q", awssdk.ToString(params.DBInstanceIdentifier))
+			}
+			return &rds.DescribeDBInstancesOutput{
+				DBInstances: []rdstypes.DBInstance{
+					{
+						DBInstanceIdentifier: awssdk.String("my-db"),
+						Engine:               awssdk.String("mysql"),
+						EngineVersion:        awssdk.String("8.0.35"),
+						DBInstanceStatus:     awssdk.String("available"),
+						DBInstanceClass:      awssdk.String("db.t3.micro"),
+						MultiAZ:              awssdk.Bool(false),
+						AllocatedStorage:     awssdk.Int32(20),
+						Endpoint: &rdstypes.Endpoint{
+							Address: awssdk.String("my-db.abc123.us-east-1.rds.amazonaws.com"),
+							Port:    awssdk.Int32(3306),
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	repo := &AwsRepository{RDSClient: mock}
+	inst, err := repo.DescribeDBInstance(context.Background(), "my-db")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if inst.DBInstanceID != "my-db" {
+		t.Errorf("expected 'my-db', got %q", inst.DBInstanceID)
+	}
+}
+
+// --- StopDBInstance tests ---
+
+func TestStopDBInstance_Success(t *testing.T) {
+	var capturedID string
+	mock := &mockRDSClient{
+		describeDBInstancesFunc: func(_ context.Context, _ *rds.DescribeDBInstancesInput, _ ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error) {
+			return &rds.DescribeDBInstancesOutput{}, nil
+		},
+		stopDBInstanceFunc: func(_ context.Context, params *rds.StopDBInstanceInput, _ ...func(*rds.Options)) (*rds.StopDBInstanceOutput, error) {
+			capturedID = awssdk.ToString(params.DBInstanceIdentifier)
+			return &rds.StopDBInstanceOutput{}, nil
+		},
+	}
+
+	repo := &AwsRepository{RDSClient: mock}
+	err := repo.StopDBInstance(context.Background(), "my-db")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedID != "my-db" {
+		t.Errorf("expected stop to be called with 'my-db', got %q", capturedID)
+	}
+}
+
+func TestStopDBInstance_Error(t *testing.T) {
+	mock := &mockRDSClient{
+		describeDBInstancesFunc: func(_ context.Context, _ *rds.DescribeDBInstancesInput, _ ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error) {
+			return &rds.DescribeDBInstancesOutput{}, nil
+		},
+		stopDBInstanceFunc: func(_ context.Context, _ *rds.StopDBInstanceInput, _ ...func(*rds.Options)) (*rds.StopDBInstanceOutput, error) {
+			return nil, fmt.Errorf("cannot stop Aurora cluster member")
+		},
+	}
+
+	repo := &AwsRepository{RDSClient: mock}
+	err := repo.StopDBInstance(context.Background(), "aurora-inst")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+// --- StartDBInstance tests ---
+
+func TestStartDBInstance_Success(t *testing.T) {
+	var capturedID string
+	mock := &mockRDSClient{
+		describeDBInstancesFunc: func(_ context.Context, _ *rds.DescribeDBInstancesInput, _ ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error) {
+			return &rds.DescribeDBInstancesOutput{}, nil
+		},
+		startDBInstanceFunc: func(_ context.Context, params *rds.StartDBInstanceInput, _ ...func(*rds.Options)) (*rds.StartDBInstanceOutput, error) {
+			capturedID = awssdk.ToString(params.DBInstanceIdentifier)
+			return &rds.StartDBInstanceOutput{}, nil
+		},
+	}
+
+	repo := &AwsRepository{RDSClient: mock}
+	err := repo.StartDBInstance(context.Background(), "my-db")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedID != "my-db" {
+		t.Errorf("expected start to be called with 'my-db', got %q", capturedID)
+	}
+}
+
+func TestStartDBInstance_Error(t *testing.T) {
+	mock := &mockRDSClient{
+		describeDBInstancesFunc: func(_ context.Context, _ *rds.DescribeDBInstancesInput, _ ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error) {
+			return &rds.DescribeDBInstancesOutput{}, nil
+		},
+		startDBInstanceFunc: func(_ context.Context, _ *rds.StartDBInstanceInput, _ ...func(*rds.Options)) (*rds.StartDBInstanceOutput, error) {
+			return nil, fmt.Errorf("instance not in stopped state")
+		},
+	}
+
+	repo := &AwsRepository{RDSClient: mock}
+	err := repo.StartDBInstance(context.Background(), "my-db")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+// --- RebootDBInstance tests ---
+
+func TestRebootDBInstance_ForceFailover(t *testing.T) {
+	var capturedFailover bool
+	mock := &mockRDSClient{
+		describeDBInstancesFunc: func(_ context.Context, _ *rds.DescribeDBInstancesInput, _ ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error) {
+			return &rds.DescribeDBInstancesOutput{}, nil
+		},
+		rebootDBInstanceFunc: func(_ context.Context, params *rds.RebootDBInstanceInput, _ ...func(*rds.Options)) (*rds.RebootDBInstanceOutput, error) {
+			capturedFailover = awssdk.ToBool(params.ForceFailover)
+			return &rds.RebootDBInstanceOutput{}, nil
+		},
+	}
+
+	repo := &AwsRepository{RDSClient: mock}
+	err := repo.RebootDBInstance(context.Background(), "my-db", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !capturedFailover {
+		t.Error("expected ForceFailover to be true")
+	}
+}
+
+// --- Model tests ---
+
+func TestRDSInstanceDisplayTitle(t *testing.T) {
+	inst := RDSInstance{
+		DBInstanceID: "my-db", InstanceClass: "db.t3.micro",
+		Engine: "mysql", EngineVersion: "8.0.35", Status: "available",
+	}
+	expected := "my-db (db.t3.micro) mysql 8.0.35 [available]"
+	if got := inst.DisplayTitle(); got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestRDSInstanceFilterText(t *testing.T) {
+	inst := RDSInstance{
+		DBInstanceID: "MyDB", Engine: "MySQL", EngineVersion: "8.0",
+		Status: "Available", InstanceClass: "db.t3.micro", ClusterID: "MyCluster",
+	}
+	ft := inst.FilterText()
+	for _, kw := range []string{"mydb", "mysql", "8.0", "available", "db.t3.micro", "mycluster"} {
+		if !strings.Contains(ft, kw) {
+			t.Errorf("FilterText %q should contain %q", ft, kw)
+		}
+	}
+}
+
+func TestCanStart_StoppedInstance(t *testing.T) {
+	inst := RDSInstance{Status: "stopped"}
+	if !inst.CanStart() {
+		t.Error("stopped instance should be startable")
+	}
+}
+
+func TestCanStart_RunningInstance(t *testing.T) {
+	inst := RDSInstance{Status: "available"}
+	if inst.CanStart() {
+		t.Error("available instance should not be startable")
+	}
+}
+
+func TestCanStop_RunningInstance(t *testing.T) {
+	inst := RDSInstance{Status: "available", ClusterID: ""}
+	if !inst.CanStop() {
+		t.Error("available standalone instance should be stoppable")
+	}
+}
+
+func TestCanStop_ClusterMember(t *testing.T) {
+	inst := RDSInstance{Status: "available", ClusterID: "my-cluster"}
+	if inst.CanStop() {
+		t.Error("cluster member should not be stoppable individually")
+	}
+}
+
+func TestCanStop_StoppedInstance(t *testing.T) {
+	inst := RDSInstance{Status: "stopped", ClusterID: ""}
+	if inst.CanStop() {
+		t.Error("stopped instance should not be stoppable")
+	}
+}
+
+func TestCanFailover_MultiAZ(t *testing.T) {
+	inst := RDSInstance{Status: "available", MultiAZ: true}
+	if !inst.CanFailover() {
+		t.Error("available Multi-AZ instance should support failover")
+	}
+}
+
+func TestCanFailover_SingleAZ(t *testing.T) {
+	inst := RDSInstance{Status: "available", MultiAZ: false}
+	if inst.CanFailover() {
+		t.Error("single-AZ instance should not support failover")
+	}
+}
+
+func TestCanFailover_StoppedMultiAZ(t *testing.T) {
+	inst := RDSInstance{Status: "stopped", MultiAZ: true}
+	if inst.CanFailover() {
+		t.Error("stopped Multi-AZ instance should not support failover")
+	}
+}
+
+func TestIsTransitionalStatus(t *testing.T) {
+	transitional := []string{"starting", "stopping", "rebooting", "modifying", "backing-up"}
+	for _, s := range transitional {
+		if !IsTransitionalStatus(s) {
+			t.Errorf("%q should be transitional", s)
+		}
+	}
+
+	stable := []string{"available", "stopped", "failed"}
+	for _, s := range stable {
+		if IsTransitionalStatus(s) {
+			t.Errorf("%q should not be transitional", s)
+		}
+	}
+}

--- a/internal/services/aws/repository.go
+++ b/internal/services/aws/repository.go
@@ -7,6 +7,7 @@ import (
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 
 	"unic/internal/config"
@@ -18,11 +19,22 @@ var _ SSMClientAPI = (*ssm.Client)(nil)
 // Verify *ec2.Client satisfies EC2ClientAPI at compile time.
 var _ EC2ClientAPI = (*ec2.Client)(nil)
 
+// Verify *rds.Client satisfies RDSClientAPI at compile time.
+var _ RDSClientAPI = (*rds.Client)(nil)
+
 // SSMClientAPI is the interface for SSM operations used by AwsRepository.
 type SSMClientAPI interface {
 	ssm.DescribeInstanceInformationAPIClient
 	StartSession(ctx context.Context, params *ssm.StartSessionInput, optFns ...func(*ssm.Options)) (*ssm.StartSessionOutput, error)
 	TerminateSession(ctx context.Context, params *ssm.TerminateSessionInput, optFns ...func(*ssm.Options)) (*ssm.TerminateSessionOutput, error)
+}
+
+// RDSClientAPI is the interface for RDS operations used by AwsRepository.
+type RDSClientAPI interface {
+	DescribeDBInstances(ctx context.Context, params *rds.DescribeDBInstancesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error)
+	StopDBInstance(ctx context.Context, params *rds.StopDBInstanceInput, optFns ...func(*rds.Options)) (*rds.StopDBInstanceOutput, error)
+	StartDBInstance(ctx context.Context, params *rds.StartDBInstanceInput, optFns ...func(*rds.Options)) (*rds.StartDBInstanceOutput, error)
+	RebootDBInstance(ctx context.Context, params *rds.RebootDBInstanceInput, optFns ...func(*rds.Options)) (*rds.RebootDBInstanceOutput, error)
 }
 
 // EC2ClientAPI is the interface for EC2 operations used by AwsRepository.
@@ -33,10 +45,11 @@ type EC2ClientAPI interface {
 	DescribeNetworkInterfaces(ctx context.Context, params *ec2.DescribeNetworkInterfacesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeNetworkInterfacesOutput, error)
 }
 
-// AwsRepository holds AWS SDK clients for EC2 and SSM.
+// AwsRepository holds AWS SDK clients for EC2, SSM, and RDS.
 type AwsRepository struct {
 	EC2Client EC2ClientAPI
 	SSMClient SSMClientAPI
+	RDSClient RDSClientAPI
 	Region    string
 	Profile   string
 }
@@ -46,10 +59,16 @@ func NewAwsRepository(ctx context.Context, cfg *config.Config) (*AwsRepository, 
 	opts := []func(*awsconfig.LoadOptions) error{
 		awsconfig.WithRegion(cfg.Region),
 	}
-	// Skip profile when environment credentials are present (e.g. STS assume-role),
-	// because WithSharedConfigProfile forces the SDK to ignore env vars.
+	// Skip explicit profile selection when:
+	// - Environment credentials are present (e.g. STS assume-role env vars)
+	// - AWS_PROFILE is set (let the SDK resolve it, including SSO)
+	// - AWS_CONFIG_FILE is set (WithSharedConfigProfile can override it incorrectly)
+	// In these cases, WithSharedConfigProfile would force credential resolution
+	// from ~/.aws/credentials, bypassing SSO and custom config files.
 	envHasCreds := os.Getenv("AWS_ACCESS_KEY_ID") != "" && os.Getenv("AWS_SECRET_ACCESS_KEY") != ""
-	if cfg.Profile != "" && !envHasCreds {
+	envHasProfile := os.Getenv("AWS_PROFILE") != ""
+	envHasConfigFile := os.Getenv("AWS_CONFIG_FILE") != ""
+	if cfg.Profile != "" && !envHasCreds && !envHasProfile && !envHasConfigFile {
 		opts = append(opts, awsconfig.WithSharedConfigProfile(cfg.Profile))
 	}
 
@@ -61,6 +80,7 @@ func NewAwsRepository(ctx context.Context, cfg *config.Config) (*AwsRepository, 
 	return &AwsRepository{
 		EC2Client: ec2.NewFromConfig(awsCfg),
 		SSMClient: ssm.NewFromConfig(awsCfg),
+		RDSClient: rds.NewFromConfig(awsCfg),
 		Region:    cfg.Region,
 		Profile:   cfg.Profile,
 	}, nil


### PR DESCRIPTION
### Summary

Implements M3.2 — RDS Browser. Adds a new AWS service to the TUI for browsing and managing RDS instances.

**New capabilities:**
- Filterable RDS instance list with engine, status, and class info
- Detail view with color-coded status (green=available, yellow=transitional, red=stopped)
- Start/Stop/Failover actions with confirmation dialogs
- Real-time status polling (5s interval) after actions until instance reaches stable state
- Aurora cluster members blocked from individual stop (must be stopped at cluster level)

**Credential fix:**
- `WithSharedConfigProfile` no longer overrides SSO-based configurations when `AWS_PROFILE` or `AWS_CONFIG_FILE` environment variables are set

**New files:**
- `internal/services/aws/rds.go` — ListDBInstances, Start/Stop/Reboot, DescribeDBInstance
- `internal/services/aws/rds_model.go` — RDSInstance struct with display/filter/action methods
- `internal/services/aws/rds_test.go` — 20+ tests with mock RDS client

**Modified files:**
- Domain layer: added ServiceRDS, FeatureRDSBrowser constants and catalog entry
- Repository: added RDSClientAPI interface and client initialization
- App: added 3 new screens (RDSList, RDSDetail, RDSConfirm) with polling logic
- App tests: 17 new tests for navigation, filtering, actions, and views

### Related Issues

- Part of M3 — AWS Services milestone (PLAN.md)
- Closes #12 

### Validation

- All tests pass (`go test ./...`)
- Manually tested against real AWS accounts:
  - IAM credentials with `--profile` flag
  - SSO login with `AWS_CONFIG_FILE` + `AWS_PROFILE`
  - Verified instance listing, filtering, detail view
  - Verified start/stop actions with confirmation and status polling

### Checklist

- [x] Scope is focused
- [x] Docs updated (if needed)
- [x] Tests/validation included
- [ ] Breaking changes documented