### PR TITLE
feat: add IAM access key browser and rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ contexts:
 
 ## TUI Key Bindings
 
-### Global Navigation
+### Global
 
 | Key | Action |
 |-----|--------|
@@ -121,7 +121,23 @@ contexts:
 | `/` | Toggle filter mode |
 | `Ctrl+C` | Force quit |
 
-### RDS Detail Actions
+### EC2 (SSM Session)
+
+| Key | Action |
+|-----|--------|
+| `/` | Filter instances |
+| `r` | Refresh instance list |
+| `Enter` | Connect to instance via SSM |
+
+### Security Groups
+
+| Key | Action |
+|-----|--------|
+| `/` | Filter security groups |
+| `r` | Refresh list |
+| `Enter` | View inbound/outbound rules |
+
+### RDS Detail
 
 | Key | Action | Condition |
 |-----|--------|-----------|
@@ -130,27 +146,28 @@ contexts:
 | `f` | Failover database | Multi-AZ standalone or Aurora cluster |
 | `r` | Refresh status | Always |
 
+### IAM Access Key Rotation
+
+| Key | Action | Screen |
+|-----|--------|--------|
+| `r` | Rotate access key | Key detail (RotateAccessKey mode) |
+| `c` | Copy new key as export commands | Rotation result |
+| `a` | Apply new key to ~/.aws/credentials and verify | Rotation result |
+| `d` | Deactivate old key | Rotation result |
+| `x` | Delete old inactive key | Rotation result |
+
 ### Context Switcher
 
 | Key | Action |
 |-----|--------|
 | `Enter` | Switch to selected context |
 | `a` | Add new context (wizard) |
+| `/` | Filter contexts |
 | `Esc` | Back |
 
 ### Filtering
 
-Available on: EC2 instances, VPC/Subnets, RDS instances, Route53 zones/records, Secrets Manager. Press `/` to enter filter mode, type to search, `Esc` or `Enter` to exit filter mode.
-
-### IAM Access Key Rotation
-
-| Key | Action | Screen |
-|-----|--------|--------|
-| `r` | Rotate access key | Key detail |
-| `c` | Copy new key as export commands | Rotation result |
-| `a` | Apply new key to ~/.aws/credentials | Rotation result |
-| `d` | Deactivate old key | Rotation result |
-| `x` | Delete old inactive key | Rotation result |
+Available on: EC2 instances, Security Groups, VPC/Subnets, RDS instances, Route53 zones/records, Secrets Manager, Contexts. Press `/` to enter filter mode, type to search, `Esc` or `Enter` to exit filter mode.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- IAM Access Key Browser: list keys with status, age, last used date
- IAM Access Key Rotation: create new key → verify/apply to ~/.aws/credentials → deactivate → delete old key
- Updated README key bindings to match all current implementations (EC2 SSM, Security Groups, RDS, IAM, Context Switcher)

## Test plan
- [ ] `go test ./...` passes
- [ ] IAM key list loads and displays correctly
- [ ] Key rotation flow: create → copy/apply → deactivate → delete
- [ ] Credential apply works for `credential` auth type contexts
- [ ] SSO contexts skip credential apply step
- [ ] README accurately reflects all TUI key bindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)