### PR TITLE
feat: add refresh key binding to EC2 SSM instance list

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,16 +74,32 @@ contexts:
 
 ## TUI Key Bindings
 
+### Global
+
 | Key | Action |
 |-----|--------|
 | `j`/`k` or `↑`/`↓` | Navigate |
 | `Enter` | Select |
 | `Esc`/`q` | Go back |
 | `H` | Go to home (service list) |
-| `/` | Filter (instances, IPs) |
 | `C` | Context switcher |
-| `s`/`x`/`f` | Start/Stop/Failover (RDS detail) |
 | `q` (on service list) | Quit |
+
+### EC2 (SSM Session)
+
+| Key | Action |
+|-----|--------|
+| `/` | Filter instances |
+| `r` | Refresh instance list |
+| `Enter` | Connect to instance |
+
+### RDS
+
+| Key | Action |
+|-----|--------|
+| `s` | Start instance |
+| `x` | Stop instance |
+| `f` | Failover (Aurora) |
 
 ## Documentation
 

--- a/internal/app/screen_ec2.go
+++ b/internal/app/screen_ec2.go
@@ -50,6 +50,11 @@ func (m Model) updateInstanceList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "/":
 		m.filterActive = true
+	case "r":
+		m.screen = screenLoading
+		m.filterInput = ""
+		m.instIdx = 0
+		return m, m.loadInstances()
 	case "enter":
 		if len(m.filtered) > 0 && m.instIdx < len(m.filtered) {
 			return m, m.startSSMSession(m.filtered[m.instIdx])
@@ -178,6 +183,6 @@ func (m Model) viewInstanceList() string {
 	}
 
 	b.WriteString("\n")
-	b.WriteString(dimStyle.Render("↑/↓: navigate • /: filter • enter: connect • esc: back • H: home"))
+	b.WriteString(dimStyle.Render("↑/↓: navigate • /: filter • r: refresh • enter: connect • esc: back • H: home"))
 	return b.String()
 }


### PR DESCRIPTION
### Summary

Add `r` key binding to refresh the EC2 SSM instance list in-place.
Previously, users had to navigate back and re-enter to see newly launched instances.

Also restructured the README key bindings table into per-feature sections (Global / EC2 / RDS).

### Related Issues

Closes #50

### Validation

- `make test` passes
- `make build` succeeds
- Pressing `r` shows Loading screen → refreshed instance list

### Checklist

- [x] Scope is focused
- [x] Docs updated (README key bindings restructured)
- [x] Tests/validation included
- [x] Breaking changes documented (none)