### PR TITLE
feat: add install script and self-update mechanism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 APP_NAME := unic
-VERSION  := 0.1.0
+VERSION  := 0.0.3
 DIST_DIR := dist
 CMD_PATH := ./cmd/unic
 
@@ -13,11 +13,11 @@ all: build
 
 ## Build for current platform (debug)
 build:
-	go build -o $(APP_NAME) $(CMD_PATH)
+	go build -ldflags="-X unic/internal/cli.Version=$(VERSION)" -o $(APP_NAME) $(CMD_PATH)
 
 ## Build for current platform (release, stripped)
 release:
-	go build -ldflags="-s -w" -o $(APP_NAME) $(CMD_PATH)
+	go build -ldflags="-s -w -X unic/internal/cli.Version=$(VERSION)" -o $(APP_NAME) $(CMD_PATH)
 
 ## Run tests
 test:
@@ -32,25 +32,25 @@ test-v:
 build-darwin: build-darwin-amd64 build-darwin-arm64
 
 build-darwin-amd64:
-	GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -o $(DIST_DIR)/$(APP_NAME)-darwin-amd64 $(CMD_PATH)
+	GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w -X unic/internal/cli.Version=$(VERSION)" -o $(DIST_DIR)/$(APP_NAME)-darwin-amd64 $(CMD_PATH)
 
 build-darwin-arm64:
-	GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w" -o $(DIST_DIR)/$(APP_NAME)-darwin-arm64 $(CMD_PATH)
+	GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w -X unic/internal/cli.Version=$(VERSION)" -o $(DIST_DIR)/$(APP_NAME)-darwin-arm64 $(CMD_PATH)
 
 ## ── Linux ───────────────────────────────────────────────
 
 build-linux: build-linux-amd64 build-linux-arm64
 
 build-linux-amd64:
-	GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o $(DIST_DIR)/$(APP_NAME)-linux-amd64 $(CMD_PATH)
+	GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X unic/internal/cli.Version=$(VERSION)" -o $(DIST_DIR)/$(APP_NAME)-linux-amd64 $(CMD_PATH)
 
 build-linux-arm64:
-	GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o $(DIST_DIR)/$(APP_NAME)-linux-arm64 $(CMD_PATH)
+	GOOS=linux GOARCH=arm64 go build -ldflags="-s -w -X unic/internal/cli.Version=$(VERSION)" -o $(DIST_DIR)/$(APP_NAME)-linux-arm64 $(CMD_PATH)
 
 ## ── Windows ─────────────────────────────────────────────
 
 build-windows:
-	GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -o $(DIST_DIR)/$(APP_NAME)-windows-amd64.exe $(CMD_PATH)
+	GOOS=windows GOARCH=amd64 go build -ldflags="-s -w -X unic/internal/cli.Version=$(VERSION)" -o $(DIST_DIR)/$(APP_NAME)-windows-amd64.exe $(CMD_PATH)
 
 ## ── All platforms ───────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,29 @@ It manages authentication contexts (SSO or STS AssumeRole) via `~/.config/unic/c
 - Concurrency: goroutines + errgroup
 - Error handling: fmt.Errorf / errors
 
-## Installation & Build
+## Installation
+
+### Homebrew (macOS/Linux)
 
 ```bash
-git clone <repository-url>
-go build -o unic ./cmd/unic
+brew tap DevopsArtFactory/unic
+brew install unic
+```
+
+### Install Script (macOS/Linux)
+
+```bash
+curl -sSL https://raw.githubusercontent.com/DevopsArtFactory/unic/main/install.sh | sh
+```
+
+Set `INSTALL_DIR` to change the install location (default: `/usr/local/bin`).
+
+### Build from Source
+
+```bash
+git clone https://github.com/DevopsArtFactory/unic.git
+cd unic
+make build
 ```
 
 ## Usage
@@ -38,6 +56,9 @@ unic -v
 # Initialize config file
 unic init                      # Create default config
 unic init --force              # Overwrite existing config
+
+# Update to latest version
+unic update                    # Auto-detects install method (brew vs binary)
 ```
 
 ## Configuration

--- a/cmd/unic/main.go
+++ b/cmd/unic/main.go
@@ -43,7 +43,7 @@ func main() {
 			"auth_type", string(cfg.AuthType),
 		)
 
-		p := tea.NewProgram(app.New(cfg, configPath), tea.WithAltScreen())
+		p := tea.NewProgram(app.New(cfg, configPath, cli.Version), tea.WithAltScreen())
 		if _, err := p.Run(); err != nil {
 			return fmt.Errorf("TUI error: %w", err)
 		}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+set -e
+
+REPO="DevopsArtFactory/unic"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
+# Detect OS
+OS="$(uname -s)"
+case "$OS" in
+  Darwin)  OS="darwin" ;;
+  Linux)   OS="linux" ;;
+  *)       echo "Unsupported OS: $OS" >&2; exit 1 ;;
+esac
+
+# Detect architecture
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64)  ARCH="amd64" ;;
+  aarch64) ARCH="arm64" ;;
+  arm64)   ARCH="arm64" ;;
+  *)       echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+
+# Get latest release tag
+echo "Fetching latest release..."
+TAG=$(curl -sSf "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+if [ -z "$TAG" ]; then
+  echo "Failed to fetch latest release tag" >&2
+  exit 1
+fi
+echo "Latest version: $TAG"
+
+# Download
+ARCHIVE="unic-${OS}-${ARCH}.tar.gz"
+URL="https://github.com/${REPO}/releases/download/${TAG}/${ARCHIVE}"
+echo "Downloading ${URL}..."
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+curl -sSfL "$URL" -o "${TMPDIR}/${ARCHIVE}"
+
+# Extract
+tar -xzf "${TMPDIR}/${ARCHIVE}" -C "$TMPDIR"
+
+# Install
+if [ -w "$INSTALL_DIR" ]; then
+  mv "${TMPDIR}/unic" "${INSTALL_DIR}/unic"
+else
+  echo "Installing to ${INSTALL_DIR} (requires sudo)..."
+  sudo mv "${TMPDIR}/unic" "${INSTALL_DIR}/unic"
+fi
+
+chmod +x "${INSTALL_DIR}/unic"
+
+echo "unic ${TAG} installed to ${INSTALL_DIR}/unic"
+echo ""
+echo "Run 'unic' to get started."

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -11,6 +11,7 @@ import (
 	"unic/internal/config"
 	"unic/internal/domain"
 	awsservice "unic/internal/services/aws"
+	"unic/internal/update"
 )
 
 // screen represents the current TUI screen.
@@ -168,6 +169,11 @@ type Model struct {
 	// Caller identity (loaded at startup)
 	callerIdentity *awsservice.CallerIdentity
 
+	// Update check
+	currentVersion  string
+	updateAvailable string             // non-empty = new version available
+	installMethod   update.InstallMethod
+
 	// Error display
 	errMsg string
 
@@ -177,19 +183,34 @@ type Model struct {
 }
 
 // New creates a new app Model.
-func New(cfg *config.Config, configPath string) Model {
+func New(cfg *config.Config, configPath string, version string) Model {
 	services := domain.Catalog()
 	return Model{
-		cfg:           cfg,
-		configPath:    configPath,
-		screen:        screenContextPicker,
-		ctxPrevScreen: screenServiceList,
-		services:      services,
+		cfg:            cfg,
+		configPath:     configPath,
+		currentVersion: version,
+		screen:         screenContextPicker,
+		ctxPrevScreen:  screenServiceList,
+		services:       services,
+	}
+}
+
+// updateAvailableMsg is sent when a background version check completes.
+type updateAvailableMsg struct {
+	version string
+	method  update.InstallMethod
+}
+
+func (m Model) checkForUpdate() tea.Cmd {
+	return func() tea.Msg {
+		method := update.DetectInstallMethod()
+		newVersion := update.CheckForUpdate(m.currentVersion)
+		return updateAvailableMsg{version: newVersion, method: method}
 	}
 }
 
 func (m Model) Init() tea.Cmd {
-	return m.loadContexts()
+	return tea.Batch(m.loadContexts(), m.checkForUpdate())
 }
 
 func (m Model) loadCallerIdentity() tea.Cmd {
@@ -217,6 +238,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case callerIdentityMsg:
 		m.callerIdentity = msg.identity
+		return m, nil
+
+	case updateAvailableMsg:
+		m.installMethod = msg.method
+		if msg.version != "" {
+			m.updateAvailable = msg.version
+		}
 		return m, nil
 
 	case instancesLoadedMsg:

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -16,21 +16,21 @@ func testConfig() *config.Config {
 }
 
 func TestNewModelNotQuitting(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	if m.quitting {
 		t.Error("new model should not be quitting")
 	}
 }
 
 func TestNewModelStartsOnContextPicker(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	if m.screen != screenContextPicker {
 		t.Error("new model should start on context picker screen")
 	}
 }
 
 func TestQuitOnCtrlC(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
 	model := updated.(Model)
 	if !model.quitting {
@@ -42,7 +42,7 @@ func TestQuitOnCtrlC(t *testing.T) {
 }
 
 func TestQuitOnQ(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenServiceList
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
 	model := updated.(Model)
@@ -55,7 +55,7 @@ func TestQuitOnQ(t *testing.T) {
 }
 
 func TestViewNotEmpty(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	v := m.View()
 	if v == "" {
 		t.Error("view should not be empty when not quitting")
@@ -71,7 +71,7 @@ func TestViewEmptyWhenQuitting(t *testing.T) {
 }
 
 func TestServiceListNavigation(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenServiceList
 	// Press down — should move to index 1 (now 2 services: EC2, VPC)
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
@@ -82,7 +82,7 @@ func TestServiceListNavigation(t *testing.T) {
 }
 
 func TestServiceListEnterGoesToFeatures(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenServiceList
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	model := updated.(Model)
@@ -92,7 +92,7 @@ func TestServiceListEnterGoesToFeatures(t *testing.T) {
 }
 
 func TestFeatureListEscGoesBack(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenFeatureList
 	m.features = m.services[0].Features
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
@@ -105,7 +105,7 @@ func TestFeatureListEscGoesBack(t *testing.T) {
 // --- RDS screen tests ---
 
 func TestRDSListNavigation(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSList
 	m.rdsInstances = []awsservice.RDSInstance{
 		{DBInstanceID: "db-1", Engine: "mysql", Status: "available", InstanceClass: "db.t3.micro"},
@@ -129,7 +129,7 @@ func TestRDSListNavigation(t *testing.T) {
 }
 
 func TestRDSListEnterGoesToDetail(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSList
 	m.rdsInstances = []awsservice.RDSInstance{
 		{DBInstanceID: "db-1", Engine: "mysql", Status: "available", InstanceClass: "db.t3.micro"},
@@ -147,7 +147,7 @@ func TestRDSListEnterGoesToDetail(t *testing.T) {
 }
 
 func TestRDSListEscGoesBack(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSList
 	m.rdsInstances = []awsservice.RDSInstance{}
 	m.filteredRDS = m.rdsInstances
@@ -160,7 +160,7 @@ func TestRDSListEscGoesBack(t *testing.T) {
 }
 
 func TestRDSDetailEscGoesBack(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSDetail
 	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "available"}
 
@@ -172,7 +172,7 @@ func TestRDSDetailEscGoesBack(t *testing.T) {
 }
 
 func TestRDSDetailStopGoesToConfirm(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSDetail
 	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "available", ClusterID: ""}
 
@@ -187,7 +187,7 @@ func TestRDSDetailStopGoesToConfirm(t *testing.T) {
 }
 
 func TestRDSDetailStartGoesToConfirm(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSDetail
 	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "stopped"}
 
@@ -202,7 +202,7 @@ func TestRDSDetailStartGoesToConfirm(t *testing.T) {
 }
 
 func TestRDSDetailFailoverGoesToConfirm(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSDetail
 	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "available", MultiAZ: true}
 
@@ -217,7 +217,7 @@ func TestRDSDetailFailoverGoesToConfirm(t *testing.T) {
 }
 
 func TestRDSDetailStopClusterMember(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSDetail
 	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "available", ClusterID: "my-cluster"}
 
@@ -234,7 +234,7 @@ func TestRDSDetailStopClusterMember(t *testing.T) {
 
 func TestRDSConfirmNoGoesBack(t *testing.T) {
 	// For start action, 'n' cancels back to detail
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSConfirm
 	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1"}
 	m.rdsAction = "start"
@@ -247,7 +247,7 @@ func TestRDSConfirmNoGoesBack(t *testing.T) {
 }
 
 func TestRDSConfirmEscGoesBack(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSConfirm
 	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1"}
 	m.rdsAction = "stop"
@@ -260,7 +260,7 @@ func TestRDSConfirmEscGoesBack(t *testing.T) {
 }
 
 func TestRDSListFilter(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSList
 	m.rdsInstances = []awsservice.RDSInstance{
 		{DBInstanceID: "prod-db", Engine: "mysql", Status: "available", InstanceClass: "db.t3.micro"},
@@ -290,7 +290,7 @@ func TestRDSListFilter(t *testing.T) {
 }
 
 func TestRDSActionDoneMsg_Success(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSDetail
 	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1"}
 
@@ -308,7 +308,7 @@ func TestRDSActionDoneMsg_Success(t *testing.T) {
 }
 
 func TestRDSInstancesLoadedMsg(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenLoading
 
 	instances := []awsservice.RDSInstance{
@@ -325,7 +325,7 @@ func TestRDSInstancesLoadedMsg(t *testing.T) {
 }
 
 func TestFeatureListRDSBrowserGoesToLoading(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenFeatureList
 	m.features = []domain.Feature{
 		{Kind: domain.FeatureRDSBrowser, Description: "Browse RDS instances"},
@@ -343,7 +343,7 @@ func TestFeatureListRDSBrowserGoesToLoading(t *testing.T) {
 }
 
 func TestRDSViewNotEmpty(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSList
 	m.rdsInstances = []awsservice.RDSInstance{
 		{DBInstanceID: "db-1", Engine: "mysql", Status: "available", InstanceClass: "db.t3.micro", EngineVersion: "8.0"},
@@ -358,7 +358,7 @@ func TestRDSViewNotEmpty(t *testing.T) {
 }
 
 func TestRDSDetailViewNotEmpty(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSDetail
 	m.selectedRDS = &awsservice.RDSInstance{
 		DBInstanceID: "db-1", Engine: "mysql", EngineVersion: "8.0",
@@ -373,7 +373,7 @@ func TestRDSDetailViewNotEmpty(t *testing.T) {
 }
 
 func TestRDSConfirmViewNotEmpty(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSConfirm
 	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1"}
 	m.rdsAction = "stop"
@@ -386,7 +386,7 @@ func TestRDSConfirmViewNotEmpty(t *testing.T) {
 
 func TestRDSConfirmStopRequiresTypedInput(t *testing.T) {
 	// Test with standalone instance (confirm target = instance ID)
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSConfirm
 	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1", ClusterID: ""}
 	m.rdsAction = "stop"
@@ -427,7 +427,7 @@ func TestRDSConfirmStopRequiresTypedInput(t *testing.T) {
 
 func TestRDSConfirmStopClusterRequiresClusterID(t *testing.T) {
 	// Test with Aurora cluster member (confirm target = cluster ID)
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSConfirm
 	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "inst-1", ClusterID: "my-cluster", Status: "available"}
 	m.rdsAction = "stop"
@@ -457,7 +457,7 @@ func TestRDSConfirmStopClusterRequiresClusterID(t *testing.T) {
 }
 
 func TestRDSConfirmFailoverRequiresTypedInput(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSConfirm
 	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "prod-db", MultiAZ: true}
 	m.rdsAction = "failover"
@@ -486,7 +486,7 @@ func TestRDSConfirmFailoverRequiresTypedInput(t *testing.T) {
 }
 
 func TestRDSConfirmStartUsesSimpleYN(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSConfirm
 	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "stopped"}
 	m.rdsAction = "start"
@@ -503,7 +503,7 @@ func TestRDSConfirmStartUsesSimpleYN(t *testing.T) {
 }
 
 func TestRDSConfirmInputBackspace(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSConfirm
 	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1"}
 	m.rdsAction = "stop"
@@ -527,7 +527,7 @@ func TestRDSConfirmInputBackspace(t *testing.T) {
 }
 
 func TestRDSConfirmInputResetOnEntry(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSDetail
 	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "available", ClusterID: ""}
 	m.rdsConfirmInput = "leftover"
@@ -544,7 +544,7 @@ func TestRDSConfirmInputResetOnEntry(t *testing.T) {
 }
 
 func TestFitToHeight(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 
 	// height=0 → no change
 	m.height = 0
@@ -573,7 +573,7 @@ func TestFitToHeight(t *testing.T) {
 }
 
 func TestViewFitsTerminalHeight(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSDetail
 	m.height = 10
 	m.selectedRDS = &awsservice.RDSInstance{
@@ -592,7 +592,7 @@ func TestViewFitsTerminalHeight(t *testing.T) {
 // --- Security Group tests ---
 
 func TestSecurityGroupListNavigation(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenSecurityGroupList
 	m.securityGroups = []awsservice.SecurityGroup{
 		{GroupID: "sg-1", Name: "web", VPCID: "vpc-1"},
@@ -614,7 +614,7 @@ func TestSecurityGroupListNavigation(t *testing.T) {
 }
 
 func TestSecurityGroupListEnterGoesToDetail(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenSecurityGroupList
 	m.securityGroups = []awsservice.SecurityGroup{
 		{GroupID: "sg-1", Name: "web", VPCID: "vpc-1"},
@@ -632,7 +632,7 @@ func TestSecurityGroupListEnterGoesToDetail(t *testing.T) {
 }
 
 func TestSecurityGroupDetailEscGoesBack(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenSecurityGroupDetail
 	m.selectedSecurityGroup = &awsservice.SecurityGroup{GroupID: "sg-1"}
 
@@ -644,7 +644,7 @@ func TestSecurityGroupDetailEscGoesBack(t *testing.T) {
 }
 
 func TestSecurityGroupFilter(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenSecurityGroupList
 	m.securityGroups = []awsservice.SecurityGroup{
 		{GroupID: "sg-1", Name: "web-sg", VPCID: "vpc-1"},
@@ -670,7 +670,7 @@ func TestSecurityGroupFilter(t *testing.T) {
 }
 
 func TestSecurityGroupDetailView(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.screen = screenSecurityGroupDetail
 	m.height = 30
 	m.selectedSecurityGroup = &awsservice.SecurityGroup{
@@ -720,7 +720,7 @@ func TestSecurityGroupBrowserInCatalog(t *testing.T) {
 // --- IAM tests ---
 
 func TestIAMFeatureListContainsSeparateActions(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 
 	for _, svc := range m.services {
 		if svc.Name == domain.ServiceIAM {
@@ -741,7 +741,7 @@ func TestIAMFeatureListContainsSeparateActions(t *testing.T) {
 }
 
 func TestIAMKeyDetailHidesRotateActionInListMode(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.iamRotationEnabled = false
 	m.selectedIAMKey = &awsservice.AccessKey{
 		AccessKeyID: "AKIATEST",
@@ -755,7 +755,7 @@ func TestIAMKeyDetailHidesRotateActionInListMode(t *testing.T) {
 }
 
 func TestIAMKeyDetailShowsRotateActionInRotateMode(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.iamRotationEnabled = true
 	m.selectedIAMKey = &awsservice.AccessKey{
 		AccessKeyID: "AKIATEST",
@@ -769,7 +769,7 @@ func TestIAMKeyDetailShowsRotateActionInRotateMode(t *testing.T) {
 }
 
 func TestIAMRotationResultRequiresApplyBeforeDeactivateForCredentialCurrentIdentity(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.cfg.AuthType = config.AuthTypeCredential
 	m.iamNewKey = &awsservice.NewAccessKey{
 		AccessKeyID:     "AKIANEWKEY",
@@ -791,7 +791,7 @@ func TestIAMRotationResultRequiresApplyBeforeDeactivateForCredentialCurrentIdent
 }
 
 func TestIAMRotationResultAllowsDeactivateAfterVerify(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.cfg.AuthType = config.AuthTypeCredential
 	m.iamNewKey = &awsservice.NewAccessKey{
 		AccessKeyID:     "AKIANEWKEY",
@@ -806,7 +806,7 @@ func TestIAMRotationResultAllowsDeactivateAfterVerify(t *testing.T) {
 }
 
 func TestIAMRotationResultRequiresNoApplyForSSOContext(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.cfg.AuthType = config.AuthTypeSSO
 	m.iamNewKey = &awsservice.NewAccessKey{
 		AccessKeyID:     "AKIANEWKEY",
@@ -820,7 +820,7 @@ func TestIAMRotationResultRequiresNoApplyForSSOContext(t *testing.T) {
 }
 
 func TestIAMRotationResultShowsApplyForLegacyCredentialContext(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.cfg.AuthType = config.AuthTypeDefault
 	m.cfg.Profile = "default"
 	m.cfg.RoleArn = ""
@@ -844,7 +844,7 @@ func TestIAMRotationResultShowsApplyForLegacyCredentialContext(t *testing.T) {
 }
 
 func TestIAMRotationResultShowsApplyForImplicitDefaultProfile(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.cfg.AuthType = config.AuthTypeDefault
 	m.cfg.Profile = ""
 	m.cfg.RoleArn = ""
@@ -868,7 +868,7 @@ func TestIAMRotationResultShowsApplyForImplicitDefaultProfile(t *testing.T) {
 }
 
 func TestIAMRotationResultShowsDisabledApplyReasonForSSO(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 	m.cfg.AuthType = config.AuthTypeSSO
 	m.iamNewKey = &awsservice.NewAccessKey{
 		AccessKeyID:     "AKIANEWKEY",
@@ -883,7 +883,7 @@ func TestIAMRotationResultShowsDisabledApplyReasonForSSO(t *testing.T) {
 }
 
 func TestRotateAccessKeyFeatureUsesCurrentIdentityFlow(t *testing.T) {
-	m := New(testConfig(), "")
+	m := New(testConfig(), "", "dev")
 
 	for _, svc := range m.services {
 		if svc.Name == domain.ServiceIAM {

--- a/internal/app/styles.go
+++ b/internal/app/styles.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"unic/internal/update"
 )
 
 var (
@@ -29,6 +31,14 @@ func (m Model) renderStatusBar() string {
 	}
 	if m.callerIdentity != nil && m.callerIdentity.Account != "" {
 		parts = append(parts, fmt.Sprintf("account:%s", m.callerIdentity.Account))
+	}
+
+	if m.updateAvailable != "" {
+		hint := "unic update"
+		if m.installMethod == update.InstallBrew {
+			hint = "brew upgrade unic"
+		}
+		parts = append(parts, filterStyle.Render(fmt.Sprintf("%s available — %s", m.updateAvailable, hint)))
 	}
 
 	bar := strings.Join(parts, "  ")

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -26,6 +26,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose debug logging")
 
 	cmd.AddCommand(newInitCmd())
+	cmd.AddCommand(newUpdateCmd())
 
 	return cmd
 }

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"unic/internal/update"
+)
+
+func newUpdateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update unic to the latest version",
+		Long:  "Check for the latest release on GitHub and replace the current binary in-place.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Printf("Current version: %s\n", Version)
+			fmt.Println("Checking for updates...")
+
+			latest, err := update.CheckLatestVersion()
+			if err != nil {
+				return fmt.Errorf("failed to check for updates: %w", err)
+			}
+
+			if !update.IsNewer(Version, latest) {
+				fmt.Printf("Already on the latest version (%s)\n", Version)
+				return nil
+			}
+
+			fmt.Printf("New version available: %s\n", latest)
+
+			method := update.DetectInstallMethod()
+			if method == update.InstallBrew {
+				fmt.Println("\nunic was installed via Homebrew. To update, run:")
+				fmt.Println("  brew upgrade unic")
+				return nil
+			}
+
+			fmt.Println("Downloading...")
+
+			if err := update.DownloadAndReplace(latest); err != nil {
+				return fmt.Errorf("update failed: %w", err)
+			}
+
+			fmt.Printf("Successfully updated to %s\n", latest)
+			return nil
+		},
+	}
+	return cmd
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,294 @@
+package update
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	repoOwner    = "DevopsArtFactory"
+	repoName     = "unic"
+	cacheFile    = "update-check.json"
+	cacheTTL     = 24 * time.Hour
+	apiURL       = "https://api.github.com/repos/" + repoOwner + "/" + repoName + "/releases/latest"
+	downloadBase = "https://github.com/" + repoOwner + "/" + repoName + "/releases/download"
+)
+
+// InstallMethod represents how unic was installed.
+type InstallMethod int
+
+const (
+	InstallUnknown InstallMethod = iota
+	InstallBrew
+	InstallBinary
+)
+
+// DetectInstallMethod checks if unic was installed via Homebrew.
+func DetectInstallMethod() InstallMethod {
+	execPath, err := os.Executable()
+	if err != nil {
+		return InstallUnknown
+	}
+	resolved, err := filepath.EvalSymlinks(execPath)
+	if err != nil {
+		return InstallUnknown
+	}
+	if strings.Contains(resolved, "Cellar") || strings.Contains(resolved, "homebrew") {
+		return InstallBrew
+	}
+	return InstallBinary
+}
+
+// cache stores the last update check result.
+type cache struct {
+	Version   string    `json:"version"`
+	CheckedAt time.Time `json:"checked_at"`
+}
+
+// cacheDir returns the unic config directory (~/.config/unic/).
+func cacheDir() (string, error) {
+	dir := os.Getenv("XDG_CONFIG_HOME")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		dir = filepath.Join(home, ".config")
+	}
+	return filepath.Join(dir, "unic"), nil
+}
+
+// cachePath returns the full path to the update check cache file.
+func cachePath() (string, error) {
+	dir, err := cacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, cacheFile), nil
+}
+
+// readCache reads the cached update check result.
+func readCache() (*cache, error) {
+	path, err := cachePath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var c cache
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+// writeCache writes the update check result to the cache file.
+func writeCache(version string) error {
+	path, err := cachePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	c := cache{Version: version, CheckedAt: time.Now()}
+	data, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+// ShouldCheck returns true if the cache is missing or older than 24h.
+func ShouldCheck() bool {
+	c, err := readCache()
+	if err != nil {
+		return true
+	}
+	return time.Since(c.CheckedAt) > cacheTTL
+}
+
+// CheckLatestVersion queries the GitHub releases API and returns the latest version tag.
+func CheckLatestVersion() (string, error) {
+	client := &http.Client{Timeout: 5 * time.Second}
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
+	}
+
+	var release struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return "", err
+	}
+	return release.TagName, nil
+}
+
+// CheckForUpdate checks if a newer version is available, using cache when possible.
+// Returns the new version string if available, or empty string if up to date.
+func CheckForUpdate(currentVersion string) string {
+	if currentVersion == "dev" {
+		return ""
+	}
+
+	// Try cache first
+	if !ShouldCheck() {
+		c, err := readCache()
+		if err == nil && IsNewer(currentVersion, c.Version) {
+			return c.Version
+		}
+		return ""
+	}
+
+	latest, err := CheckLatestVersion()
+	if err != nil {
+		return ""
+	}
+
+	// Update cache regardless of result
+	_ = writeCache(latest)
+
+	if IsNewer(currentVersion, latest) {
+		return latest
+	}
+	return ""
+}
+
+// IsNewer returns true if latest is a newer version than current.
+// Both may have a "v" prefix (e.g., "v0.1.0" or "0.1.0").
+func IsNewer(current, latest string) bool {
+	c := normalizeVersion(current)
+	l := normalizeVersion(latest)
+	if c == "" || l == "" {
+		return false
+	}
+	return l > c
+}
+
+// normalizeVersion strips "v" prefix for comparison.
+func normalizeVersion(v string) string {
+	return strings.TrimPrefix(v, "v")
+}
+
+// archiveName returns the expected archive filename for the current platform.
+func archiveName(version string) string {
+	os := runtime.GOOS
+	arch := runtime.GOARCH
+	v := strings.TrimPrefix(version, "v")
+	if os == "windows" {
+		return fmt.Sprintf("unic-%s-%s.zip", os, arch)
+	}
+	_ = v
+	return fmt.Sprintf("unic-%s-%s.tar.gz", os, arch)
+}
+
+// DownloadURL returns the download URL for the given version and current platform.
+func DownloadURL(version string) string {
+	return fmt.Sprintf("%s/%s/%s", downloadBase, version, archiveName(version))
+}
+
+// DownloadAndReplace downloads the given version and replaces the current binary.
+func DownloadAndReplace(version string) error {
+	url := DownloadURL(version)
+
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return fmt.Errorf("download failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download returned status %d", resp.StatusCode)
+	}
+
+	// Extract binary from tar.gz
+	binary, err := extractBinaryFromTarGz(resp.Body)
+	if err != nil {
+		return fmt.Errorf("extract failed: %w", err)
+	}
+
+	// Get current binary path
+	execPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("could not determine executable path: %w", err)
+	}
+	execPath, err = filepath.EvalSymlinks(execPath)
+	if err != nil {
+		return fmt.Errorf("could not resolve symlinks: %w", err)
+	}
+
+	// Write to temp file in same directory, then atomic rename
+	dir := filepath.Dir(execPath)
+	tmp, err := os.CreateTemp(dir, "unic-update-*")
+	if err != nil {
+		return fmt.Errorf("could not create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	if _, err := tmp.Write(binary); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("write failed: %w", err)
+	}
+	tmp.Close()
+
+	if err := os.Chmod(tmpPath, 0755); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("chmod failed: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, execPath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("replace failed (may need sudo): %w", err)
+	}
+
+	return nil
+}
+
+// extractBinaryFromTarGz reads a tar.gz stream and returns the "unic" binary contents.
+func extractBinaryFromTarGz(r io.Reader) ([]byte, error) {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if filepath.Base(hdr.Name) == "unic" && hdr.Typeflag == tar.TypeReg {
+			return io.ReadAll(tr)
+		}
+	}
+	return nil, fmt.Errorf("binary 'unic' not found in archive")
+}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,116 @@
+package update
+
+import (
+	"testing"
+)
+
+func TestIsNewer(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		latest  string
+		want    bool
+	}{
+		{"newer patch", "0.1.0", "0.1.1", true},
+		{"newer minor", "0.1.0", "0.2.0", true},
+		{"newer major", "0.1.0", "1.0.0", true},
+		{"same version", "0.1.0", "0.1.0", false},
+		{"older version", "0.2.0", "0.1.0", false},
+		{"with v prefix", "v0.1.0", "v0.2.0", true},
+		{"mixed prefix", "0.1.0", "v0.2.0", true},
+		{"dev version", "dev", "", false},
+		{"empty latest", "0.1.0", "", false},
+		{"empty current", "", "0.1.0", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsNewer(tt.current, tt.latest)
+			if got != tt.want {
+				t.Errorf("IsNewer(%q, %q) = %v, want %v", tt.current, tt.latest, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeVersion(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"v0.1.0", "0.1.0"},
+		{"0.1.0", "0.1.0"},
+		{"v1.2.3", "1.2.3"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		got := normalizeVersion(tt.input)
+		if got != tt.want {
+			t.Errorf("normalizeVersion(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestArchiveName(t *testing.T) {
+	name := archiveName("v0.2.0")
+	// Just check it's not empty and has expected format
+	if name == "" {
+		t.Error("archiveName returned empty string")
+	}
+	if len(name) < 10 {
+		t.Errorf("archiveName returned unexpectedly short: %q", name)
+	}
+}
+
+func TestDownloadURL(t *testing.T) {
+	url := DownloadURL("v0.2.0")
+	if url == "" {
+		t.Error("DownloadURL returned empty string")
+	}
+	expected := "https://github.com/DevopsArtFactory/unic/releases/download/v0.2.0/"
+	if len(url) < len(expected) {
+		t.Errorf("DownloadURL too short: %q", url)
+	}
+}
+
+func TestShouldCheck_NoCacheFile(t *testing.T) {
+	// With no cache file, should always return true
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if !ShouldCheck() {
+		t.Error("ShouldCheck should return true when no cache exists")
+	}
+}
+
+func TestWriteAndReadCache(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	// Write cache
+	err := writeCache("v0.2.0")
+	if err != nil {
+		t.Fatalf("writeCache failed: %v", err)
+	}
+
+	// Read cache
+	c, err := readCache()
+	if err != nil {
+		t.Fatalf("readCache failed: %v", err)
+	}
+	if c.Version != "v0.2.0" {
+		t.Errorf("expected version v0.2.0, got %s", c.Version)
+	}
+
+	// Should not need to check again (cache is fresh)
+	if ShouldCheck() {
+		t.Error("ShouldCheck should return false with fresh cache")
+	}
+}
+
+func TestCheckForUpdate_DevVersion(t *testing.T) {
+	// dev version should never trigger update check
+	result := CheckForUpdate("dev")
+	if result != "" {
+		t.Errorf("expected empty string for dev version, got %q", result)
+	}
+}


### PR DESCRIPTION
### Summary

Add distribution tooling and self-update mechanism to complete M4.3:

- **`install.sh`**: Curl-based install script that detects OS/arch and downloads the correct binary from GitHub releases
- **`unic update` command**: Checks latest GitHub release, downloads and replaces binary in-place. Detects Homebrew installs and suggests `brew upgrade unic` instead
- **Startup version check**: Non-blocking background check on TUI launch with 24h cache. Shows orange notice in status bar with install-method-aware hint
- **Makefile fix**: All build targets now inject version via `-X unic/internal/cli.Version`

### Related Issues

Closes #66

### Validation

- `make test` — all tests pass (8 new tests for update package: IsNewer, cache, ShouldCheck, dev version)
- `make build` — binary compiles with correct version (`./unic --version` → `unic version 0.0.3`)
- `./unic update` — checks GitHub API and reports current status
- TUI status bar shows update notice when running with old version (`-X cli.Version=0.0.1`)

### Checklist

- [x] Scope is focused
- [x] Docs updated (if needed)
- [x] Tests/validation included
- [ ] Breaking changes documented