### PR TITLE
docs: add architecture diagrams for contributors

### DIFF
--- a/docs/diagrams/architecture-overview.drawio
+++ b/docs/diagrams/architecture-overview.drawio
@@ -1,0 +1,136 @@
+<mxfile host="app.diagrams.net" type="device">
+  <diagram id="arch" name="Architecture Overview">
+    <mxGraphModel dx="1200" dy="800" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <mxCell id="2" value="unic &#8212; Architecture Overview" style="text;html=1;align=center;verticalAlign=middle;fontSize=20;fontStyle=1;fillColor=none;strokeColor=none;fontColor=#333333;" vertex="1" parent="1">
+          <mxGeometry x="200" y="20" width="400" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="3" value="CLI Layer" style="swimlane;startSize=30;fillColor=#dae8fc;strokeColor=#6c8ebf;rounded=1;arcSize=8;fontSize=14;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="100" y="80" width="600" height="90" as="geometry"/>
+        </mxCell>
+        <mxCell id="4" value="Cobra Root Command&#xa;cmd/unic/main.go" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;" vertex="1" parent="3">
+          <mxGeometry x="20" y="35" width="170" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="5" value="CLI Flags&#xa;--profile, --region, --verbose" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;" vertex="1" parent="3">
+          <mxGeometry x="210" y="35" width="180" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="6" value="Context Commands&#xa;unic ctx, unic env" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;" vertex="1" parent="3">
+          <mxGeometry x="410" y="35" width="170" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="7" value="TUI Layer (Bubbletea)" style="swimlane;startSize=30;fillColor=#d5e8d4;strokeColor=#82b366;rounded=1;arcSize=8;fontSize=14;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="100" y="190" width="600" height="130" as="geometry"/>
+        </mxCell>
+        <mxCell id="8" value="Model&#xa;(State Machine)&#xa;app.go" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;" vertex="1" parent="7">
+          <mxGeometry x="20" y="35" width="120" height="55" as="geometry"/>
+        </mxCell>
+        <mxCell id="9" value="41 Screen Handlers&#xa;screen_*.go" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;" vertex="1" parent="7">
+          <mxGeometry x="160" y="35" width="130" height="55" as="geometry"/>
+        </mxCell>
+        <mxCell id="10" value="Messages&#xa;(Cmd/Msg Pattern)&#xa;messages.go" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;" vertex="1" parent="7">
+          <mxGeometry x="310" y="35" width="130" height="55" as="geometry"/>
+        </mxCell>
+        <mxCell id="11" value="Styles&#xa;(Lipgloss)&#xa;styles.go" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;" vertex="1" parent="7">
+          <mxGeometry x="460" y="35" width="120" height="55" as="geometry"/>
+        </mxCell>
+        <mxCell id="12" value="Filter&lt;T&gt;" style="rounded=1;whiteSpace=wrap;fillColor=#fff2cc;strokeColor=#d6b656;fontColor=#333333;fontSize=11;" vertex="1" parent="7">
+          <mxGeometry x="160" y="95" width="80" height="25" as="geometry"/>
+        </mxCell>
+        <mxCell id="13" value="tea.ExecProcess" style="rounded=1;whiteSpace=wrap;fillColor=#fff2cc;strokeColor=#d6b656;fontColor=#333333;fontSize=11;" vertex="1" parent="7">
+          <mxGeometry x="310" y="95" width="100" height="25" as="geometry"/>
+        </mxCell>
+        <mxCell id="14" value="Domain Layer" style="swimlane;startSize=30;fillColor=#fff2cc;strokeColor=#d6b656;rounded=1;arcSize=8;fontSize=14;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="100" y="340" width="600" height="90" as="geometry"/>
+        </mxCell>
+        <mxCell id="15" value="Service Catalog&#xa;catalog.go" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;" vertex="1" parent="14">
+          <mxGeometry x="20" y="35" width="130" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="16" value="Domain Models&#xa;model.go" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;" vertex="1" parent="14">
+          <mxGeometry x="170" y="35" width="130" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="17" value="Filterable Interface" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;" vertex="1" parent="14">
+          <mxGeometry x="320" y="35" width="130" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="18" value="Service / Feature&#xa;Definitions" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;" vertex="1" parent="14">
+          <mxGeometry x="470" y="35" width="110" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="19" value="Services Layer" style="swimlane;startSize=30;fillColor=#e1d5e7;strokeColor=#9673a6;rounded=1;arcSize=8;fontSize=14;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="100" y="450" width="600" height="140" as="geometry"/>
+        </mxCell>
+        <mxCell id="20" value="AwsRepository&#xa;repository.go" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;fontStyle=1;" vertex="1" parent="19">
+          <mxGeometry x="220" y="35" width="160" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="21" value="EC2" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=11;" vertex="1" parent="19">
+          <mxGeometry x="20" y="95" width="60" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="22" value="RDS" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=11;" vertex="1" parent="19">
+          <mxGeometry x="90" y="95" width="60" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="23" value="Route53" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=11;" vertex="1" parent="19">
+          <mxGeometry x="160" y="95" width="60" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="24" value="ECS" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=11;" vertex="1" parent="19">
+          <mxGeometry x="230" y="95" width="60" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="25" value="S3" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=11;" vertex="1" parent="19">
+          <mxGeometry x="300" y="95" width="60" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="26" value="IAM" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=11;" vertex="1" parent="19">
+          <mxGeometry x="370" y="95" width="60" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="27" value="SG" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=11;" vertex="1" parent="19">
+          <mxGeometry x="440" y="95" width="60" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="28" value="CW Logs" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=11;" vertex="1" parent="19">
+          <mxGeometry x="510" y="95" width="70" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="29" value="Infrastructure Layer" style="swimlane;startSize=30;fillColor=#f8cecc;strokeColor=#b85450;rounded=1;arcSize=8;fontSize=14;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="100" y="610" width="600" height="90" as="geometry"/>
+        </mxCell>
+        <mxCell id="30" value="Auth&#xa;(SSO / AssumeRole / Credential)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;" vertex="1" parent="29">
+          <mxGeometry x="20" y="35" width="190" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="31" value="Config&#xa;(YAML contexts)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;" vertex="1" parent="29">
+          <mxGeometry x="230" y="35" width="140" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="32" value="Clipboard" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;" vertex="1" parent="29">
+          <mxGeometry x="390" y="35" width="90" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="33" value="Logger&#xa;(File-based)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;" vertex="1" parent="29">
+          <mxGeometry x="500" y="35" width="80" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="34" value="External" style="swimlane;startSize=30;fillColor=#f5f5f5;strokeColor=#666666;rounded=1;arcSize=8;fontSize=14;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="100" y="720" width="600" height="90" as="geometry"/>
+        </mxCell>
+        <mxCell id="35" value="AWS SDK v2" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;" vertex="1" parent="34">
+          <mxGeometry x="20" y="35" width="110" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="36" value="session-manager-plugin" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;" vertex="1" parent="34">
+          <mxGeometry x="150" y="35" width="160" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="37" value="AWS CLI" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;" vertex="1" parent="34">
+          <mxGeometry x="330" y="35" width="100" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="38" value="AWS APIs&#xa;(EC2, RDS, Route53, ...)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;" vertex="1" parent="34">
+          <mxGeometry x="450" y="35" width="130" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="39" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#666666;" edge="1" source="3" target="7" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="40" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#666666;" edge="1" source="7" target="14" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="41" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#666666;" edge="1" source="14" target="19" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="42" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#666666;" edge="1" source="19" target="29" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="43" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#666666;" edge="1" source="29" target="34" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/diagrams/async-data-flow.drawio
+++ b/docs/diagrams/async-data-flow.drawio
@@ -1,0 +1,106 @@
+<mxfile host="app.diagrams.net" type="device">
+  <diagram id="async" name="Async Data Flow">
+    <mxGraphModel dx="1200" dy="800" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="750" math="0" shadow="0">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <mxCell id="2" value="unic &#8212; Async Data Flow (Bubbletea Elm Architecture)" style="text;html=1;align=center;verticalAlign=middle;fontSize=20;fontStyle=1;fillColor=none;strokeColor=none;fontColor=#333333;" vertex="1" parent="1">
+          <mxGeometry x="150" y="10" width="500" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="3" value="Example: EC2 Instance List Loading" style="text;html=1;align=center;verticalAlign=middle;fontSize=12;fillColor=none;strokeColor=none;fontColor=#999999;" vertex="1" parent="1">
+          <mxGeometry x="250" y="45" width="300" height="25" as="geometry"/>
+        </mxCell>
+        <mxCell id="4" value="User" style="shape=actor;whiteSpace=wrap;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=12;" vertex="1" parent="1">
+          <mxGeometry x="50" y="100" width="40" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="5" value="Model.Update()&#xa;State Machine&#xa;app.go" style="rounded=1;whiteSpace=wrap;fillColor=#d5e8d4;strokeColor=#82b366;fontColor=#333333;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="170" y="95" width="160" height="60" as="geometry"/>
+        </mxCell>
+        <mxCell id="6" value="tea.Cmd&#xa;(Goroutine)" style="rounded=1;whiteSpace=wrap;fillColor=#fff2cc;strokeColor=#d6b656;fontColor=#333333;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="420" y="95" width="130" height="60" as="geometry"/>
+        </mxCell>
+        <mxCell id="7" value="AWS API&#xa;(SDK v2)" style="rounded=1;whiteSpace=wrap;fillColor=#f8cecc;strokeColor=#b85450;fontColor=#333333;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="640" y="95" width="120" height="60" as="geometry"/>
+        </mxCell>
+        <mxCell id="8" value="Model.View()&#xa;Render TUI&#xa;screen_*.go" style="rounded=1;whiteSpace=wrap;fillColor=#e1d5e7;strokeColor=#9673a6;fontColor=#333333;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="170" y="220" width="160" height="60" as="geometry"/>
+        </mxCell>
+        <mxCell id="9" value="Terminal&#xa;Output" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=12;" vertex="1" parent="1">
+          <mxGeometry x="20" y="220" width="90" height="60" as="geometry"/>
+        </mxCell>
+        <mxCell id="10" value="1. Key Press&#xa;(Enter on Feature)" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#6c8ebf;fontColor=#333333;fontSize=10;" edge="1" source="4" target="5" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="11" value="2. Return Cmd&#xa;m.loadInstances()" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#82b366;fontColor=#333333;fontSize=10;" edge="1" source="5" target="6" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="12" value="3. repo.ListRunningInstances()&#xa;(blocking in goroutine)" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#d6b656;fontColor=#333333;fontSize=10;" edge="1" source="6" target="7" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="13" value="4. []EC2Instance" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#b85450;fontColor=#333333;fontSize=10;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" edge="1" source="7" target="6" parent="1">
+          <mxGeometry relative="1" as="geometry"><Array as="points"><mxPoint x="700" y="180"/><mxPoint x="485" y="180"/></Array></mxGeometry>
+        </mxCell>
+        <mxCell id="14" value="5. instancesLoadedMsg{}" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#d6b656;fontColor=#333333;fontSize=10;exitX=0;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0;entryDx=0;entryDy=0;" edge="1" source="6" target="8" parent="1">
+          <mxGeometry relative="1" as="geometry"><Array as="points"><mxPoint x="400" y="190"/><mxPoint x="400" y="190"/></Array></mxGeometry>
+        </mxCell>
+        <mxCell id="15" value="6. screen = screenInstanceList&#xa;m.instances = msg.instances" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#82b366;fontColor=#333333;fontSize=10;" edge="1" source="5" target="8" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="16" value="7. Render" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#9673a6;fontColor=#333333;fontSize=10;" edge="1" source="8" target="9" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="17" value="Filter Flow" style="swimlane;startSize=25;fillColor=#fff2cc;strokeColor=#d6b656;rounded=1;fontSize=12;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="30" y="330" width="740" height="160" as="geometry"/>
+        </mxCell>
+        <mxCell id="18" value="User presses /" style="ellipse;whiteSpace=wrap;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="17">
+          <mxGeometry x="10" y="35" width="100" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="19" value="filterActive = true&#xa;Show filter input" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=10;" vertex="1" parent="17">
+          <mxGeometry x="140" y="35" width="130" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="20" value="Each keystroke:&#xa;handleFilterKey()" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=10;" vertex="1" parent="17">
+          <mxGeometry x="300" y="35" width="130" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="21" value="applyFilter&lt;T&gt;()&#xa;Case-insensitive&#xa;substring on FilterText()" style="rounded=1;whiteSpace=wrap;fillColor=#d5e8d4;strokeColor=#82b366;fontColor=#333333;fontSize=10;" vertex="1" parent="17">
+          <mxGeometry x="460" y="30" width="160" height="55" as="geometry"/>
+        </mxCell>
+        <mxCell id="22" value="m.filtered = result&#xa;m.instIdx = 0&#xa;Re-render view" style="rounded=1;whiteSpace=wrap;fillColor=#e1d5e7;strokeColor=#9673a6;fontColor=#333333;fontSize=10;" vertex="1" parent="17">
+          <mxGeometry x="460" y="100" width="160" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="23" value="Two-Slice Design:&#xa;m.instances = full API data (immutable)&#xa;m.filtered = current filtered view" style="rounded=1;whiteSpace=wrap;fillColor=#fff2cc;strokeColor=#d6b656;fontColor=#333333;fontSize=10;align=left;spacingLeft=8;" vertex="1" parent="17">
+          <mxGeometry x="140" y="100" width="250" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="24" style="strokeColor=#999999;" edge="1" source="18" target="19" parent="17">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="25" style="strokeColor=#999999;" edge="1" source="19" target="20" parent="17">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="26" style="strokeColor=#999999;" edge="1" source="20" target="21" parent="17">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="27" style="strokeColor=#999999;" edge="1" source="21" target="22" parent="17">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="28" value="Message Types" style="swimlane;startSize=25;fillColor=#f5f5f5;strokeColor=#666666;rounded=1;fontSize=12;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="30" y="520" width="740" height="130" as="geometry"/>
+        </mxCell>
+        <mxCell id="29" value="Resource Loading&#xa;instancesLoadedMsg&#xa;vpcsLoadedMsg&#xa;rdsInstancesLoadedMsg&#xa;s3BucketsLoadedMsg&#xa;..." style="rounded=1;whiteSpace=wrap;fillColor=#dae8fc;strokeColor=#6c8ebf;fontColor=#333333;fontSize=9;align=left;spacingLeft=8;" vertex="1" parent="28">
+          <mxGeometry x="10" y="30" width="140" height="90" as="geometry"/>
+        </mxCell>
+        <mxCell id="30" value="Action Results&#xa;rdsActionDoneMsg&#xa;route53ActionDoneMsg&#xa;iamKeyCreatedMsg&#xa;iamKeyDeactivatedMsg&#xa;..." style="rounded=1;whiteSpace=wrap;fillColor=#d5e8d4;strokeColor=#82b366;fontColor=#333333;fontSize=9;align=left;spacingLeft=8;" vertex="1" parent="28">
+          <mxGeometry x="165" y="30" width="140" height="90" as="geometry"/>
+        </mxCell>
+        <mxCell id="31" value="Context/Auth&#xa;contextSwitchedMsg&#xa;contextsLoadedMsg&#xa;ssoLoginDoneMsg&#xa;callerIdentityMsg" style="rounded=1;whiteSpace=wrap;fillColor=#fff2cc;strokeColor=#d6b656;fontColor=#333333;fontSize=9;align=left;spacingLeft=8;" vertex="1" parent="28">
+          <mxGeometry x="320" y="30" width="130" height="90" as="geometry"/>
+        </mxCell>
+        <mxCell id="32" value="Polling/Timer&#xa;rdsTickMsg&#xa;route53PollTickMsg&#xa;cwLogTailTickMsg" style="rounded=1;whiteSpace=wrap;fillColor=#e1d5e7;strokeColor=#9673a6;fontColor=#333333;fontSize=9;align=left;spacingLeft=8;" vertex="1" parent="28">
+          <mxGeometry x="465" y="30" width="130" height="90" as="geometry"/>
+        </mxCell>
+        <mxCell id="33" value="Subprocess&#xa;ssmSessionDoneMsg&#xa;ecsExecDoneMsg" style="rounded=1;whiteSpace=wrap;fillColor=#f8cecc;strokeColor=#b85450;fontColor=#333333;fontSize=9;align=left;spacingLeft=8;" vertex="1" parent="28">
+          <mxGeometry x="610" y="30" width="120" height="90" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/diagrams/auth-flow.drawio
+++ b/docs/diagrams/auth-flow.drawio
@@ -1,0 +1,154 @@
+<mxfile host="app.diagrams.net" type="device">
+  <diagram id="auth" name="Auth Flow">
+    <mxGraphModel dx="1200" dy="1000" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <mxCell id="2" value="unic &#8212; Auth Flow Decision Tree" style="text;html=1;align=center;verticalAlign=middle;fontSize=20;fontStyle=1;fillColor=none;strokeColor=none;fontColor=#333333;" vertex="1" parent="1">
+          <mxGeometry x="220" y="10" width="400" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="3" value="Context Selected&#xa;(Enter on Context Picker)" style="ellipse;whiteSpace=wrap;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="310" y="70" width="200" height="60" as="geometry"/>
+        </mxCell>
+        <mxCell id="4" value="config.SetCurrent()&#xa;Update YAML" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="330" y="160" width="160" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="5" value="config.Load()&#xa;CLI flags &gt; context &gt; defaults &gt; hardcoded" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="300" y="230" width="220" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="6" value="cfg.AuthType?" style="rhombus;whiteSpace=wrap;fillColor=#fff2cc;strokeColor=#d6b656;fontColor=#333333;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="340" y="310" width="140" height="80" as="geometry"/>
+        </mxCell>
+        <mxCell id="7" value="SSO Path" style="swimlane;startSize=25;fillColor=#d5e8d4;strokeColor=#82b366;rounded=1;fontSize=12;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="30" y="430" width="220" height="330" as="geometry"/>
+        </mxCell>
+        <mxCell id="8" value="BuildSSOLoginCmd()&#xa;Create temp config if needed" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=10;" vertex="1" parent="7">
+          <mxGeometry x="10" y="35" width="200" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="9" value="tea.ExecProcess()&#xa;Suspend TUI" style="rounded=1;whiteSpace=wrap;fillColor=#e1d5e7;strokeColor=#9673a6;fontColor=#333333;fontSize=10;" vertex="1" parent="7">
+          <mxGeometry x="10" y="85" width="200" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="10" value="aws sso login --profile ...&#xa;Opens browser for auth" style="rounded=1;whiteSpace=wrap;fillColor=#fff2cc;strokeColor=#d6b656;fontColor=#333333;fontSize=10;" vertex="1" parent="7">
+          <mxGeometry x="10" y="130" width="200" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="11" value="cleanup()&#xa;Remove temp config dir" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=10;" vertex="1" parent="7">
+          <mxGeometry x="10" y="180" width="200" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="12" value="resolveSSOCredentials()&#xa;Read ~/.aws/sso/cache/{sha1}.json&#xa;sso.GetRoleCredentials()" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=10;" vertex="1" parent="7">
+          <mxGeometry x="10" y="225" width="200" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="13" value="StaticCredentialsProvider&#xa;(temp AccessKey + SessionToken)" style="rounded=1;whiteSpace=wrap;fillColor=#d5e8d4;strokeColor=#82b366;fontColor=#333333;fontSize=10;" vertex="1" parent="7">
+          <mxGeometry x="10" y="285" width="200" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="14" style="strokeColor=#999999;" edge="1" source="8" target="9" parent="7">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="15" style="strokeColor=#999999;" edge="1" source="9" target="10" parent="7">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="16" style="strokeColor=#999999;" edge="1" source="10" target="11" parent="7">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="17" style="strokeColor=#999999;" edge="1" source="11" target="12" parent="7">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="18" style="strokeColor=#999999;" edge="1" source="12" target="13" parent="7">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="19" value="Credential Path" style="swimlane;startSize=25;fillColor=#dae8fc;strokeColor=#6c8ebf;rounded=1;fontSize=12;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="300" y="430" width="220" height="200" as="geometry"/>
+        </mxCell>
+        <mxCell id="20" value="Read ~/.aws/credentials&#xa;Find [profile] section" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=10;" vertex="1" parent="19">
+          <mxGeometry x="10" y="35" width="200" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="21" value="LoadBaseConfig()&#xa;SharedConfigProfile(profile)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=10;" vertex="1" parent="19">
+          <mxGeometry x="10" y="85" width="200" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="22" value="AWS SDK Credential Chain&#xa;(env vars, credentials file, instance role)" style="rounded=1;whiteSpace=wrap;fillColor=#dae8fc;strokeColor=#6c8ebf;fontColor=#333333;fontSize=10;" vertex="1" parent="19">
+          <mxGeometry x="10" y="145" width="200" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="23" style="strokeColor=#999999;" edge="1" source="20" target="21" parent="19">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="24" style="strokeColor=#999999;" edge="1" source="21" target="22" parent="19">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="25" value="AssumeRole Path" style="swimlane;startSize=25;fillColor=#f8cecc;strokeColor=#b85450;rounded=1;fontSize=12;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="570" y="430" width="240" height="330" as="geometry"/>
+        </mxCell>
+        <mxCell id="26" value="LoadBaseConfig()&#xa;Load base profile credentials" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=10;" vertex="1" parent="25">
+          <mxGeometry x="10" y="35" width="220" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="27" value="sts.AssumeRole()&#xa;RoleArn + ExternalID (optional)&#xa;SessionName: &quot;unic-session&quot;" style="rounded=1;whiteSpace=wrap;fillColor=#fff2cc;strokeColor=#d6b656;fontColor=#333333;fontSize=10;" vertex="1" parent="25">
+          <mxGeometry x="10" y="85" width="220" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="28" value="Extract temp credentials&#xa;AccessKeyId + SecretAccessKey&#xa;+ SessionToken" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=10;" vertex="1" parent="25">
+          <mxGeometry x="10" y="150" width="220" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="29" value="Build export string&#xa;export AWS_ACCESS_KEY_ID=...&#xa;export AWS_SECRET_ACCESS_KEY=...&#xa;export AWS_SESSION_TOKEN=..." style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=10;" vertex="1" parent="25">
+          <mxGeometry x="10" y="215" width="220" height="60" as="geometry"/>
+        </mxCell>
+        <mxCell id="30" value="Copy to clipboard&#xa;(fallback: display inline)" style="rounded=1;whiteSpace=wrap;fillColor=#f8cecc;strokeColor=#b85450;fontColor=#333333;fontSize=10;" vertex="1" parent="25">
+          <mxGeometry x="10" y="285" width="220" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="31" style="strokeColor=#999999;" edge="1" source="26" target="27" parent="25">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="32" style="strokeColor=#999999;" edge="1" source="27" target="28" parent="25">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="33" style="strokeColor=#999999;" edge="1" source="28" target="29" parent="25">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="34" style="strokeColor=#999999;" edge="1" source="29" target="30" parent="25">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="35" value="All Paths Converge" style="swimlane;startSize=25;fillColor=#e1d5e7;strokeColor=#9673a6;rounded=1;fontSize=12;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="270" y="800" width="280" height="130" as="geometry"/>
+        </mxCell>
+        <mxCell id="36" value="NewAwsRepository(cfg)&#xa;Create all AWS service clients" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=10;" vertex="1" parent="35">
+          <mxGeometry x="10" y="30" width="260" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="37" value="GetCallerIdentity()&#xa;Verify credentials work, display ARN" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=10;" vertex="1" parent="35">
+          <mxGeometry x="10" y="80" width="260" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="38" style="strokeColor=#999999;" edge="1" source="36" target="37" parent="35">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="39" value="Return to&#xa;Previous Screen" style="ellipse;whiteSpace=wrap;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=11;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="345" y="960" width="130" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="40" style="strokeColor=#666666;" edge="1" source="3" target="4" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="41" style="strokeColor=#666666;" edge="1" source="4" target="5" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="42" style="strokeColor=#666666;" edge="1" source="5" target="6" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="43" value="sso" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#82b366;fontColor=#333333;fontSize=11;fontStyle=1;" edge="1" source="6" target="7" parent="1">
+          <mxGeometry relative="1" as="geometry"><Array as="points"><mxPoint x="340" y="350"/><mxPoint x="140" y="350"/></Array></mxGeometry>
+        </mxCell>
+        <mxCell id="44" value="credential" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#6c8ebf;fontColor=#333333;fontSize=11;fontStyle=1;" edge="1" source="6" target="19" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="45" value="assume_role" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#b85450;fontColor=#333333;fontSize=11;fontStyle=1;" edge="1" source="6" target="25" parent="1">
+          <mxGeometry relative="1" as="geometry"><Array as="points"><mxPoint x="480" y="350"/><mxPoint x="690" y="350"/></Array></mxGeometry>
+        </mxCell>
+        <mxCell id="46" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#82b366;" edge="1" source="7" target="35" parent="1">
+          <mxGeometry relative="1" as="geometry"><Array as="points"><mxPoint x="140" y="790"/><mxPoint x="410" y="790"/></Array></mxGeometry>
+        </mxCell>
+        <mxCell id="47" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#6c8ebf;" edge="1" source="19" target="35" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="48" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#b85450;" edge="1" source="25" target="35" parent="1">
+          <mxGeometry relative="1" as="geometry"><Array as="points"><mxPoint x="690" y="790"/><mxPoint x="410" y="790"/></Array></mxGeometry>
+        </mxCell>
+        <mxCell id="49" style="strokeColor=#666666;" edge="1" source="35" target="39" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/diagrams/config-resolution.drawio
+++ b/docs/diagrams/config-resolution.drawio
@@ -1,0 +1,100 @@
+<mxfile host="app.diagrams.net" type="device">
+  <diagram id="config" name="Config Resolution">
+    <mxGraphModel dx="1200" dy="900" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="900" math="0" shadow="0">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <mxCell id="2" value="unic &#8212; Config Resolution Priority Chain" style="text;html=1;align=center;verticalAlign=middle;fontSize=20;fontStyle=1;fillColor=none;strokeColor=none;fontColor=#333333;" vertex="1" parent="1">
+          <mxGeometry x="130" y="10" width="440" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="3" value="config.Load()&#xa;Entry Point" style="ellipse;whiteSpace=wrap;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=12;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="270" y="70" width="160" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="4" value="Priority 5: Hardcoded Defaults&#xa;region = &quot;us-east-1&quot;&#xa;profile = &quot;&quot;" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=11;align=left;spacingLeft=10;" vertex="1" parent="1">
+          <mxGeometry x="220" y="150" width="260" height="55" as="geometry"/>
+        </mxCell>
+        <mxCell id="5" value="Legacy flat format&#xa;in config.yaml?" style="rhombus;whiteSpace=wrap;fillColor=#fff2cc;strokeColor=#d6b656;fontColor=#333333;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="285" y="235" width="130" height="70" as="geometry"/>
+        </mxCell>
+        <mxCell id="6" value="Priority 4: Legacy Flat Format&#xa;fc.DefaultProfile (if not &quot;default&quot;)&#xa;fc.DefaultRegion" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=10;align=left;spacingLeft=10;" vertex="1" parent="1">
+          <mxGeometry x="460" y="235" width="220" height="55" as="geometry"/>
+        </mxCell>
+        <mxCell id="7" value="Defaults section&#xa;exists?" style="rhombus;whiteSpace=wrap;fillColor=#fff2cc;strokeColor=#d6b656;fontColor=#333333;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="285" y="335" width="130" height="70" as="geometry"/>
+        </mxCell>
+        <mxCell id="8" value="Priority 3: Config Defaults Section&#xa;fc.Defaults.Region" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=10;align=left;spacingLeft=10;" vertex="1" parent="1">
+          <mxGeometry x="460" y="340" width="220" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="9" value="Current context&#xa;set?" style="rhombus;whiteSpace=wrap;fillColor=#fff2cc;strokeColor=#d6b656;fontColor=#333333;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="285" y="435" width="130" height="70" as="geometry"/>
+        </mxCell>
+        <mxCell id="10" value="Priority 2: Current Context" style="swimlane;startSize=25;fillColor=#d5e8d4;strokeColor=#82b366;rounded=1;fontSize=11;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="460" y="420" width="230" height="200" as="geometry"/>
+        </mxCell>
+        <mxCell id="11" value="context_name&#xa;auth_type (sso / credential / assume_role)&#xa;profile&#xa;region" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=9;align=left;spacingLeft=8;" vertex="1" parent="10">
+          <mxGeometry x="10" y="30" width="210" height="60" as="geometry"/>
+        </mxCell>
+        <mxCell id="12" value="SSO fields:&#xa;sso_start_url&#xa;sso_account_id&#xa;sso_role_name" style="rounded=1;whiteSpace=wrap;fillColor=#d5e8d4;strokeColor=#82b366;fontColor=#333333;fontSize=9;align=left;spacingLeft=8;" vertex="1" parent="10">
+          <mxGeometry x="10" y="95" width="100" height="60" as="geometry"/>
+        </mxCell>
+        <mxCell id="13" value="AssumeRole:&#xa;role_arn&#xa;external_id" style="rounded=1;whiteSpace=wrap;fillColor=#f8cecc;strokeColor=#b85450;fontColor=#333333;fontSize=9;align=left;spacingLeft=8;" vertex="1" parent="10">
+          <mxGeometry x="120" y="95" width="100" height="60" as="geometry"/>
+        </mxCell>
+        <mxCell id="14" value="normalizeAuthType()&#xa;sso, credential(s), assume_role / assume-role" style="rounded=1;whiteSpace=wrap;fillColor=#fff2cc;strokeColor=#d6b656;fontColor=#333333;fontSize=9;" vertex="1" parent="10">
+          <mxGeometry x="10" y="160" width="210" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="15" value="CLI flags&#xa;provided?" style="rhombus;whiteSpace=wrap;fillColor=#fff2cc;strokeColor=#d6b656;fontColor=#333333;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="285" y="545" width="130" height="70" as="geometry"/>
+        </mxCell>
+        <mxCell id="16" value="Priority 1: CLI Flags (Highest)&#xa;--profile (-p) overrides profile&#xa;--region overrides region" style="rounded=1;whiteSpace=wrap;fillColor=#dae8fc;strokeColor=#6c8ebf;fontColor=#333333;fontSize=10;fontStyle=1;align=left;spacingLeft=10;" vertex="1" parent="1">
+          <mxGeometry x="460" y="545" width="230" height="55" as="geometry"/>
+        </mxCell>
+        <mxCell id="17" value="Final Config Struct" style="swimlane;startSize=25;fillColor=#e1d5e7;strokeColor=#9673a6;rounded=1;fontSize=12;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="220" y="660" width="260" height="140" as="geometry"/>
+        </mxCell>
+        <mxCell id="18" value="Profile: string&#xa;Region: string&#xa;ContextName: string&#xa;AuthType: (sso | credential | assume_role)&#xa;RoleArn: string&#xa;ExternalID: string&#xa;SSOStartURL: string&#xa;SSOAccountID: string&#xa;SSORoleName: string" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=9;align=left;spacingLeft=10;" vertex="1" parent="17">
+          <mxGeometry x="10" y="30" width="240" height="100" as="geometry"/>
+        </mxCell>
+        <mxCell id="19" value="~/.config/unic/config.yaml" style="swimlane;startSize=25;fillColor=#f5f5f5;strokeColor=#666666;rounded=1;fontSize=11;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="20" y="235" width="220" height="280" as="geometry"/>
+        </mxCell>
+        <mxCell id="20" value="default_region: ap-northeast-2&#xa;default_profile: my-profile&#xa;&#xa;defaults:&#xa;  region: us-west-2&#xa;&#xa;current: prod-sso&#xa;&#xa;contexts:&#xa;  - name: prod-sso&#xa;    auth_type: sso&#xa;    region: ap-northeast-2&#xa;    sso_start_url: https://...&#xa;    sso_account_id: &quot;123456&quot;&#xa;    sso_role_name: Admin&#xa;&#xa;  - name: staging&#xa;    auth_type: assume_role&#xa;    profile: base-profile&#xa;    role_arn: arn:aws:iam::..." style="text;whiteSpace=wrap;fillColor=none;strokeColor=none;fontColor=#666666;fontSize=9;fontFamily=Courier New;align=left;spacingLeft=5;" vertex="1" parent="19">
+          <mxGeometry x="5" y="30" width="210" height="245" as="geometry"/>
+        </mxCell>
+        <mxCell id="21" style="strokeColor=#666666;" edge="1" source="3" target="4" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="22" style="strokeColor=#666666;" edge="1" source="4" target="5" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="23" value="yes" style="strokeColor=#82b366;fontColor=#333333;fontSize=9;" edge="1" source="5" target="6" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="24" style="strokeColor=#666666;" edge="1" source="5" target="7" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="25" value="yes" style="strokeColor=#82b366;fontColor=#333333;fontSize=9;" edge="1" source="7" target="8" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="26" style="strokeColor=#666666;" edge="1" source="7" target="9" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="27" value="yes" style="strokeColor=#82b366;fontColor=#333333;fontSize=9;" edge="1" source="9" target="10" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="28" style="strokeColor=#666666;" edge="1" source="9" target="15" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="29" value="yes" style="strokeColor=#82b366;fontColor=#333333;fontSize=9;" edge="1" source="15" target="16" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="30" style="strokeColor=#666666;" edge="1" source="15" target="17" parent="1">
+          <mxGeometry relative="1" as="geometry"><Array as="points"><mxPoint x="350" y="640"/><mxPoint x="350" y="640"/></Array></mxGeometry>
+        </mxCell>
+        <mxCell id="31" value="Each priority level overrides&#xa;values set by lower priorities.&#xa;Empty/unset values are skipped." style="text;html=1;align=left;verticalAlign=middle;fontSize=9;fillColor=none;strokeColor=none;fontColor=#999999;" vertex="1" parent="1">
+          <mxGeometry x="510" y="660" width="200" height="45" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/diagrams/screen-navigation.drawio
+++ b/docs/diagrams/screen-navigation.drawio
@@ -1,0 +1,283 @@
+<mxfile host="app.diagrams.net" type="device">
+  <diagram id="nav" name="Screen Navigation">
+    <mxGraphModel dx="1400" dy="900" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1100" pageHeight="850" math="0" shadow="0">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <mxCell id="2" value="unic &#8212; Screen Navigation State Machine" style="text;html=1;align=center;verticalAlign=middle;fontSize=20;fontStyle=1;fillColor=none;strokeColor=none;fontColor=#333333;" vertex="1" parent="1">
+          <mxGeometry x="300" y="10" width="500" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="3" value="Global Keys: H=Home  C=Context  /=Filter  Esc/q=Back  Enter=Select  Ctrl+C=Quit" style="text;html=1;align=center;verticalAlign=middle;fontSize=11;fillColor=#fff2cc;strokeColor=#d6b656;rounded=1;" vertex="1" parent="1">
+          <mxGeometry x="280" y="55" width="540" height="25" as="geometry"/>
+        </mxCell>
+        <mxCell id="4" value="Context Picker&#xa;(37)" style="rounded=1;whiteSpace=wrap;fillColor=#d5e8d4;strokeColor=#82b366;fontStyle=1;fontSize=13;" vertex="1" parent="1">
+          <mxGeometry x="460" y="100" width="140" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="5" value="Context Add&#xa;Wizard (38)" style="rounded=1;whiteSpace=wrap;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="650" y="100" width="110" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="6" value="Service List&#xa;(0)" style="rounded=1;whiteSpace=wrap;fillColor=#dae8fc;strokeColor=#6c8ebf;fontStyle=1;fontSize=13;" vertex="1" parent="1">
+          <mxGeometry x="460" y="190" width="140" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="7" value="Feature List&#xa;(1)" style="rounded=1;whiteSpace=wrap;fillColor=#dae8fc;strokeColor=#6c8ebf;fontStyle=1;fontSize=13;" vertex="1" parent="1">
+          <mxGeometry x="460" y="280" width="140" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="8" value="Loading&#xa;(39)" style="ellipse;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="310" y="280" width="80" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="9" value="Error&#xa;(40)" style="ellipse;whiteSpace=wrap;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="670" y="280" width="80" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="10" value="EC2 / SSM" style="swimlane;startSize=20;fillColor=#fff2cc;strokeColor=#d6b656;rounded=1;fontSize=11;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="20" y="380" width="150" height="90" as="geometry"/>
+        </mxCell>
+        <mxCell id="11" value="Instance List (2)&#xa;Enter &#8594; SSM Session" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="10">
+          <mxGeometry x="10" y="30" width="130" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="12" value="VPC Browser" style="swimlane;startSize=20;fillColor=#fff2cc;strokeColor=#d6b656;rounded=1;fontSize=11;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="190" y="380" width="150" height="160" as="geometry"/>
+        </mxCell>
+        <mxCell id="13" value="VPC List (3)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="12">
+          <mxGeometry x="10" y="25" width="130" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="14" value="Subnet List (4)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="12">
+          <mxGeometry x="10" y="70" width="130" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="15" value="Subnet Detail (5)&#xa;Available IPs" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="12">
+          <mxGeometry x="10" y="115" width="130" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="16" value="RDS Browser" style="swimlane;startSize=20;fillColor=#fff2cc;strokeColor=#d6b656;rounded=1;fontSize=11;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="360" y="380" width="150" height="160" as="geometry"/>
+        </mxCell>
+        <mxCell id="17" value="RDS List (6)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="16">
+          <mxGeometry x="10" y="25" width="130" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="18" value="RDS Detail (7)&#xa;start/stop/failover" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="16">
+          <mxGeometry x="10" y="70" width="130" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="19" value="RDS Confirm (8)&#xa;type-to-confirm" style="rounded=1;whiteSpace=wrap;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;" vertex="1" parent="16">
+          <mxGeometry x="10" y="115" width="130" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="20" value="Route53 DNS" style="swimlane;startSize=20;fillColor=#fff2cc;strokeColor=#d6b656;rounded=1;fontSize=11;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="530" y="380" width="160" height="250" as="geometry"/>
+        </mxCell>
+        <mxCell id="21" value="Zone List (9)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="20">
+          <mxGeometry x="10" y="25" width="140" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="22" value="Record List (10)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="20">
+          <mxGeometry x="10" y="65" width="140" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="23" value="Record Detail (11)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="20">
+          <mxGeometry x="10" y="105" width="140" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="24" value="Create Record (12)" style="rounded=1;whiteSpace=wrap;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="20">
+          <mxGeometry x="10" y="145" width="140" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="25" value="Edit Record (13)" style="rounded=1;whiteSpace=wrap;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="20">
+          <mxGeometry x="10" y="185" width="65" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="26" value="Delete (14)" style="rounded=1;whiteSpace=wrap;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;" vertex="1" parent="20">
+          <mxGeometry x="85" y="185" width="65" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="27" value="Security Groups" style="swimlane;startSize=20;fillColor=#fff2cc;strokeColor=#d6b656;rounded=1;fontSize=11;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="710" y="380" width="150" height="205" as="geometry"/>
+        </mxCell>
+        <mxCell id="28" value="SG List (17)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="27">
+          <mxGeometry x="10" y="25" width="130" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="29" value="SG Detail (18)&#xa;Inbound / Outbound" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="27">
+          <mxGeometry x="10" y="70" width="130" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="30" value="Add Rule (19)&#xa;Multi-field form" style="rounded=1;whiteSpace=wrap;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="27">
+          <mxGeometry x="10" y="115" width="130" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="31" value="Delete Rule (20)&#xa;type-to-confirm" style="rounded=1;whiteSpace=wrap;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;" vertex="1" parent="27">
+          <mxGeometry x="10" y="160" width="130" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="32" value="IAM" style="swimlane;startSize=20;fillColor=#fff2cc;strokeColor=#d6b656;rounded=1;fontSize=11;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="20" y="560" width="300" height="160" as="geometry"/>
+        </mxCell>
+        <mxCell id="33" value="User List (21)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="32">
+          <mxGeometry x="10" y="25" width="90" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="34" value="User Detail (22)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="32">
+          <mxGeometry x="10" y="70" width="90" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="35" value="Key List (23)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="32">
+          <mxGeometry x="120" y="25" width="90" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="36" value="Key Detail (24)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="32">
+          <mxGeometry x="120" y="70" width="90" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="37" value="Rotate Confirm (25)" style="rounded=1;whiteSpace=wrap;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;" vertex="1" parent="32">
+          <mxGeometry x="120" y="115" width="90" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="38" value="Rotate Result (26)&#xa;copy/apply/deactivate/delete" style="rounded=1;whiteSpace=wrap;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="32">
+          <mxGeometry x="10" y="115" width="100" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="39" value="CloudWatch Logs" style="swimlane;startSize=20;fillColor=#fff2cc;strokeColor=#d6b656;rounded=1;fontSize=11;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="340" y="560" width="150" height="160" as="geometry"/>
+        </mxCell>
+        <mxCell id="40" value="Log Groups (27)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="39">
+          <mxGeometry x="10" y="25" width="130" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="41" value="Log Streams (28)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="39">
+          <mxGeometry x="10" y="70" width="130" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="42" value="Log Viewer (29)&#xa;live tail / time range" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="39">
+          <mxGeometry x="10" y="115" width="130" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="43" value="ECS Exec" style="swimlane;startSize=20;fillColor=#fff2cc;strokeColor=#d6b656;rounded=1;fontSize=11;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="510" y="560" width="150" height="200" as="geometry"/>
+        </mxCell>
+        <mxCell id="44" value="Clusters (30)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="43">
+          <mxGeometry x="10" y="25" width="130" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="45" value="Services (31)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="43">
+          <mxGeometry x="10" y="70" width="130" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="46" value="Tasks (32)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="43">
+          <mxGeometry x="10" y="115" width="130" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="47" value="Containers (33)&#xa;Enter &#8594; ECS Exec" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="43">
+          <mxGeometry x="10" y="160" width="130" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="48" value="S3 Browser" style="swimlane;startSize=20;fillColor=#fff2cc;strokeColor=#d6b656;rounded=1;fontSize=11;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="680" y="560" width="150" height="160" as="geometry"/>
+        </mxCell>
+        <mxCell id="49" value="Buckets (34)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="48">
+          <mxGeometry x="10" y="25" width="130" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="50" value="Objects (35)&#xa;prefix stack nav" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="48">
+          <mxGeometry x="10" y="70" width="130" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="51" value="Object Detail (36)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="48">
+          <mxGeometry x="10" y="115" width="130" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="52" value="Secrets Manager" style="swimlane;startSize=20;fillColor=#fff2cc;strokeColor=#d6b656;rounded=1;fontSize=11;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="850" y="560" width="140" height="110" as="geometry"/>
+        </mxCell>
+        <mxCell id="53" value="Secret List (15)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="52">
+          <mxGeometry x="10" y="25" width="120" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="54" value="Secret Detail (16)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;" vertex="1" parent="52">
+          <mxGeometry x="10" y="65" width="120" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="55" value="Enter" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#82b366;fontColor=#333333;fontSize=10;" edge="1" source="4" target="6" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="56" value="a" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#82b366;fontColor=#333333;fontSize=10;" edge="1" source="4" target="5" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="57" value="Enter" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#6c8ebf;fontColor=#333333;fontSize=10;" edge="1" source="6" target="7" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="58" value="C" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#82b366;fontColor=#333333;fontSize=10;dashed=1;" edge="1" source="6" target="4" parent="1">
+          <mxGeometry relative="1" as="geometry"><Array as="points"><mxPoint x="420" y="215"/><mxPoint x="420" y="125"/></Array></mxGeometry>
+        </mxCell>
+        <mxCell id="59" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#d6b656;fontSize=10;" edge="1" source="7" target="10" parent="1">
+          <mxGeometry relative="1" as="geometry"><Array as="points"><mxPoint x="460" y="350"/><mxPoint x="95" y="350"/></Array></mxGeometry>
+        </mxCell>
+        <mxCell id="60" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#d6b656;fontSize=10;" edge="1" source="7" target="12" parent="1">
+          <mxGeometry relative="1" as="geometry"><Array as="points"><mxPoint x="480" y="350"/><mxPoint x="265" y="350"/></Array></mxGeometry>
+        </mxCell>
+        <mxCell id="61" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#d6b656;fontSize=10;" edge="1" source="7" target="16" parent="1">
+          <mxGeometry relative="1" as="geometry"><Array as="points"><mxPoint x="500" y="350"/><mxPoint x="435" y="350"/></Array></mxGeometry>
+        </mxCell>
+        <mxCell id="62" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#d6b656;fontSize=10;" edge="1" source="7" target="20" parent="1">
+          <mxGeometry relative="1" as="geometry"><Array as="points"><mxPoint x="530" y="350"/><mxPoint x="610" y="350"/></Array></mxGeometry>
+        </mxCell>
+        <mxCell id="63" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#d6b656;fontSize=10;" edge="1" source="7" target="27" parent="1">
+          <mxGeometry relative="1" as="geometry"><Array as="points"><mxPoint x="560" y="360"/><mxPoint x="785" y="360"/></Array></mxGeometry>
+        </mxCell>
+        <mxCell id="64" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#999999;fontSize=9;" edge="1" source="13" target="14" parent="12">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="65" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#999999;fontSize=9;" edge="1" source="14" target="15" parent="12">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="66" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#999999;fontSize=9;" edge="1" source="17" target="18" parent="16">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="67" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#999999;fontSize=9;" edge="1" source="18" target="19" parent="16">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="68" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#999999;fontSize=9;" edge="1" source="21" target="22" parent="20">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="69" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#999999;fontSize=9;" edge="1" source="22" target="23" parent="20">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="70" value="c" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#82b366;fontColor=#333333;fontSize=9;" edge="1" source="23" target="24" parent="20">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="71" value="e" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#6c8ebf;fontColor=#333333;fontSize=9;exitX=0;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="23" target="25" parent="20">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="72" value="d" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#b85450;fontColor=#333333;fontSize=9;exitX=1;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="23" target="26" parent="20">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="73" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#999999;fontSize=9;" edge="1" source="28" target="29" parent="27">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="74" value="a" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#82b366;fontColor=#333333;fontSize=9;" edge="1" source="29" target="30" parent="27">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="75" value="d" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#b85450;fontColor=#333333;fontSize=9;" edge="1" source="29" target="31" parent="27">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="76" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#999999;fontSize=9;" edge="1" source="33" target="34" parent="32">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="77" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#999999;fontSize=9;" edge="1" source="35" target="36" parent="32">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="78" value="r" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#b85450;fontColor=#333333;fontSize=9;" edge="1" source="36" target="37" parent="32">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="79" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#999999;fontSize=9;" edge="1" source="37" target="38" parent="32">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="80" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#999999;fontSize=9;" edge="1" source="40" target="41" parent="39">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="81" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#999999;fontSize=9;" edge="1" source="41" target="42" parent="39">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="82" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#999999;fontSize=9;" edge="1" source="44" target="45" parent="43">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="83" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#999999;fontSize=9;" edge="1" source="45" target="46" parent="43">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="84" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#999999;fontSize=9;" edge="1" source="46" target="47" parent="43">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="85" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#999999;fontSize=9;" edge="1" source="49" target="50" parent="48">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="86" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#999999;fontSize=9;" edge="1" source="50" target="51" parent="48">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="87" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#999999;fontSize=9;" edge="1" source="53" target="54" parent="52">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="88" value="Color Legend:" style="text;html=1;align=left;verticalAlign=middle;fontSize=10;fontStyle=1;fillColor=none;strokeColor=none;fontColor=#333333;" vertex="1" parent="1">
+          <mxGeometry x="870" y="380" width="80" height="20" as="geometry"/>
+        </mxCell>
+        <mxCell id="89" value="Create / Add" style="rounded=1;whiteSpace=wrap;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="870" y="405" width="80" height="25" as="geometry"/>
+        </mxCell>
+        <mxCell id="90" value="Destructive" style="rounded=1;whiteSpace=wrap;fillColor=#f8cecc;strokeColor=#b85450;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="870" y="435" width="80" height="25" as="geometry"/>
+        </mxCell>
+        <mxCell id="91" value="Navigation" style="rounded=1;whiteSpace=wrap;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="870" y="465" width="80" height="25" as="geometry"/>
+        </mxCell>
+        <mxCell id="92" value="Read-only" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="870" y="495" width="80" height="25" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/diagrams/subprocess-handoff.drawio
+++ b/docs/diagrams/subprocess-handoff.drawio
@@ -1,0 +1,157 @@
+<mxfile host="app.diagrams.net" type="device">
+  <diagram id="subproc" name="Subprocess Handoff">
+    <mxGraphModel dx="1200" dy="800" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="750" math="0" shadow="0">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <mxCell id="2" value="unic &#8212; Subprocess Handoff via tea.ExecProcess" style="text;html=1;align=center;verticalAlign=middle;fontSize=20;fontStyle=1;fillColor=none;strokeColor=none;fontColor=#333333;" vertex="1" parent="1">
+          <mxGeometry x="150" y="10" width="500" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="3" value="TUI Active" style="swimlane;startSize=25;fillColor=#d5e8d4;strokeColor=#82b366;rounded=1;fontSize=12;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="30" y="70" width="270" height="570" as="geometry"/>
+        </mxCell>
+        <mxCell id="4" value="User selects item&#xa;(Enter on instance / container)" style="ellipse;whiteSpace=wrap;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="3">
+          <mxGeometry x="50" y="35" width="170" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="5" value="Cmd closure runs in goroutine" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=10;" vertex="1" parent="3">
+          <mxGeometry x="50" y="100" width="170" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="6" value="SSM: repo.StartSession()&#xa;Get session ID + endpoint" style="rounded=1;whiteSpace=wrap;fillColor=#fff2cc;strokeColor=#d6b656;fontColor=#333333;fontSize=10;" vertex="1" parent="3">
+          <mxGeometry x="10" y="150" width="120" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="7" value="ECS: repo.ResolveCredentialEnv()&#xa;Get temp creds for subprocess" style="rounded=1;whiteSpace=wrap;fillColor=#fff2cc;strokeColor=#d6b656;fontColor=#333333;fontSize=10;" vertex="1" parent="3">
+          <mxGeometry x="140" y="150" width="120" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="8" value="Build exec.Cmd&#xa;(not executed yet)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=10;fontStyle=1;" vertex="1" parent="3">
+          <mxGeometry x="50" y="220" width="170" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="9" value="SSM:&#xa;BuildPluginCommand()&#xa;session-manager-plugin&#xa;+ session JSON args" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=9;" vertex="1" parent="3">
+          <mxGeometry x="10" y="270" width="120" height="60" as="geometry"/>
+        </mxCell>
+        <mxCell id="10" value="ECS:&#xa;BuildECSExecCommand()&#xa;aws ecs execute-command&#xa;+ credential env vars" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=9;" vertex="1" parent="3">
+          <mxGeometry x="140" y="270" width="120" height="60" as="geometry"/>
+        </mxCell>
+        <mxCell id="11" value="tea.ExecProcess(cmd, callback)&#xa;Return as tea.Cmd" style="rounded=1;whiteSpace=wrap;fillColor=#e1d5e7;strokeColor=#9673a6;fontColor=#333333;fontSize=10;fontStyle=1;" vertex="1" parent="3">
+          <mxGeometry x="35" y="350" width="200" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="12" style="strokeColor=#999999;" edge="1" source="4" target="5" parent="3">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="13" style="strokeColor=#999999;" edge="1" source="5" target="6" parent="3">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="14" style="strokeColor=#999999;" edge="1" source="5" target="7" parent="3">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="15" style="strokeColor=#999999;" edge="1" source="6" target="8" parent="3">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="16" style="strokeColor=#999999;" edge="1" source="7" target="8" parent="3">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="17" style="strokeColor=#999999;" edge="1" source="8" target="9" parent="3">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="18" style="strokeColor=#999999;" edge="1" source="8" target="10" parent="3">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="19" style="strokeColor=#999999;" edge="1" source="9" target="11" parent="3">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="20" style="strokeColor=#999999;" edge="1" source="10" target="11" parent="3">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="21" value="TUI Suspended (Subprocess Active)" style="swimlane;startSize=25;fillColor=#f8cecc;strokeColor=#b85450;rounded=1;fontSize=12;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="330" y="70" width="220" height="570" as="geometry"/>
+        </mxCell>
+        <mxCell id="22" value="Bubbletea clears screen&#xa;Releases terminal to subprocess" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=10;" vertex="1" parent="21">
+          <mxGeometry x="10" y="45" width="200" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="23" value="Subprocess runs in foreground&#xa;stdin/stdout/stderr connected" style="rounded=1;whiteSpace=wrap;fillColor=#fff2cc;strokeColor=#d6b656;fontColor=#333333;fontSize=10;fontStyle=1;" vertex="1" parent="21">
+          <mxGeometry x="10" y="115" width="200" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="24" value="SIGINT ignored by TUI&#xa;(subprocess handles Ctrl+C)" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=10;" vertex="1" parent="21">
+          <mxGeometry x="10" y="185" width="200" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="25" value="SSM: Interactive shell&#xa;session-manager-plugin&#xa;running" style="rounded=1;whiteSpace=wrap;fillColor=#f8cecc;strokeColor=#b85450;fontColor=#333333;fontSize=10;" vertex="1" parent="21">
+          <mxGeometry x="10" y="255" width="90" height="60" as="geometry"/>
+        </mxCell>
+        <mxCell id="26" value="ECS: Interactive shell&#xa;aws ecs execute-command&#xa;running" style="rounded=1;whiteSpace=wrap;fillColor=#f8cecc;strokeColor=#b85450;fontColor=#333333;fontSize=10;" vertex="1" parent="21">
+          <mxGeometry x="110" y="255" width="100" height="60" as="geometry"/>
+        </mxCell>
+        <mxCell id="27" value="User exits shell&#xa;(exit / Ctrl+D)" style="ellipse;whiteSpace=wrap;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;" vertex="1" parent="21">
+          <mxGeometry x="30" y="340" width="160" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="28" value="Subprocess terminates&#xa;Return exit error to callback" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=10;" vertex="1" parent="21">
+          <mxGeometry x="10" y="415" width="200" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="29" value="Callback runs:&#xa;SSM: TerminateSession()&#xa;ECS: (no cleanup)&#xa;SSO: cleanup() temp dir" style="rounded=1;whiteSpace=wrap;fillColor=#e1d5e7;strokeColor=#9673a6;fontColor=#333333;fontSize=10;" vertex="1" parent="21">
+          <mxGeometry x="10" y="480" width="200" height="60" as="geometry"/>
+        </mxCell>
+        <mxCell id="30" style="strokeColor=#999999;" edge="1" source="22" target="23" parent="21">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="31" style="strokeColor=#999999;" edge="1" source="23" target="24" parent="21">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="32" style="strokeColor=#999999;" edge="1" source="24" target="25" parent="21">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="33" style="strokeColor=#999999;" edge="1" source="24" target="26" parent="21">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="34" style="strokeColor=#999999;" edge="1" source="25" target="27" parent="21">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="35" style="strokeColor=#999999;" edge="1" source="26" target="27" parent="21">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="36" style="strokeColor=#999999;" edge="1" source="27" target="28" parent="21">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="37" style="strokeColor=#999999;" edge="1" source="28" target="29" parent="21">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="38" value="TUI Resumed" style="swimlane;startSize=25;fillColor=#d5e8d4;strokeColor=#82b366;rounded=1;fontSize=12;fontStyle=1;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="580" y="70" width="210" height="350" as="geometry"/>
+        </mxCell>
+        <mxCell id="39" value="Callback returns Msg&#xa;ssmSessionDoneMsg /&#xa;ecsExecDoneMsg" style="rounded=1;whiteSpace=wrap;fillColor=#fff2cc;strokeColor=#d6b656;fontColor=#333333;fontSize=10;" vertex="1" parent="38">
+          <mxGeometry x="10" y="45" width="190" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="40" value="Bubbletea restores screen&#xa;Re-renders TUI" style="rounded=1;whiteSpace=wrap;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontSize=10;" vertex="1" parent="38">
+          <mxGeometry x="10" y="115" width="190" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="41" value="Error?" style="rhombus;whiteSpace=wrap;fillColor=#fff2cc;strokeColor=#d6b656;fontColor=#333333;fontSize=10;" vertex="1" parent="38">
+          <mxGeometry x="45" y="185" width="120" height="60" as="geometry"/>
+        </mxCell>
+        <mxCell id="42" value="screen = screenError&#xa;Display error message" style="rounded=1;whiteSpace=wrap;fillColor=#f8cecc;strokeColor=#b85450;fontColor=#333333;fontSize=10;" vertex="1" parent="38">
+          <mxGeometry x="10" y="270" width="90" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="43" value="screen = previous list&#xa;(Instance / Container)" style="rounded=1;whiteSpace=wrap;fillColor=#d5e8d4;strokeColor=#82b366;fontColor=#333333;fontSize=10;" vertex="1" parent="38">
+          <mxGeometry x="110" y="270" width="90" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="44" style="strokeColor=#999999;" edge="1" source="39" target="40" parent="38">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="45" style="strokeColor=#999999;" edge="1" source="40" target="41" parent="38">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="46" value="yes" style="strokeColor=#b85450;fontColor=#333333;fontSize=9;" edge="1" source="41" target="42" parent="38">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="47" value="no" style="strokeColor=#82b366;fontColor=#333333;fontSize=9;" edge="1" source="41" target="43" parent="38">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="48" value="tea.ExecProcess" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#b85450;fontColor=#333333;fontSize=11;fontStyle=1;strokeWidth=2;" edge="1" source="3" target="21" parent="1">
+          <mxGeometry relative="1" as="geometry"><Array as="points"><mxPoint x="310" y="460"/><mxPoint x="310" y="460"/></Array></mxGeometry>
+        </mxCell>
+        <mxCell id="49" value="callback(err) tea.Msg" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#82b366;fontColor=#333333;fontSize=11;fontStyle=1;strokeWidth=2;" edge="1" source="21" target="38" parent="1">
+          <mxGeometry relative="1" as="geometry"><Array as="points"><mxPoint x="565" y="460"/><mxPoint x="565" y="460"/></Array></mxGeometry>
+        </mxCell>
+        <mxCell id="50" value="ECS Credential Injection:&#xa;1. repo.ResolveCredentialEnv()&#xa;2. Strip AWS_PROFILE from env&#xa;3. Inject AWS_ACCESS_KEY_ID,&#xa;   AWS_SECRET_ACCESS_KEY,&#xa;   AWS_SESSION_TOKEN&#xa;4. cmd.Env = credEnv&#xa;&#xa;Prevents AccountID mismatch&#xa;with assume_role contexts" style="rounded=1;whiteSpace=wrap;fillColor=#fff2cc;strokeColor=#d6b656;fontColor=#333333;fontSize=9;align=left;spacingLeft=8;" vertex="1" parent="1">
+          <mxGeometry x="580" y="480" width="210" height="150" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>


### PR DESCRIPTION
### Summary

Add 6 draw.io architecture diagrams under `docs/diagrams/` to help contributors and users understand the codebase:

| Diagram | What it shows |
|---------|---------------|
| `architecture-overview.drawio` | 6-layer structure: CLI → TUI (Bubbletea) → Domain → Services → Infrastructure → External |
| `screen-navigation.drawio` | All 41 screens grouped by AWS service, with transitions and key bindings color-coded |
| `auth-flow.drawio` | Decision tree for SSO / credential / assume_role paths, including PostSwitch behavior |
| `async-data-flow.drawio` | Bubbletea Elm architecture (Cmd/Msg pattern), filter two-slice design, message type catalog |
| `subprocess-handoff.drawio` | tea.ExecProcess lifecycle for SSM and ECS exec sessions with credential injection |
| `config-resolution.drawio` | Priority chain from hardcoded defaults through CLI flags, with YAML example |

All files are native `.drawio` format — editable in draw.io desktop app or [app.diagrams.net](https://app.diagrams.net).

### Related Issues

N/A — documentation addition for contributor onboarding

### Validation

- Verified all 6 files open correctly in draw.io desktop app
- `go test ./...` passes (no Go code changed)

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed — N/A (internal docs only)
- [x] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed — diagrams ARE the docs update
- [x] Tests/validation included
- [x] Breaking changes documented — N/A