### PR TITLE
docs: add Codex agent skills and override config

### DIFF
--- a/.agents/skills/unic-create-issues/SKILL.md
+++ b/.agents/skills/unic-create-issues/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: unic-create-issues
+description: Use when the user asks to create GitHub issues from planned but unimplemented unic work in PLAN.md. Do not use for editing existing issues or for implementation.
+---
+
+Create GitHub issues for planned `unic` work that does not already have issue
+coverage.
+
+## Workflow
+
+1. Read `PLAN.md` to identify planned milestones and unimplemented work.
+2. Fetch existing issues with `gh issue list --state all --limit 100`.
+3. For borderline matches, inspect candidate issues with `gh issue view <number>`
+before deciding a PLAN item is uncovered.
+4. Identify PLAN items without corresponding issues.
+5. Create missing issues with `gh issue create`.
+- Title format: `feat: <description> (M<X>.<Y>)`
+- Label: `enhancement`
+- Body sections: Summary, Details, Checklist
+- Keep checklist items grounded in the repo's real files and directories
+
+6. Skip anything that already has an open or closed issue.
+
+## Output
+
+Report the created issues with URLs and note any PLAN items you intentionally
+left alone because matching issues already existed.

--- a/.agents/skills/unic-implement-feature/SKILL.md
+++ b/.agents/skills/unic-implement-feature/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: unic-implement-feature
+description: Use when the user asks to implement a feature, milestone item, or GitHub issue in the unic repository, especially new AWS service work. Do not use for pure refactors, docs-only updates, PR shipping, or issue triage.
+---
+
+Implement a feature for `unic` using the repository's existing service and TUI
+patterns.
+
+## Input
+
+Treat the prompt as one of:
+- a GitHub issue number such as `#29`
+- a feature description
+- a `PLAN.md` milestone item
+
+## Workflow
+
+1. Resolve scope first.
+- If the user gave an issue number, read it with `gh issue view <number>`.
+- If the user gave a description, search open issues first with
+  `gh issue list --state open --search '<terms>' --limit 20`.
+- If the user did not name a concrete feature, inspect the current backlog with
+  `gh issue list --state open --limit 50` and prefer an open issue over
+  inventing new scope from `PLAN.md`.
+- Read `PLAN.md` to find the relevant milestone, prerequisites, and design
+  notes.
+- If multiple open issues fit equally well, ask only the minimum clarifying
+  question needed to pick the right one.
+
+2. Gather repo context before editing.
+- Read `internal/domain/model.go` and `internal/domain/catalog.go`.
+- Read `internal/services/aws/repository.go`.
+- Use the RDS implementation in `internal/services/aws/rds.go`,
+  `internal/services/aws/rds_model.go`, and `internal/services/aws/rds_test.go`
+  as the first reference pattern.
+- Read the owning TUI flow in `internal/app/app.go` and any extracted helper
+  files nearby.
+
+3. Plan the change before writing code.
+- For new service work, prefer this order:
+  1. domain model and catalog
+  2. AWS service layer and models
+  3. repository interface wiring
+  4. TUI integration
+  5. tests
+- Keep behavior aligned with existing Bubbletea and Lipgloss conventions.
+- Use `visibleLines := max(m.height-N, 5)` style windowing where applicable.
+- Destructive actions must use the existing type-to-confirm pattern.
+
+4. Implement with minimal divergence.
+- Follow existing naming, layout, and error-handling patterns.
+- Use mock client interfaces in tests.
+- Avoid introducing new abstractions unless the surrounding code already points
+  in that direction.
+
+5. Validate and sync docs.
+- Run `make test`.
+- Run `make build`.
+- Update `README.md` when shipped behavior changes.
+- Update `PLAN.md` when milestone status or sequencing changes.
+
+## Output
+
+Report what changed, how it was validated, and any remaining follow-up or PR
+preparation steps.

--- a/.agents/skills/unic-refactor-review/SKILL.md
+++ b/.agents/skills/unic-refactor-review/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: unic-refactor-review
+description: Use when the user asks to implement refactors from a prior unic senior review report. Do not use for new features or behavior changes.
+---
+
+Refactor `unic` based on an existing senior review report while preserving
+behavior.
+
+## Workflow
+
+1. Load the latest review report.
+- Prefer `.agents/reports/senior-review-*.md`.
+- Fall back to `.claude/reports/senior-review-*.md`.
+- If no report exists, tell the user to run `unic-senior-review` first.
+
+2. Select scope.
+- If the user named a priority or finding, scope the work to that item.
+- If the user named a GitHub issue, read it with `gh issue view <number>`.
+- When GitHub access is available, search open issues with
+  `gh issue list --state open --search '<terms>'` to see whether the finding is
+  already tracked before choosing scope.
+- If not, summarize the report priorities and ask which one to tackle.
+
+3. Plan before editing.
+- Read every file referenced by the selected findings.
+- Preserve behavior; this is refactor-only work.
+- Do not change public APIs unless the finding specifically requires it.
+- If the change would touch more than 10 files, split it into smaller steps.
+
+4. Implement and validate incrementally.
+- Make focused changes.
+- Run `make test` after each logical refactor group when practical.
+- Run `make test` and `make build` at the end.
+
+5. Update the report when appropriate.
+- Mark completed findings or note what changed.
+- If the work maps to an issue, note the issue number in the report update.
+- If a recommendation from the report turns out to be impractical, explain why
+  instead of forcing the refactor.
+
+## Constraints
+
+- No new features.
+- No intentional behavior changes.
+- Note newly discovered issues, but leave them for a future review cycle.

--- a/.agents/skills/unic-senior-review/SKILL.md
+++ b/.agents/skills/unic-senior-review/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: unic-senior-review
+description: Use when the user wants a deep maintainability or refactoring review of the unic codebase, including file-size analysis, Go idioms, and concrete refactoring priorities. Do not use for normal bug reviews or feature implementation.
+---
+
+Conduct a senior-engineer style review of `unic` focused on code quality,
+maintainability, and refactoring opportunities.
+
+## Workflow
+
+1. Start with a line-count inventory.
+- Run `find internal/ cmd/ -name '*.go' | xargs wc -l | sort -rn`.
+- Run `find internal/ cmd/ -name '*_test.go' | xargs wc -l | sort -rn`.
+- When GitHub access is available, run `gh issue list --state open --limit 50`
+  so you can distinguish already-tracked work from net-new findings.
+- Produce a table with File, Lines, and Status.
+- Flag files over 300 lines as `[LONG]` and over 500 lines as `[CRITICAL]`.
+
+2. Review the code against these categories.
+- file size and function length
+- naming and readability
+- SOLID, abstraction, and DRY pressure
+- error handling and edge cases
+- Go-specific idioms such as context flow, error wrapping, goroutine cleanup,
+  and `defer` usage
+
+3. Keep the review actionable.
+- Lead with concrete findings.
+- Include file references.
+- Give a specific refactoring suggestion for every finding.
+- Call out when a finding already appears to be tracked by an open GitHub
+  issue.
+- Avoid style-only feedback unless it hides a real maintenance risk.
+- Do not nitpick test-file length unless there is a real quality issue.
+
+4. End with a report.
+- Executive summary
+- LoC breakdown table
+- Findings ordered by severity
+- Top 5 refactoring priorities
+- Positive patterns worth preserving
+
+## Optional persistence
+
+If the user wants the report saved, prefer `.agents/reports/senior-review-YYYY-MM-DD.md`.
+You may read legacy reports from `.claude/reports/` for context when helpful.

--- a/.agents/skills/unic-ship-pr/SKILL.md
+++ b/.agents/skills/unic-ship-pr/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: unic-ship-pr
+description: Use when the user explicitly asks to stage, commit, push, and open a pull request for unic. Do not use for general coding work or docs-only sync unless the user is asking to ship the current branch.
+---
+
+Ship the current `unic` changes through the repository's expected branch,
+commit, and PR flow.
+
+## Workflow
+
+1. Validate first.
+- Run `make test` and stop if it fails.
+- Run `make build` and stop if it fails.
+
+2. Inspect scope.
+- Check `git status` and `git diff --stat`.
+- Confirm the changes are ready to ship and map to the intended issue.
+- If the issue number is known, read it with `gh issue view <number>`.
+- If the issue is implied but not named, search with
+  `gh issue list --state open --search '<terms>' --limit 20` before opening the
+  PR.
+- Do not open a PR without an issue reference unless the user explicitly
+  approves that exception.
+
+3. Create the branch.
+- Branch from `main`.
+- Use a conventional prefix such as `feat/`, `fix/`, or `docs/`.
+- Use the user hint when provided; otherwise infer a concise branch name from
+  the change.
+
+4. Stage and commit carefully.
+- Stage only the relevant files by name.
+- Never use `git add .` or `git add -A`.
+- Use a conventional commit title consistent with recent history.
+- Include a short body with bullet points for key changes.
+- Do not add `Co-Authored-By` lines.
+
+5. Push and open the PR.
+- Push with `-u origin <branch>`.
+- Use `gh pr create` to open the PR.
+- If a PR already exists for the branch, inspect it with `gh pr view` and
+  update that PR instead of opening a duplicate.
+- If `.github/pull_request_template.md` exists, follow it.
+- Otherwise structure the PR body with: Summary, Related Issues, Validation,
+  and Checklist.
+
+## Output
+
+Return the branch name, commit message, and PR URL.

--- a/.agents/skills/unic-update-docs/SKILL.md
+++ b/.agents/skills/unic-update-docs/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: unic-update-docs
+description: Use when the user asks to refresh documentation for the unic repository after code changes, shipped features, milestone progress, or README drift. Do not use for feature implementation or PR shipping.
+---
+
+Update `unic` documentation so the checked-in docs match the current repo
+state.
+
+## Workflow
+
+1. Gather current state.
+- Read `README.md` and `PLAN.md`.
+- Check recent history with `git log --oneline -10`.
+- If the docs update is tied to shipped or in-flight GitHub work, inspect the
+  source issue or PR with `gh issue view <number>` or `gh pr view <number>`.
+- When feature naming or status is ambiguous, use
+  `gh issue list --state open --limit 50` to align the docs with the actual
+  backlog.
+- Read the touched code paths or diff when the docs change is tied to a
+  specific implementation.
+
+2. Update `README.md` to match shipped behavior.
+- Keep `Currently Implemented Features` accurate.
+- Update `TUI Key Bindings` when shortcuts changed.
+- Update `Usage` when commands or flags changed.
+- Update `Configuration` when config shape or precedence changed.
+
+3. Update `PLAN.md` when roadmap state changed.
+- Mark completed items.
+- Adjust sequencing notes when implementation order shifted.
+- Add narrowly scoped sub-items only when the codebase clearly requires them.
+
+4. Keep the docs factual.
+- Do not mark work complete unless the code and validation support it.
+- Do not invent roadmap items or future scope that is not grounded in the repo.
+
+## Output
+
+Summarize what documentation changed and call out any remaining mismatches you
+could not resolve from the current repo state.

--- a/.agents/skills/unic-update-issues/SKILL.md
+++ b/.agents/skills/unic-update-issues/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: unic-update-issues
+description: Use when the user asks to review, reconcile, or update open GitHub issues for the unic repository against the current repo state. Do not use for creating new issues or implementing the work itself.
+---
+
+Review open `unic` GitHub issues against the current repo state and propose or
+apply updates.
+
+## Workflow
+
+1. Gather state.
+- Fetch open issues with `gh issue list --state open --limit 50`.
+- Read issue details with `gh issue view <number>` before proposing edits.
+- Read `PLAN.md`.
+- Check recent history with `git log --oneline -20`.
+- Inspect merged PRs or current code when an issue appears complete.
+- Use `gh pr view <number>` or `gh pr list --state merged --limit 50` when an
+  issue may already be shipped through a PR.
+
+2. Assess each issue or filtered subset.
+- already done
+- partially done
+- stale or superseded
+- missing details or missing links
+- labels or milestone references that should change
+
+3. Present recommendations before mutating anything.
+- Summarize each issue and the suggested action.
+- Show the planned body diff before editing issue text.
+- Do not close or edit an issue without explicit user confirmation.
+
+4. Execute approved actions only.
+- Use `gh issue close`, `gh issue edit`, or `gh issue comment` as needed.
+- If an issue references a PR, verify whether the PR was merged.
+
+## Output
+
+Report what changed, what was left unchanged, and any issues that still need a
+human product decision.

--- a/AGENTS.override.md
+++ b/AGENTS.override.md
@@ -1,0 +1,62 @@
+# unic — Codex Override
+
+Codex is the primary coding agent for this repository. Own implementation,
+testing, documentation updates, and PR preparation unless the user explicitly
+asks for planning or advisory-only output.
+
+## Workflow
+
+- Do not commit directly to `main`.
+- New work should map to a GitHub issue. If the user asks to ship changes
+  without an issue reference, call that out before opening a PR.
+- The expected delivery flow is: issue -> implementation -> feature branch ->
+  PR that references the issue.
+- Read `PLAN.md` when planning new work so feature scope stays aligned with the
+  active milestone and prior design decisions.
+- Follow recent commit history for commit title style (`feat:`, `fix:`,
+  `docs:`, and similar prefixes).
+
+## Implementation Patterns
+
+- Follow existing service patterns before inventing new ones. Use the RDS
+  implementation (`internal/services/aws/rds.go`, `rds_model.go`,
+  `rds_test.go`) as the first reference for new AWS service work.
+- Keep Bubbletea and Lipgloss output consistent with the current UI patterns:
+  column-aligned tables, dimmed labels, and existing style helpers.
+- For scrolling detail views, preserve the windowing pattern
+  `visibleLines := max(m.height-N, 5)`.
+- Destructive or high-risk actions must use the existing type-to-confirm
+  workflow before execution.
+- Tests should use mock client interfaces following the existing AWS service
+  test style.
+
+## Feature Implementation Order
+
+- For new service work, prefer this order:
+  1. `internal/domain/model.go` and `internal/domain/catalog.go`
+  2. `internal/services/aws/<service>.go` and `<service>_model.go`
+  3. `internal/services/aws/repository.go`
+  4. `internal/app/` integration
+  5. Tests
+- Match surrounding naming and file layout unless there is a clear reason not
+  to.
+
+## Validation
+
+- After behavior changes, run `make test`.
+- After behavior changes, run `make build`.
+- If either validation step cannot be run, say so explicitly.
+
+## Documentation
+
+- When features are added, changed, or removed, update `README.md` to match the
+  shipped behavior.
+- Keep `Currently Implemented Features`, `TUI Key Bindings`, `Usage`, and
+  `Configuration` aligned with the code.
+- When milestone status changes, update `PLAN.md` before the PR is opened.
+
+## Repo Skills
+
+- Use the repo-local skills in `.agents/skills/` for the migrated Claude Code
+  workflows: feature implementation, docs refresh, PR shipping, senior review,
+  review-driven refactors, and issue maintenance.


### PR DESCRIPTION
### Summary

Add Codex agent configuration and repo-local skills for Claude Code workflows:

- **AGENTS.override.md**: Codex override with workflow rules, implementation patterns, validation steps, and documentation guidelines
- **7 SKILL.md files** under `.agents/skills/`: implement-feature, ship-pr, senior-review, refactor-review, update-docs, update-issues, create-issues

These skills codify the project's existing conventions (issue-first workflow, RDS reference pattern, README maintenance, etc.) so that Codex can follow them consistently.

### Related Issues

N/A — configuration/tooling addition

### Validation

- Verified `go test ./...` passes (no Go code changed)
- Reviewed each SKILL.md for alignment with CLAUDE.md and existing project conventions

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed — N/A (no user-facing changes)
- [x] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed — N/A
- [x] Tests/validation included
- [x] Breaking changes documented — N/A