### PR TITLE
fix: use TAP_GITHUB_TOKEN for homebrew formula push

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,6 +28,7 @@ brews:
   - repository:
       owner: DevopsArtFactory
       name: homebrew-unic
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
     name: unic
     homepage: "https://github.com/DevopsArtFactory/unic"
     description: "Go-based TUI tool for browsing and managing AWS resources in the terminal"


### PR DESCRIPTION
## Summary

Add `token` field to goreleaser `brews.repository` config so it uses `TAP_GITHUB_TOKEN` (PAT) instead of the default `GITHUB_TOKEN` to push the formula to `DevopsArtFactory/homebrew-unic`.

## Problem

goreleaser failed with `403 Resource not accessible by integration` because `GITHUB_TOKEN` only has access to the current repo, not the homebrew tap repo.

## Fix

```yaml
brews:
  - repository:
      owner: DevopsArtFactory
      name: homebrew-unic
      token: "{{ .Env.TAP_GITHUB_TOKEN }}"  # <-- added
```

Requires `TAP_GITHUB_TOKEN` secret (PAT with `repo` scope) in repo settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)