### PR TITLE
feat: unify TUI filter input handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 APP_NAME := unic
-VERSION  := 0.0.3
+VERSION  := 0.0.4
 DIST_DIR := dist
 CMD_PATH := ./cmd/unic
 

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 )
 
 require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.20 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.41.9 h1:Cng+OOwCHmFljXIxpEVXAGMnBia8
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.9/go.mod h1:LrlIndBDdjA/EeXeyNBle+gyCwTlizzW5ycgWnvIxkk=
 github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
 github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
@@ -78,11 +79,9 @@ type Model struct {
 	featIdx  int
 
 	// Instance list with filtering
-	instances    []awsservice.EC2Instance
-	filtered     []awsservice.EC2Instance
-	instIdx      int
-	filterInput  string
-	filterActive bool
+	instances []awsservice.EC2Instance
+	filtered  []awsservice.EC2Instance
+	instIdx   int
 
 	// SSM session state
 	selectedInstance *awsservice.EC2Instance
@@ -98,33 +97,25 @@ type Model struct {
 	availableIPs   []string
 	filteredIPs    []string
 	ipScrollOffset int
-	ipFilter       string
-	ipFilterActive bool
 
 	// RDS browser state
 	rdsInstances    []awsservice.RDSInstance
 	filteredRDS     []awsservice.RDSInstance
 	rdsIdx          int
-	rdsFilter       string
-	rdsFilterActive bool
 	selectedRDS     *awsservice.RDSInstance
 	rdsAction       string // "start", "stop", "failover"
 	rdsConfirmInput string // typed input for destructive action confirmation
 	rdsPolling      bool
 
 	// Route53 browser state
-	route53Zones              []awsservice.HostedZone
-	filteredRoute53Zones      []awsservice.HostedZone
-	route53ZoneIdx            int
-	route53ZoneFilter         string
-	route53ZoneFilterActive   bool
-	selectedRoute53Zone       *awsservice.HostedZone
-	route53Records            []awsservice.DNSRecord
-	filteredRoute53Records    []awsservice.DNSRecord
-	route53RecordIdx          int
-	route53RecordFilter       string
-	route53RecordFilterActive bool
-	selectedRoute53Record     *awsservice.DNSRecord
+	route53Zones           []awsservice.HostedZone
+	filteredRoute53Zones   []awsservice.HostedZone
+	route53ZoneIdx         int
+	selectedRoute53Zone    *awsservice.HostedZone
+	route53Records         []awsservice.DNSRecord
+	filteredRoute53Records []awsservice.DNSRecord
+	route53RecordIdx       int
+	selectedRoute53Record  *awsservice.DNSRecord
 
 	// Route53 mutation state
 	route53Action        string            // "create", "edit", "delete"
@@ -141,8 +132,6 @@ type Model struct {
 	iamUsers            []awsservice.IAMUser
 	filteredIAMUsers    []awsservice.IAMUser
 	iamUserIdx          int
-	iamUserFilter       string
-	iamUserFilterActive bool
 	iamUserLoadingMore  bool
 	iamUserHasMore      bool
 	iamUserNextMarker   string
@@ -161,19 +150,15 @@ type Model struct {
 	iamOldKeyInactive   bool
 
 	// Secrets Manager browser state
-	secrets            []awsservice.Secret
-	filteredSecrets    []awsservice.Secret
-	secretIdx          int
-	secretFilter       string
-	secretFilterActive bool
-	selectedSecret     *awsservice.SecretDetail
+	secrets         []awsservice.Secret
+	filteredSecrets []awsservice.Secret
+	secretIdx       int
+	selectedSecret  *awsservice.SecretDetail
 
 	// Security Group browser state
 	securityGroups         []awsservice.SecurityGroup
 	filteredSecurityGroups []awsservice.SecurityGroup
 	sgIdx                  int
-	sgFilter               string
-	sgFilterActive         bool
 	selectedSecurityGroup  *awsservice.SecurityGroup
 	sgRuleSection          string // "ingress" or "egress" — active section in detail view
 	sgRuleIdx              int    // selected rule index within the active section
@@ -185,19 +170,15 @@ type Model struct {
 	sgAddSelectIdx         int               // index for select-type fields (direction, protocol)
 
 	// ECS browser state
-	ecsClusters            []awsservice.ECSCluster
-	filteredECSClusters    []awsservice.ECSCluster
-	ecsClusterIdx          int
-	ecsClusterFilter       string
-	ecsClusterFilterActive bool
-	selectedECSCluster     *awsservice.ECSCluster
+	ecsClusters         []awsservice.ECSCluster
+	filteredECSClusters []awsservice.ECSCluster
+	ecsClusterIdx       int
+	selectedECSCluster  *awsservice.ECSCluster
 
-	ecsServices            []awsservice.ECSService
-	filteredECSServices    []awsservice.ECSService
-	ecsServiceIdx          int
-	ecsServiceFilter       string
-	ecsServiceFilterActive bool
-	selectedECSService     *awsservice.ECSService
+	ecsServices         []awsservice.ECSService
+	filteredECSServices []awsservice.ECSService
+	ecsServiceIdx       int
+	selectedECSService  *awsservice.ECSService
 
 	ecsTasks        []awsservice.ECSTask
 	ecsTaskIdx      int
@@ -207,50 +188,38 @@ type Model struct {
 	ecsContainerIdx int
 
 	// CloudWatch Logs browser state
-	cwLogGroups             []awsservice.LogGroup
-	filteredCWLogGroups     []awsservice.LogGroup
-	cwLogGroupIdx           int
-	cwLogGroupFilter        string
-	cwLogGroupFilterActive  bool
-	selectedCWLogGroup      *awsservice.LogGroup
-	cwLogStreams            []awsservice.LogStream
-	filteredCWLogStreams    []awsservice.LogStream
-	cwLogStreamIdx          int
-	cwLogStreamFilter       string
-	cwLogStreamFilterActive bool
-	selectedCWLogStream     *awsservice.LogStream
-	cwLogEvents             []awsservice.LogEvent
-	cwLogScrollOffset       int
-	cwLogNextToken          *string
-	cwLogTimeRange          int // index into preset time ranges
-	cwLogFilterPattern      string
-	cwLogFilterActive       bool // filter pattern input active
-	cwLogTailing            bool // live tail active
-	cwLogTailToken          *string
+	cwLogGroups          []awsservice.LogGroup
+	filteredCWLogGroups  []awsservice.LogGroup
+	cwLogGroupIdx        int
+	selectedCWLogGroup   *awsservice.LogGroup
+	cwLogStreams         []awsservice.LogStream
+	filteredCWLogStreams []awsservice.LogStream
+	cwLogStreamIdx       int
+	selectedCWLogStream  *awsservice.LogStream
+	cwLogEvents          []awsservice.LogEvent
+	cwLogScrollOffset    int
+	cwLogNextToken       *string
+	cwLogTimeRange       int  // index into preset time ranges
+	cwLogTailing         bool // live tail active
+	cwLogTailToken       *string
 
 	// S3 browser state
-	s3Buckets            []awsservice.S3Bucket
-	filteredS3Buckets    []awsservice.S3Bucket
-	s3BucketIdx          int
-	s3BucketFilter       string
-	s3BucketFilterActive bool
-	selectedS3Bucket     *awsservice.S3Bucket
-	s3Objects            []awsservice.S3Object
-	filteredS3Objects    []awsservice.S3Object
-	s3ObjectIdx          int
-	s3ObjectFilter       string
-	s3ObjectFilterActive bool
-	s3CurrentPrefix      string
-	s3PrefixStack        []string
-	selectedS3Object     *awsservice.S3ObjectDetail
+	s3Buckets         []awsservice.S3Bucket
+	filteredS3Buckets []awsservice.S3Bucket
+	s3BucketIdx       int
+	selectedS3Bucket  *awsservice.S3Bucket
+	s3Objects         []awsservice.S3Object
+	filteredS3Objects []awsservice.S3Object
+	s3ObjectIdx       int
+	s3CurrentPrefix   string
+	s3PrefixStack     []string
+	selectedS3Object  *awsservice.S3ObjectDetail
 
 	// Context picker
 	configPath         string
 	ctxList            []config.ContextInfo
 	filteredCtxList    []config.ContextInfo
 	ctxIdx             int
-	ctxFilterInput     string
-	ctxFilterActive    bool
 	ctxPrevScreen      screen
 	pendingContextName string
 
@@ -275,6 +244,9 @@ type Model struct {
 
 	// Loading state
 	loadingSpinner spinner.Model
+	filterTI       textinput.Model
+	activeFilter   filterTarget
+	filters        map[filterTarget]string
 
 	// Terminal size
 	width  int
@@ -284,6 +256,7 @@ type Model struct {
 // New creates a new app Model.
 func New(cfg *config.Config, configPath string, version string) Model {
 	services := domain.Catalog()
+	filterTI := newFilterInput()
 	return Model{
 		cfg:            cfg,
 		configPath:     configPath,
@@ -292,6 +265,8 @@ func New(cfg *config.Config, configPath string, version string) Model {
 		ctxPrevScreen:  screenServiceList,
 		services:       services,
 		loadingSpinner: newLoadingSpinner(),
+		filterTI:       filterTI,
+		filters:        make(map[filterTarget]string),
 	}
 }
 
@@ -351,6 +326,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+		m.syncFilterInputWidth()
 		return m, nil
 	case callerIdentityMsg:
 		m.callerIdentity = msg.identity
@@ -402,12 +378,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Global home — return to service list from any screen (skip text-input screens)
 		if msg.String() == "H" && m.screen != screenServiceList && m.screen != screenContextPicker &&
 			m.screen != screenSecurityGroupAddRule && m.screen != screenSecurityGroupDeleteConfirm {
+			m.deactivateFilter()
 			m.screen = screenServiceList
 			return m, nil
 		}
 		// Global context switch — C key opens context picker (skip text-input screens)
 		if msg.String() == "C" && m.screen != screenContextPicker &&
 			m.screen != screenSecurityGroupAddRule && m.screen != screenSecurityGroupDeleteConfirm {
+			m.deactivateFilter()
 			m.ctxPrevScreen = m.screen
 			return m, m.loadContexts()
 		}
@@ -494,6 +472,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case screenError:
 			return m.updateError(msg)
 		}
+	}
+
+	if m.filterTI.Focused() {
+		var cmd tea.Cmd
+		m.filterTI, cmd = m.filterTI.Update(msg)
+		return m, cmd
 	}
 
 	return m, nil
@@ -831,25 +815,14 @@ func (m Model) loadSecretDetail(name string) tea.Cmd {
 func (m Model) updateSecretList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
-	if m.secretFilterActive {
-		newFilter, deactivate, changed := handleFilterKey(key, m.secretFilter)
-		m.secretFilter = newFilter
-		if deactivate {
-			m.secretFilterActive = false
-		}
-		if changed {
-			m.filteredSecrets = applyFilter(m.secrets, m.secretFilter)
-			m.secretIdx = 0
-		}
-		return m, nil
+	if cmd, handled := m.updateSharedFilter(msg, filterSecrets); handled {
+		return m, cmd
 	}
 
 	switch key {
 	case "q", "esc":
 		m.screen = screenFeatureList
-		m.secretFilter = ""
-		m.filteredSecrets = m.secrets
-		m.secretIdx = 0
+		m.resetFilter(filterSecrets)
 	case "up", "k":
 		if m.secretIdx > 0 {
 			m.secretIdx--
@@ -859,7 +832,7 @@ func (m Model) updateSecretList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.secretIdx++
 		}
 	case "/":
-		m.secretFilterActive = true
+		return m, m.activateFilter(filterSecrets)
 	case "enter":
 		if len(m.filteredSecrets) > 0 && m.secretIdx < len(m.filteredSecrets) {
 			selected := m.filteredSecrets[m.secretIdx]
@@ -884,11 +857,7 @@ func (m Model) viewSecretList() string {
 	b.WriteString(titleStyle.Render("Secrets Manager"))
 	b.WriteString("\n")
 
-	if m.secretFilterActive {
-		b.WriteString(filterStyle.Render(fmt.Sprintf("Filter: %s▏", m.secretFilter)))
-	} else if m.secretFilter != "" {
-		b.WriteString(dimStyle.Render(fmt.Sprintf("Filter: %s", m.secretFilter)))
-	}
+	b.WriteString(m.renderFilterValue(filterSecrets))
 	b.WriteString("\n\n")
 
 	if len(m.filteredSecrets) == 0 {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -324,7 +324,7 @@ func TestRDSListFilter(t *testing.T) {
 	// Activate filter
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
 	model := updated.(Model)
-	if !model.rdsFilterActive {
+	if !model.isFiltering(filterRDS) {
 		t.Error("filter should be active")
 	}
 
@@ -708,7 +708,7 @@ func TestSecurityGroupFilter(t *testing.T) {
 	// Activate filter
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
 	model := updated.(Model)
-	if !model.sgFilterActive {
+	if !model.isFiltering(filterSecurityGroups) {
 		t.Error("filter should be active")
 	}
 
@@ -867,7 +867,7 @@ func TestIAMUserListFilterStartsBackgroundSummaryLoad(t *testing.T) {
 
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
 	model := updated.(Model)
-	if !model.iamUserFilterActive {
+	if !model.isFiltering(filterIAMUsers) {
 		t.Fatal("expected IAM user filter to activate")
 	}
 	if !model.iamUserLoadingMore {
@@ -966,7 +966,7 @@ func TestIAMUserListShowsFilterBackgroundLoadHint(t *testing.T) {
 	m.screen = screenIAMUserList
 	m.iamUsers = []awsservice.IAMUser{{UserName: "alice"}}
 	m.filteredIAMUsers = m.iamUsers
-	m.iamUserFilterActive = true
+	m.storeFilterValue(filterIAMUsers, "ali")
 	m.iamUserLoadingMore = true
 
 	view := m.viewIAMUserList()

--- a/internal/app/filter.go
+++ b/internal/app/filter.go
@@ -1,10 +1,44 @@
 package app
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type filterTarget int
+
+const (
+	filterNone filterTarget = iota
+	filterInstances
+	filterSubnetIPs
+	filterRDS
+	filterRoute53Zones
+	filterRoute53Records
+	filterIAMUsers
+	filterSecrets
+	filterSecurityGroups
+	filterECSClusters
+	filterECSServices
+	filterCWLogGroups
+	filterCWLogStreams
+	filterCWLogViewer
+	filterS3Buckets
+	filterS3Objects
+	filterContexts
+)
 
 // Filterable is implemented by any type that supports text-based filtering.
 type Filterable interface {
 	FilterText() string
+}
+
+func newFilterInput() textinput.Model {
+	ti := textinput.New()
+	ti.Prompt = ""
+	ti.CharLimit = 256
+	return ti
 }
 
 // applyFilter returns items matching the query via case-insensitive substring on FilterText.
@@ -23,21 +57,133 @@ func applyFilter[T Filterable](items []T, query string) []T {
 	return result
 }
 
-// handleFilterKey processes a keystroke while filter input is active.
-// Returns the updated filter string, whether to deactivate filter mode, and whether the filter changed.
-func handleFilterKey(key, filter string) (newFilter string, deactivate bool, changed bool) {
-	switch key {
-	case "esc", "enter":
-		return filter, true, false
-	case "backspace":
-		if len(filter) > 0 {
-			return filter[:len(filter)-1], false, true
-		}
-		return filter, false, false
-	default:
-		if len(key) == 1 {
-			return filter + key, false, true
-		}
-		return filter, false, false
+func (m *Model) syncFilterInputWidth() {
+	width := m.width - len("Filter: ") - 4
+	if width < 10 {
+		width = 10
 	}
+	m.filterTI.Width = width
+}
+
+func (m Model) filterValue(target filterTarget) string {
+	if m.filters == nil {
+		return ""
+	}
+	return m.filters[target]
+}
+
+func (m *Model) storeFilterValue(target filterTarget, value string) {
+	if m.filters == nil {
+		m.filters = make(map[filterTarget]string)
+	}
+	if value == "" {
+		delete(m.filters, target)
+		return
+	}
+	m.filters[target] = value
+}
+
+func (m *Model) activateFilter(target filterTarget) tea.Cmd {
+	m.activeFilter = target
+	m.filterTI.SetValue(m.filterValue(target))
+	m.filterTI.CursorEnd()
+	m.syncFilterInputWidth()
+	return m.filterTI.Focus()
+}
+
+func (m *Model) deactivateFilter() {
+	m.filterTI.Blur()
+	m.activeFilter = filterNone
+}
+
+func (m Model) isFiltering(target filterTarget) bool {
+	return m.filterTI.Focused() && m.activeFilter == target
+}
+
+func (m *Model) resetFilter(target filterTarget) {
+	m.storeFilterValue(target, "")
+	if m.activeFilter == target {
+		m.filterTI.Reset()
+		m.deactivateFilter()
+	}
+	m.applyFilterTarget(target)
+}
+
+func (m *Model) updateSharedFilter(msg tea.KeyMsg, target filterTarget) (tea.Cmd, bool) {
+	if !m.isFiltering(target) {
+		return nil, false
+	}
+
+	switch msg.String() {
+	case "esc", "enter":
+		m.deactivateFilter()
+		return nil, true
+	}
+
+	prev := m.filterTI.Value()
+	var cmd tea.Cmd
+	m.filterTI, cmd = m.filterTI.Update(msg)
+	if next := m.filterTI.Value(); next != prev {
+		m.storeFilterValue(target, next)
+		m.applyFilterTarget(target)
+	}
+	return cmd, true
+}
+
+func (m *Model) applyFilterTarget(target filterTarget) {
+	switch target {
+	case filterInstances:
+		m.filtered = applyFilter(m.instances, m.filterValue(target))
+		m.instIdx = 0
+	case filterSubnetIPs:
+		m.applyIPFilter()
+	case filterRDS:
+		m.filteredRDS = applyFilter(m.rdsInstances, m.filterValue(target))
+		m.rdsIdx = 0
+	case filterRoute53Zones:
+		m.filteredRoute53Zones = applyFilter(m.route53Zones, m.filterValue(target))
+		m.route53ZoneIdx = 0
+	case filterRoute53Records:
+		m.filteredRoute53Records = applyFilter(m.route53Records, m.filterValue(target))
+		m.route53RecordIdx = 0
+	case filterIAMUsers:
+		m.refreshIAMUserFilter()
+	case filterSecrets:
+		m.filteredSecrets = applyFilter(m.secrets, m.filterValue(target))
+		m.secretIdx = 0
+	case filterSecurityGroups:
+		m.filteredSecurityGroups = applyFilter(m.securityGroups, m.filterValue(target))
+		m.sgIdx = 0
+	case filterECSClusters:
+		m.filteredECSClusters = applyFilter(m.ecsClusters, m.filterValue(target))
+		m.ecsClusterIdx = 0
+	case filterECSServices:
+		m.filteredECSServices = applyFilter(m.ecsServices, m.filterValue(target))
+		m.ecsServiceIdx = 0
+	case filterCWLogGroups:
+		m.filteredCWLogGroups = applyFilter(m.cwLogGroups, m.filterValue(target))
+		m.cwLogGroupIdx = 0
+	case filterCWLogStreams:
+		m.filteredCWLogStreams = applyFilter(m.cwLogStreams, m.filterValue(target))
+		m.cwLogStreamIdx = 0
+	case filterS3Buckets:
+		m.filteredS3Buckets = applyFilter(m.s3Buckets, m.filterValue(target))
+		m.s3BucketIdx = 0
+	case filterS3Objects:
+		m.filteredS3Objects = applyFilter(m.s3Objects, m.filterValue(target))
+		m.s3ObjectIdx = 0
+	case filterContexts:
+		m.filteredCtxList = applyFilter(m.ctxList, m.filterValue(target))
+		m.ctxIdx = 0
+	}
+}
+
+func (m Model) renderFilterValue(target filterTarget) string {
+	if m.isFiltering(target) {
+		return filterStyle.Render("Filter: " + m.filterTI.View())
+	}
+	if value := m.filterValue(target); value != "" {
+		return dimStyle.Render("Filter: " + value)
+	}
+	return ""
 }

--- a/internal/app/screen_cloudwatchlogs.go
+++ b/internal/app/screen_cloudwatchlogs.go
@@ -132,25 +132,14 @@ func (m Model) handleCloudWatchLogsMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 func (m Model) updateCWLogGroupList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
-	if m.cwLogGroupFilterActive {
-		newFilter, deactivate, changed := handleFilterKey(key, m.cwLogGroupFilter)
-		m.cwLogGroupFilter = newFilter
-		if deactivate {
-			m.cwLogGroupFilterActive = false
-		}
-		if changed {
-			m.filteredCWLogGroups = applyFilter(m.cwLogGroups, m.cwLogGroupFilter)
-			m.cwLogGroupIdx = 0
-		}
-		return m, nil
+	if cmd, handled := m.updateSharedFilter(msg, filterCWLogGroups); handled {
+		return m, cmd
 	}
 
 	switch key {
 	case "q", "esc":
 		m.screen = screenFeatureList
-		m.cwLogGroupFilter = ""
-		m.filteredCWLogGroups = m.cwLogGroups
-		m.cwLogGroupIdx = 0
+		m.resetFilter(filterCWLogGroups)
 	case "up", "k":
 		if m.cwLogGroupIdx > 0 {
 			m.cwLogGroupIdx--
@@ -160,7 +149,7 @@ func (m Model) updateCWLogGroupList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.cwLogGroupIdx++
 		}
 	case "/":
-		m.cwLogGroupFilterActive = true
+		return m, m.activateFilter(filterCWLogGroups)
 	case "enter":
 		if len(m.filteredCWLogGroups) > 0 && m.cwLogGroupIdx < len(m.filteredCWLogGroups) {
 			selected := m.filteredCWLogGroups[m.cwLogGroupIdx]
@@ -177,11 +166,7 @@ func (m Model) viewCWLogGroupList() string {
 	b.WriteString(titleStyle.Render("CloudWatch Log Groups"))
 	b.WriteString("\n")
 
-	if m.cwLogGroupFilterActive {
-		b.WriteString(filterStyle.Render(fmt.Sprintf("Filter: %s▏", m.cwLogGroupFilter)))
-	} else if m.cwLogGroupFilter != "" {
-		b.WriteString(dimStyle.Render(fmt.Sprintf("Filter: %s", m.cwLogGroupFilter)))
-	}
+	b.WriteString(m.renderFilterValue(filterCWLogGroups))
 	b.WriteString("\n\n")
 
 	if len(m.filteredCWLogGroups) == 0 {
@@ -248,25 +233,14 @@ func (m Model) viewCWLogGroupList() string {
 func (m Model) updateCWLogStreamList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
-	if m.cwLogStreamFilterActive {
-		newFilter, deactivate, changed := handleFilterKey(key, m.cwLogStreamFilter)
-		m.cwLogStreamFilter = newFilter
-		if deactivate {
-			m.cwLogStreamFilterActive = false
-		}
-		if changed {
-			m.filteredCWLogStreams = applyFilter(m.cwLogStreams, m.cwLogStreamFilter)
-			m.cwLogStreamIdx = 0
-		}
-		return m, nil
+	if cmd, handled := m.updateSharedFilter(msg, filterCWLogStreams); handled {
+		return m, cmd
 	}
 
 	switch key {
 	case "q", "esc":
 		m.screen = screenCWLogGroupList
-		m.cwLogStreamFilter = ""
-		m.filteredCWLogStreams = m.cwLogStreams
-		m.cwLogStreamIdx = 0
+		m.resetFilter(filterCWLogStreams)
 	case "up", "k":
 		if m.cwLogStreamIdx > 0 {
 			m.cwLogStreamIdx--
@@ -276,13 +250,13 @@ func (m Model) updateCWLogStreamList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.cwLogStreamIdx++
 		}
 	case "/":
-		m.cwLogStreamFilterActive = true
+		return m, m.activateFilter(filterCWLogStreams)
 	case "enter":
 		if len(m.filteredCWLogStreams) > 0 && m.cwLogStreamIdx < len(m.filteredCWLogStreams) {
 			selected := m.filteredCWLogStreams[m.cwLogStreamIdx]
 			m.selectedCWLogStream = &selected
 			m.cwLogTimeRange = 2 // default: 1h
-			m.cwLogFilterPattern = ""
+			m.resetFilter(filterCWLogViewer)
 			m.cwLogTailing = false
 			m.cwLogTailToken = nil
 			return m.startLoading(m.loadCWLogEvents(false))
@@ -301,11 +275,7 @@ func (m Model) viewCWLogStreamList() string {
 	b.WriteString(titleStyle.Render(fmt.Sprintf("Log Streams — %s", groupName)))
 	b.WriteString("\n")
 
-	if m.cwLogStreamFilterActive {
-		b.WriteString(filterStyle.Render(fmt.Sprintf("Filter: %s▏", m.cwLogStreamFilter)))
-	} else if m.cwLogStreamFilter != "" {
-		b.WriteString(dimStyle.Render(fmt.Sprintf("Filter: %s", m.cwLogStreamFilter)))
-	}
+	b.WriteString(m.renderFilterValue(filterCWLogStreams))
 	b.WriteString("\n\n")
 
 	if len(m.filteredCWLogStreams) == 0 {
@@ -370,25 +340,14 @@ func (m Model) viewCWLogStreamList() string {
 func (m Model) updateCWLogViewer(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
-	// Filter pattern input mode
-	if m.cwLogFilterActive {
-		switch key {
-		case "esc":
-			m.cwLogFilterActive = false
-		case "enter":
-			m.cwLogFilterActive = false
-			// Reload with new filter
+	if m.isFiltering(filterCWLogViewer) {
+		if key == "enter" {
+			m.deactivateFilter()
 			return m.startLoading(m.loadCWLogEvents(false))
-		case "backspace":
-			if len(m.cwLogFilterPattern) > 0 {
-				m.cwLogFilterPattern = m.cwLogFilterPattern[:len(m.cwLogFilterPattern)-1]
-			}
-		default:
-			if len(key) == 1 {
-				m.cwLogFilterPattern += key
-			}
 		}
-		return m, nil
+		if cmd, handled := m.updateSharedFilter(msg, filterCWLogViewer); handled {
+			return m, cmd
+		}
 	}
 
 	visibleLines := max(m.height-8, 5)
@@ -420,7 +379,7 @@ func (m Model) updateCWLogViewer(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, m.tickCWLogTail()
 		}
 	case "f": // Filter pattern input
-		m.cwLogFilterActive = true
+		return m, m.activateFilter(filterCWLogViewer)
 	case "n": // Load more (older events)
 		if m.cwLogNextToken != nil {
 			return m, m.loadCWLogEvents(true)
@@ -466,10 +425,8 @@ func (m Model) viewCWLogViewer() string {
 		}
 		status = append(status, strings.Join(ranges, ""))
 	}
-	if m.cwLogFilterActive {
-		status = append(status, filterStyle.Render(fmt.Sprintf("Filter: %s▏", m.cwLogFilterPattern)))
-	} else if m.cwLogFilterPattern != "" {
-		status = append(status, dimStyle.Render(fmt.Sprintf("Filter: %s", m.cwLogFilterPattern)))
+	if filter := m.renderFilterValue(filterCWLogViewer); filter != "" {
+		status = append(status, filter)
 	}
 	if m.cwLogTailing {
 		status = append(status, filterStyle.Render("TAILING"))
@@ -597,7 +554,7 @@ func (m Model) loadCWLogEvents(appendMode bool) tea.Cmd {
 			token = m.cwLogNextToken
 		}
 
-		events, nextToken, err := repo.FilterLogEvents(ctx, m.selectedCWLogGroup.Name, startTime, endTime, m.cwLogFilterPattern, token)
+		events, nextToken, err := repo.FilterLogEvents(ctx, m.selectedCWLogGroup.Name, startTime, endTime, m.filterValue(filterCWLogViewer), token)
 		if err != nil {
 			return errMsg{err: err}
 		}
@@ -633,7 +590,7 @@ func (m Model) pollCWLogTail() tea.Cmd {
 		startTime := now.Add(-30 * time.Second).UnixMilli()
 		endTime := now.UnixMilli()
 
-		events, nextToken, err := repo.FilterLogEvents(ctx, m.selectedCWLogGroup.Name, startTime, endTime, m.cwLogFilterPattern, m.cwLogTailToken)
+		events, nextToken, err := repo.FilterLogEvents(ctx, m.selectedCWLogGroup.Name, startTime, endTime, m.filterValue(filterCWLogViewer), m.cwLogTailToken)
 		if err != nil {
 			return cwLogEventsLoadedMsg{append: true}
 		}

--- a/internal/app/screen_context.go
+++ b/internal/app/screen_context.go
@@ -19,8 +19,7 @@ func (m Model) handleContextMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		m.ctxList = msg.contexts
 		m.filteredCtxList = msg.contexts
 		m.ctxIdx = 0
-		m.ctxFilterInput = ""
-		m.ctxFilterActive = false
+		m.resetFilter(filterContexts)
 		for i, ctx := range m.filteredCtxList {
 			if ctx.Current {
 				m.ctxIdx = i
@@ -61,17 +60,8 @@ func (m Model) loadContexts() tea.Cmd {
 func (m Model) updateContextPicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
-	if m.ctxFilterActive {
-		newFilter, deactivate, changed := handleFilterKey(key, m.ctxFilterInput)
-		m.ctxFilterInput = newFilter
-		if deactivate {
-			m.ctxFilterActive = false
-		}
-		if changed {
-			m.filteredCtxList = applyFilter(m.ctxList, m.ctxFilterInput)
-			m.ctxIdx = 0
-		}
-		return m, nil
+	if cmd, handled := m.updateSharedFilter(msg, filterContexts); handled {
+		return m, cmd
 	}
 
 	switch key {
@@ -83,8 +73,7 @@ func (m Model) updateContextPicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// If initial launch, quit.
 		if m.cfg.ContextName != "" {
 			m.screen = m.ctxPrevScreen
-			m.ctxFilterInput = ""
-			m.filteredCtxList = m.ctxList
+			m.resetFilter(filterContexts)
 		} else {
 			m.quitting = true
 			return m, tea.Quit
@@ -98,7 +87,7 @@ func (m Model) updateContextPicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.ctxIdx++
 		}
 	case "/":
-		m.ctxFilterActive = true
+		return m, m.activateFilter(filterContexts)
 	case "enter":
 		if len(m.filteredCtxList) > 0 && m.ctxIdx < len(m.filteredCtxList) {
 			selected := m.filteredCtxList[m.ctxIdx]
@@ -183,12 +172,7 @@ func (m Model) viewContextPicker() string {
 	b.WriteString(titleStyle.Render("Select Context"))
 	b.WriteString("\n")
 
-	// Filter bar
-	if m.ctxFilterActive {
-		b.WriteString(filterStyle.Render(fmt.Sprintf("Filter: %s▏", m.ctxFilterInput)))
-	} else if m.ctxFilterInput != "" {
-		b.WriteString(dimStyle.Render(fmt.Sprintf("Filter: %s", m.ctxFilterInput)))
-	}
+	b.WriteString(m.renderFilterValue(filterContexts))
 	b.WriteString("\n\n")
 
 	if len(m.ctxList) == 0 {

--- a/internal/app/screen_ec2.go
+++ b/internal/app/screen_ec2.go
@@ -34,10 +34,7 @@ func (m Model) handleEC2VPCMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 
 	case availableIPsLoadedMsg:
 		m.availableIPs = msg.ips
-		m.filteredIPs = msg.ips
-		m.ipScrollOffset = 0
-		m.ipFilter = ""
-		m.ipFilterActive = false
+		m.resetFilter(filterSubnetIPs)
 		m.screen = screenSubnetDetail
 		return m, nil, true
 
@@ -56,25 +53,14 @@ func (m Model) handleEC2VPCMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 func (m Model) updateInstanceList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
-	if m.filterActive {
-		newFilter, deactivate, changed := handleFilterKey(key, m.filterInput)
-		m.filterInput = newFilter
-		if deactivate {
-			m.filterActive = false
-		}
-		if changed {
-			m.filtered = applyFilter(m.instances, m.filterInput)
-			m.instIdx = 0
-		}
-		return m, nil
+	if cmd, handled := m.updateSharedFilter(msg, filterInstances); handled {
+		return m, cmd
 	}
 
 	switch key {
 	case "q", "esc":
 		m.screen = screenFeatureList
-		m.filterInput = ""
-		m.filtered = m.instances
-		m.instIdx = 0
+		m.resetFilter(filterInstances)
 	case "up", "k":
 		if m.instIdx > 0 {
 			m.instIdx--
@@ -84,10 +70,9 @@ func (m Model) updateInstanceList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.instIdx++
 		}
 	case "/":
-		m.filterActive = true
+		return m, m.activateFilter(filterInstances)
 	case "r":
-		m.filterInput = ""
-		m.instIdx = 0
+		m.resetFilter(filterInstances)
 		return m.startLoading(m.loadInstances())
 	case "enter":
 		if len(m.filtered) > 0 && m.instIdx < len(m.filtered) {
@@ -164,12 +149,7 @@ func (m Model) viewInstanceList() string {
 	b.WriteString(titleStyle.Render("EC2 Instances (Running)"))
 	b.WriteString("\n")
 
-	// Filter bar
-	if m.filterActive {
-		b.WriteString(filterStyle.Render(fmt.Sprintf("Filter: %s▏", m.filterInput)))
-	} else if m.filterInput != "" {
-		b.WriteString(dimStyle.Render(fmt.Sprintf("Filter: %s", m.filterInput)))
-	}
+	b.WriteString(m.renderFilterValue(filterInstances))
 	b.WriteString("\n\n")
 
 	if len(m.filtered) == 0 {

--- a/internal/app/screen_ecs.go
+++ b/internal/app/screen_ecs.go
@@ -20,8 +20,7 @@ func (m Model) handleECSMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		m.ecsClusters = msg.clusters
 		m.filteredECSClusters = msg.clusters
 		m.ecsClusterIdx = 0
-		m.ecsClusterFilter = ""
-		m.ecsClusterFilterActive = false
+		m.resetFilter(filterECSClusters)
 		m.screen = screenECSClusterList
 		return m, nil, true
 
@@ -29,8 +28,7 @@ func (m Model) handleECSMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		m.ecsServices = msg.services
 		m.filteredECSServices = msg.services
 		m.ecsServiceIdx = 0
-		m.ecsServiceFilter = ""
-		m.ecsServiceFilterActive = false
+		m.resetFilter(filterECSServices)
 		m.screen = screenECSServiceList
 		return m, nil, true
 
@@ -58,17 +56,8 @@ func (m Model) handleECSMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 func (m Model) updateECSClusterList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
-	if m.ecsClusterFilterActive {
-		newFilter, deactivate, changed := handleFilterKey(key, m.ecsClusterFilter)
-		m.ecsClusterFilter = newFilter
-		if deactivate {
-			m.ecsClusterFilterActive = false
-		}
-		if changed {
-			m.filteredECSClusters = applyFilter(m.ecsClusters, m.ecsClusterFilter)
-			m.ecsClusterIdx = 0
-		}
-		return m, nil
+	if cmd, handled := m.updateSharedFilter(msg, filterECSClusters); handled {
+		return m, cmd
 	}
 
 	switch key {
@@ -83,7 +72,7 @@ func (m Model) updateECSClusterList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.ecsClusterIdx++
 		}
 	case "/":
-		m.ecsClusterFilterActive = true
+		return m, m.activateFilter(filterECSClusters)
 	case "r":
 		return m.startLoading(m.loadECSClusters())
 	case "enter":
@@ -102,11 +91,7 @@ func (m Model) viewECSClusterList() string {
 	b.WriteString(titleStyle.Render("ECS Clusters"))
 	b.WriteString("\n")
 
-	if m.ecsClusterFilterActive {
-		b.WriteString(filterStyle.Render(fmt.Sprintf("Filter: %s▏", m.ecsClusterFilter)))
-	} else if m.ecsClusterFilter != "" {
-		b.WriteString(dimStyle.Render(fmt.Sprintf("Filter: %s", m.ecsClusterFilter)))
-	}
+	b.WriteString(m.renderFilterValue(filterECSClusters))
 	b.WriteString("\n\n")
 
 	if len(m.filteredECSClusters) == 0 {
@@ -146,17 +131,8 @@ func (m Model) viewECSClusterList() string {
 func (m Model) updateECSServiceList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
-	if m.ecsServiceFilterActive {
-		newFilter, deactivate, changed := handleFilterKey(key, m.ecsServiceFilter)
-		m.ecsServiceFilter = newFilter
-		if deactivate {
-			m.ecsServiceFilterActive = false
-		}
-		if changed {
-			m.filteredECSServices = applyFilter(m.ecsServices, m.ecsServiceFilter)
-			m.ecsServiceIdx = 0
-		}
-		return m, nil
+	if cmd, handled := m.updateSharedFilter(msg, filterECSServices); handled {
+		return m, cmd
 	}
 
 	switch key {
@@ -171,7 +147,7 @@ func (m Model) updateECSServiceList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.ecsServiceIdx++
 		}
 	case "/":
-		m.ecsServiceFilterActive = true
+		return m, m.activateFilter(filterECSServices)
 	case "r":
 		return m.startLoading(m.loadECSServices())
 	case "enter":
@@ -194,11 +170,7 @@ func (m Model) viewECSServiceList() string {
 	b.WriteString(titleStyle.Render(fmt.Sprintf("ECS Services — %s", clusterName)))
 	b.WriteString("\n")
 
-	if m.ecsServiceFilterActive {
-		b.WriteString(filterStyle.Render(fmt.Sprintf("Filter: %s▏", m.ecsServiceFilter)))
-	} else if m.ecsServiceFilter != "" {
-		b.WriteString(dimStyle.Render(fmt.Sprintf("Filter: %s", m.ecsServiceFilter)))
-	}
+	b.WriteString(m.renderFilterValue(filterECSServices))
 	b.WriteString("\n\n")
 
 	if len(m.filteredECSServices) == 0 {

--- a/internal/app/screen_iam.go
+++ b/internal/app/screen_iam.go
@@ -329,23 +329,15 @@ func (m Model) iamApplyActionLine() string {
 func (m Model) updateIAMUserList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
-	if m.iamUserFilterActive {
-		newFilter, deactivate, changed := handleFilterKey(key, m.iamUserFilter)
-		m.iamUserFilter = newFilter
-		if deactivate {
-			m.iamUserFilterActive = false
-		}
-		if changed {
-			m.refreshIAMUserFilter()
-		}
-		return m, nil
+	if cmd, handled := m.updateSharedFilter(msg, filterIAMUsers); handled {
+		return m, cmd
 	}
 
 	switch key {
 	case "q", "esc":
 		m.screen = screenFeatureList
 		m.selectedIAMUser = nil
-		m.iamUserFilter = ""
+		m.resetFilter(filterIAMUsers)
 		m.iamUserLoadingMore = false
 		m.iamUserHasMore = false
 		m.iamUserNextMarker = ""
@@ -360,11 +352,12 @@ func (m Model) updateIAMUserList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.iamUserIdx++
 		}
 	case "/":
-		m.iamUserFilterActive = true
+		filterCmd := m.activateFilter(filterIAMUsers)
 		if m.iamUserHasMore && !m.iamUserLoadingMore {
 			m.iamUserLoadingMore = true
-			return m, m.loadAllIAMUserSummaries(m.iamUserNextMarker)
+			return m, tea.Batch(filterCmd, m.loadAllIAMUserSummaries(m.iamUserNextMarker))
 		}
+		return m, filterCmd
 	case "enter":
 		if len(m.filteredIAMUsers) > 0 && m.iamUserIdx < len(m.filteredIAMUsers) {
 			selected := m.filteredIAMUsers[m.iamUserIdx]
@@ -380,10 +373,11 @@ func (m Model) updateIAMUserList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) refreshIAMUserFilter() {
-	if m.iamUserFilter == "" {
+	query := m.filterValue(filterIAMUsers)
+	if query == "" {
 		m.filteredIAMUsers = m.iamUsers
 	} else {
-		m.filteredIAMUsers = applyFilter(m.iamUsers, m.iamUserFilter)
+		m.filteredIAMUsers = applyFilter(m.iamUsers, query)
 	}
 
 	if len(m.filteredIAMUsers) == 0 {
@@ -520,11 +514,7 @@ func (m Model) viewIAMUserList() string {
 	b.WriteString(titleStyle.Render("IAM Users"))
 	b.WriteString("\n")
 
-	if m.iamUserFilterActive {
-		b.WriteString(filterStyle.Render(fmt.Sprintf("Filter: %s▏", m.iamUserFilter)))
-	} else if m.iamUserFilter != "" {
-		b.WriteString(dimStyle.Render(fmt.Sprintf("Filter: %s", m.iamUserFilter)))
-	}
+	b.WriteString(m.renderFilterValue(filterIAMUsers))
 	b.WriteString("\n\n")
 
 	if len(m.filteredIAMUsers) == 0 {
@@ -584,14 +574,14 @@ func (m Model) viewIAMUserList() string {
 
 	if m.iamUserLoadingMore {
 		b.WriteString("\n")
-		if m.iamUserFilterActive || m.iamUserFilter != "" {
+		if m.isFiltering(filterIAMUsers) || m.filterValue(filterIAMUsers) != "" {
 			b.WriteString(filterStyle.Render("  Loading remaining IAM usernames for filter..."))
 		} else {
 			b.WriteString(filterStyle.Render("  Loading more IAM users..."))
 		}
 	} else if m.iamUserHasMore {
 		b.WriteString("\n")
-		if m.iamUserFilterActive || m.iamUserFilter != "" {
+		if m.isFiltering(filterIAMUsers) || m.filterValue(filterIAMUsers) != "" {
 			b.WriteString(dimStyle.Render("  Continue typing to filter loaded usernames"))
 		} else {
 			b.WriteString(dimStyle.Render("  Press n to load the next page"))

--- a/internal/app/screen_rds.go
+++ b/internal/app/screen_rds.go
@@ -42,7 +42,7 @@ func (m Model) handleRDSMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 				break
 			}
 		}
-		m.filteredRDS = applyFilter(m.rdsInstances, m.rdsFilter)
+		m.filteredRDS = applyFilter(m.rdsInstances, m.filterValue(filterRDS))
 		m.rdsIdx = 0
 		if awsservice.IsTransitionalStatus(msg.instance.Status) {
 			return m, m.tickRDSPoll(msg.instance.DBInstanceID), true
@@ -62,25 +62,14 @@ func (m Model) handleRDSMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 func (m Model) updateRDSList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
-	if m.rdsFilterActive {
-		newFilter, deactivate, changed := handleFilterKey(key, m.rdsFilter)
-		m.rdsFilter = newFilter
-		if deactivate {
-			m.rdsFilterActive = false
-		}
-		if changed {
-			m.filteredRDS = applyFilter(m.rdsInstances, m.rdsFilter)
-			m.rdsIdx = 0
-		}
-		return m, nil
+	if cmd, handled := m.updateSharedFilter(msg, filterRDS); handled {
+		return m, cmd
 	}
 
 	switch key {
 	case "q", "esc":
 		m.screen = screenFeatureList
-		m.rdsFilter = ""
-		m.filteredRDS = m.rdsInstances
-		m.rdsIdx = 0
+		m.resetFilter(filterRDS)
 	case "up", "k":
 		if m.rdsIdx > 0 {
 			m.rdsIdx--
@@ -90,7 +79,7 @@ func (m Model) updateRDSList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.rdsIdx++
 		}
 	case "/":
-		m.rdsFilterActive = true
+		return m, m.activateFilter(filterRDS)
 	case "enter":
 		if len(m.filteredRDS) > 0 && m.rdsIdx < len(m.filteredRDS) {
 			selected := m.filteredRDS[m.rdsIdx]
@@ -176,7 +165,6 @@ func (m Model) updateRDSConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	return m, nil
 }
-
 
 func (m Model) loadRDSInstances() tea.Cmd {
 	return func() tea.Msg {
@@ -268,12 +256,7 @@ func (m Model) viewRDSList() string {
 	b.WriteString(titleStyle.Render("RDS Instances"))
 	b.WriteString("\n")
 
-	// Filter bar
-	if m.rdsFilterActive {
-		b.WriteString(filterStyle.Render(fmt.Sprintf("Filter: %s▏", m.rdsFilter)))
-	} else if m.rdsFilter != "" {
-		b.WriteString(dimStyle.Render(fmt.Sprintf("Filter: %s", m.rdsFilter)))
-	}
+	b.WriteString(m.renderFilterValue(filterRDS))
 	b.WriteString("\n\n")
 
 	if len(m.filteredRDS) == 0 {

--- a/internal/app/screen_route53.go
+++ b/internal/app/screen_route53.go
@@ -70,25 +70,14 @@ func (m Model) handleRoute53Msg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 func (m Model) updateRoute53ZoneList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
-	if m.route53ZoneFilterActive {
-		newFilter, deactivate, changed := handleFilterKey(key, m.route53ZoneFilter)
-		m.route53ZoneFilter = newFilter
-		if deactivate {
-			m.route53ZoneFilterActive = false
-		}
-		if changed {
-			m.filteredRoute53Zones = applyFilter(m.route53Zones, m.route53ZoneFilter)
-			m.route53ZoneIdx = 0
-		}
-		return m, nil
+	if cmd, handled := m.updateSharedFilter(msg, filterRoute53Zones); handled {
+		return m, cmd
 	}
 
 	switch key {
 	case "q", "esc":
 		m.screen = screenFeatureList
-		m.route53ZoneFilter = ""
-		m.filteredRoute53Zones = m.route53Zones
-		m.route53ZoneIdx = 0
+		m.resetFilter(filterRoute53Zones)
 	case "up", "k":
 		if m.route53ZoneIdx > 0 {
 			m.route53ZoneIdx--
@@ -98,7 +87,7 @@ func (m Model) updateRoute53ZoneList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.route53ZoneIdx++
 		}
 	case "/":
-		m.route53ZoneFilterActive = true
+		return m, m.activateFilter(filterRoute53Zones)
 	case "enter":
 		if len(m.filteredRoute53Zones) > 0 && m.route53ZoneIdx < len(m.filteredRoute53Zones) {
 			selected := m.filteredRoute53Zones[m.route53ZoneIdx]
@@ -112,25 +101,14 @@ func (m Model) updateRoute53ZoneList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m Model) updateRoute53RecordList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
-	if m.route53RecordFilterActive {
-		newFilter, deactivate, changed := handleFilterKey(key, m.route53RecordFilter)
-		m.route53RecordFilter = newFilter
-		if deactivate {
-			m.route53RecordFilterActive = false
-		}
-		if changed {
-			m.filteredRoute53Records = applyFilter(m.route53Records, m.route53RecordFilter)
-			m.route53RecordIdx = 0
-		}
-		return m, nil
+	if cmd, handled := m.updateSharedFilter(msg, filterRoute53Records); handled {
+		return m, cmd
 	}
 
 	switch key {
 	case "q", "esc":
 		m.screen = screenRoute53ZoneList
-		m.route53RecordFilter = ""
-		m.filteredRoute53Records = m.route53Records
-		m.route53RecordIdx = 0
+		m.resetFilter(filterRoute53Records)
 	case "up", "k":
 		if m.route53RecordIdx > 0 {
 			m.route53RecordIdx--
@@ -140,7 +118,7 @@ func (m Model) updateRoute53RecordList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.route53RecordIdx++
 		}
 	case "/":
-		m.route53RecordFilterActive = true
+		return m, m.activateFilter(filterRoute53Records)
 	case "c":
 		m.route53Action = "create"
 		m.route53EditField = 0
@@ -243,11 +221,7 @@ func (m Model) viewRoute53ZoneList() string {
 	b.WriteString(titleStyle.Render("Route53 Hosted Zones"))
 	b.WriteString("\n")
 
-	if m.route53ZoneFilterActive {
-		b.WriteString(filterStyle.Render(fmt.Sprintf("Filter: %s▏", m.route53ZoneFilter)))
-	} else if m.route53ZoneFilter != "" {
-		b.WriteString(dimStyle.Render(fmt.Sprintf("Filter: %s", m.route53ZoneFilter)))
-	}
+	b.WriteString(m.renderFilterValue(filterRoute53Zones))
 	b.WriteString("\n\n")
 
 	if len(m.filteredRoute53Zones) == 0 {
@@ -319,11 +293,7 @@ func (m Model) viewRoute53RecordList() string {
 	b.WriteString(titleStyle.Render(fmt.Sprintf("DNS Records — %s", zoneName)))
 	b.WriteString("\n")
 
-	if m.route53RecordFilterActive {
-		b.WriteString(filterStyle.Render(fmt.Sprintf("Filter: %s▏", m.route53RecordFilter)))
-	} else if m.route53RecordFilter != "" {
-		b.WriteString(dimStyle.Render(fmt.Sprintf("Filter: %s", m.route53RecordFilter)))
-	}
+	b.WriteString(m.renderFilterValue(filterRoute53Records))
 	b.WriteString("\n\n")
 
 	if len(m.filteredRoute53Records) == 0 {

--- a/internal/app/screen_s3.go
+++ b/internal/app/screen_s3.go
@@ -18,8 +18,7 @@ func (m Model) handleS3Msg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		m.s3Buckets = msg.buckets
 		m.filteredS3Buckets = msg.buckets
 		m.s3BucketIdx = 0
-		m.s3BucketFilter = ""
-		m.s3BucketFilterActive = false
+		m.resetFilter(filterS3Buckets)
 		m.screen = screenS3BucketList
 		return m, nil, true
 	case s3ObjectsLoadedMsg:
@@ -30,8 +29,7 @@ func (m Model) handleS3Msg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		m.s3Objects = flattenS3Objects(msg.objects)
 		m.filteredS3Objects = m.s3Objects
 		m.s3ObjectIdx = 0
-		m.s3ObjectFilter = ""
-		m.s3ObjectFilterActive = false
+		m.resetFilter(filterS3Objects)
 		m.screen = screenS3ObjectList
 		return m, nil, true
 	case s3ObjectDetailLoadedMsg:
@@ -117,25 +115,14 @@ func (m Model) loadS3ObjectDetail(bucketName, key string) tea.Cmd {
 func (m Model) updateS3BucketList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
-	if m.s3BucketFilterActive {
-		newFilter, deactivate, changed := handleFilterKey(key, m.s3BucketFilter)
-		m.s3BucketFilter = newFilter
-		if deactivate {
-			m.s3BucketFilterActive = false
-		}
-		if changed {
-			m.filteredS3Buckets = applyFilter(m.s3Buckets, m.s3BucketFilter)
-			m.s3BucketIdx = 0
-		}
-		return m, nil
+	if cmd, handled := m.updateSharedFilter(msg, filterS3Buckets); handled {
+		return m, cmd
 	}
 
 	switch key {
 	case "q", "esc":
 		m.screen = screenFeatureList
-		m.s3BucketFilter = ""
-		m.filteredS3Buckets = m.s3Buckets
-		m.s3BucketIdx = 0
+		m.resetFilter(filterS3Buckets)
 	case "up", "k":
 		if m.s3BucketIdx > 0 {
 			m.s3BucketIdx--
@@ -145,7 +132,7 @@ func (m Model) updateS3BucketList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.s3BucketIdx++
 		}
 	case "/":
-		m.s3BucketFilterActive = true
+		return m, m.activateFilter(filterS3Buckets)
 	case "enter":
 		if len(m.filteredS3Buckets) > 0 && m.s3BucketIdx < len(m.filteredS3Buckets) {
 			selected := m.filteredS3Buckets[m.s3BucketIdx]
@@ -161,17 +148,8 @@ func (m Model) updateS3BucketList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m Model) updateS3ObjectList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
-	if m.s3ObjectFilterActive {
-		newFilter, deactivate, changed := handleFilterKey(key, m.s3ObjectFilter)
-		m.s3ObjectFilter = newFilter
-		if deactivate {
-			m.s3ObjectFilterActive = false
-		}
-		if changed {
-			m.filteredS3Objects = applyFilter(m.s3Objects, m.s3ObjectFilter)
-			m.s3ObjectIdx = 0
-		}
-		return m, nil
+	if cmd, handled := m.updateSharedFilter(msg, filterS3Objects); handled {
+		return m, cmd
 	}
 
 	switch key {
@@ -198,7 +176,7 @@ func (m Model) updateS3ObjectList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.s3ObjectIdx++
 		}
 	case "/":
-		m.s3ObjectFilterActive = true
+		return m, m.activateFilter(filterS3Objects)
 	case "enter":
 		if len(m.filteredS3Objects) == 0 || m.s3ObjectIdx >= len(m.filteredS3Objects) || m.selectedS3Bucket == nil {
 			return m, nil
@@ -228,11 +206,7 @@ func (m Model) viewS3BucketList() string {
 	b.WriteString(titleStyle.Render("S3 Buckets"))
 	b.WriteString("\n")
 
-	if m.s3BucketFilterActive {
-		b.WriteString(filterStyle.Render(fmt.Sprintf("Filter: %s▏", m.s3BucketFilter)))
-	} else if m.s3BucketFilter != "" {
-		b.WriteString(dimStyle.Render(fmt.Sprintf("Filter: %s", m.s3BucketFilter)))
-	}
+	b.WriteString(m.renderFilterValue(filterS3Buckets))
 	b.WriteString("\n\n")
 
 	if len(m.filteredS3Buckets) == 0 {
@@ -304,11 +278,7 @@ func (m Model) viewS3ObjectList() string {
 	b.WriteString(dimStyle.Render(fmt.Sprintf("Path: %s", awsservice.S3Breadcrumb(m.s3CurrentPrefix))))
 	b.WriteString("\n")
 
-	if m.s3ObjectFilterActive {
-		b.WriteString(filterStyle.Render(fmt.Sprintf("Filter: %s▏", m.s3ObjectFilter)))
-	} else if m.s3ObjectFilter != "" {
-		b.WriteString(dimStyle.Render(fmt.Sprintf("Filter: %s", m.s3ObjectFilter)))
-	}
+	b.WriteString(m.renderFilterValue(filterS3Objects))
 	b.WriteString("\n\n")
 
 	if len(m.filteredS3Objects) == 0 {

--- a/internal/app/screen_securitygroup.go
+++ b/internal/app/screen_securitygroup.go
@@ -58,7 +58,7 @@ func (m Model) handleSecurityGroupMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 				break
 			}
 		}
-		m.filteredSecurityGroups = applyFilter(m.securityGroups, m.sgFilter)
+		m.filteredSecurityGroups = applyFilter(m.securityGroups, m.filterValue(filterSecurityGroups))
 		m.sgIdx = 0
 		m.sgRuleIdx = 0
 		m.screen = screenSecurityGroupDetail
@@ -165,25 +165,14 @@ func (m Model) refreshSecurityGroup() tea.Cmd {
 func (m Model) updateSecurityGroupList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
-	if m.sgFilterActive {
-		newFilter, deactivate, changed := handleFilterKey(key, m.sgFilter)
-		m.sgFilter = newFilter
-		if deactivate {
-			m.sgFilterActive = false
-		}
-		if changed {
-			m.filteredSecurityGroups = applyFilter(m.securityGroups, m.sgFilter)
-			m.sgIdx = 0
-		}
-		return m, nil
+	if cmd, handled := m.updateSharedFilter(msg, filterSecurityGroups); handled {
+		return m, cmd
 	}
 
 	switch key {
 	case "q", "esc":
 		m.screen = screenFeatureList
-		m.sgFilter = ""
-		m.filteredSecurityGroups = m.securityGroups
-		m.sgIdx = 0
+		m.resetFilter(filterSecurityGroups)
 	case "up", "k":
 		if m.sgIdx > 0 {
 			m.sgIdx--
@@ -193,10 +182,9 @@ func (m Model) updateSecurityGroupList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.sgIdx++
 		}
 	case "/":
-		m.sgFilterActive = true
+		return m, m.activateFilter(filterSecurityGroups)
 	case "r":
-		m.sgFilter = ""
-		m.sgIdx = 0
+		m.resetFilter(filterSecurityGroups)
 		return m.startLoading(m.loadSecurityGroups())
 	case "enter":
 		if len(m.filteredSecurityGroups) > 0 && m.sgIdx < len(m.filteredSecurityGroups) {
@@ -216,11 +204,7 @@ func (m Model) viewSecurityGroupList() string {
 	b.WriteString(titleStyle.Render("Security Groups"))
 	b.WriteString("\n")
 
-	if m.sgFilterActive {
-		b.WriteString(filterStyle.Render(fmt.Sprintf("Filter: %s▏", m.sgFilter)))
-	} else if m.sgFilter != "" {
-		b.WriteString(dimStyle.Render(fmt.Sprintf("Filter: %s", m.sgFilter)))
-	}
+	b.WriteString(m.renderFilterValue(filterSecurityGroups))
 	b.WriteString("\n\n")
 
 	if len(m.filteredSecurityGroups) == 0 {

--- a/internal/app/screen_vpc.go
+++ b/internal/app/screen_vpc.go
@@ -59,16 +59,8 @@ func (m Model) updateSubnetList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m Model) updateSubnetDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
-	if m.ipFilterActive {
-		newFilter, deactivate, changed := handleFilterKey(key, m.ipFilter)
-		m.ipFilter = newFilter
-		if deactivate {
-			m.ipFilterActive = false
-		}
-		if changed {
-			m.applyIPFilter()
-		}
-		return m, nil
+	if cmd, handled := m.updateSharedFilter(msg, filterSubnetIPs); handled {
+		return m, cmd
 	}
 
 	switch key {
@@ -84,18 +76,19 @@ func (m Model) updateSubnetDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.ipScrollOffset++
 		}
 	case "/":
-		m.ipFilterActive = true
+		return m, m.activateFilter(filterSubnetIPs)
 	}
 	return m, nil
 }
 
 func (m *Model) applyIPFilter() {
-	if m.ipFilter == "" {
+	query := m.filterValue(filterSubnetIPs)
+	if query == "" {
 		m.filteredIPs = m.availableIPs
 	} else {
 		var result []string
 		for _, ip := range m.availableIPs {
-			if strings.Contains(ip, m.ipFilter) {
+			if strings.Contains(ip, query) {
 				result = append(result, ip)
 			}
 		}
@@ -264,12 +257,7 @@ func (m Model) viewSubnetDetail() string {
 	b.WriteString(normalStyle.Render(fmt.Sprintf("  Available IPs : %d", len(m.availableIPs))))
 	b.WriteString("\n\n")
 
-	// Filter bar
-	if m.ipFilterActive {
-		b.WriteString(filterStyle.Render(fmt.Sprintf("Filter: %s▏", m.ipFilter)))
-	} else if m.ipFilter != "" {
-		b.WriteString(dimStyle.Render(fmt.Sprintf("Filter: %s", m.ipFilter)))
-	}
+	b.WriteString(m.renderFilterValue(filterSubnetIPs))
 	b.WriteString("\n")
 
 	if len(m.filteredIPs) == 0 {


### PR DESCRIPTION
### Summary

- replace per-screen filter state with a shared `bubbles/textinput` model and central filter helpers
- route filter activation, rendering, and query application through the shared flow across EC2, VPC, RDS, Route53, Secrets, Security Groups, IAM, ECS, S3, CloudWatch Logs, and the context picker
- update tests and module metadata for the shared filter input path

### Related Issues

Closes #61

### Validation

- `GOCACHE=/tmp/unic-go-build make test`
- `GOCACHE=/tmp/unic-go-build make build`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed
- [x] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented