### PR TITLE
ci: add homebrew tap auto-update to goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,9 +18,24 @@ builds:
         goarch: arm64
 
 archives:
-  - format: binary
+  - format: tar.gz
     name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
 
+brews:
+  - repository:
+      owner: DevopsArtFactory
+      name: homebrew-unic
+    name: unic
+    homepage: "https://github.com/DevopsArtFactory/unic"
+    description: "Go-based TUI tool for browsing and managing AWS resources in the terminal"
+    license: "MIT"
+    install: |
+      bin.install "unic"
+    test: |
+      system "#{bin}/unic", "--version"
 
 changelog:
   sort: asc


### PR DESCRIPTION
## Summary

- Add `brews` section to `.goreleaser.yaml` so that on tag push, goreleaser automatically updates the formula in `DevopsArtFactory/homebrew-unic`
- Switch archive format from raw binary to `tar.gz` for homebrew compatibility (`zip` for windows)

## Changes

- `.goreleaser.yaml`: Add `brews` config targeting `DevopsArtFactory/homebrew-unic`, switch archive format to `tar.gz`

## How it works

On `git tag v0.x.x && git push origin v0.x.x`, goreleaser will:
1. Build binaries for darwin/linux (amd64/arm64) + windows (amd64)
2. Upload tar.gz archives to GitHub Release
3. Auto-update `unic.rb` in `DevopsArtFactory/homebrew-unic` with correct sha256, version, and URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)