### PR TITLE
feat: add security inspector workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It combines a Bubble Tea application, Cobra-based CLI commands, and AWS SDK v2 c
 - Drill down into resources with filters, detail views, and action screens
 - Show animated loading indicators while async AWS data is being fetched
 - Perform operational workflows such as SSM sessions, RDS control, Route53 record changes, ECS exec, and IAM access key rotation
+- Open the Security Inspector workflow and review scan results by severity as rule packs are added
 
 ## Documentation Map
 
@@ -181,6 +182,9 @@ CLI flags > selected context > config defaults > hardcoded default (us-east-1)
 | IAM | IAM User Browser |
 | IAM | ListAccessKeys |
 | IAM | RotateAccessKey |
+| Inspector | Security Scan |
+
+The Inspector feature currently ships the service shell, scan orchestration, and results browser. The first built-in rule packs land in follow-up issues.
 
 ## TUI Navigation
 
@@ -208,6 +212,7 @@ CLI flags > selected context > config defaults > hardcoded default (us-east-1)
 | IAM Key Rotation | `r` rotate, `c` copy exports, `a` apply and verify, `d` deactivate old key, `x` delete old key |
 | CloudWatch Logs | `1`-`6` time presets, `t` live tail, `f` filter pattern, `n` load more |
 | ECS Exec | `r` refresh, `Enter` drill down / exec |
+| Inspector | `r` run/rescan, `1`-`5` severity filter, `Enter` finding detail |
 | Context Picker | `a` add context, `/` filter |
 
 Filtering is currently available on EC2 instances, IAM users, VPCs/subnets, RDS instances, Route53 zones/records, CloudWatch log groups/streams, Secrets Manager resources, ECS clusters/services, S3 buckets/objects, and the context picker.

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -89,6 +89,7 @@ Current repository clients include:
 Pattern:
 
 - `repository.go` initializes SDK clients
+- `inspector*.go` owns Security Inspector scan orchestration and finding models
 - `*_model.go` defines UI-facing data models
 - `*.go` implements service operations
 - tests use mock client interfaces per AWS service
@@ -107,6 +108,7 @@ The app remains centered on a root model, but screen-specific rendering is now s
 - `screen_cloudwatchlogs.go`
 - `screen_ecs.go`
 - `screen_s3.go`
+- `screen_inspector.go`
 - `screen_context.go`
 
 Supporting files include `styles.go`, `filter.go`, and `messages.go`.
@@ -155,6 +157,7 @@ Current screen families include:
 - CloudWatch Logs group/stream/viewer flows
 - ECS cluster/service/task/container flows
 - S3 bucket/object/detail flows
+- Inspector home/scanning/results/detail flows
 - context picker and context add flows
 - loading and error screens
 

--- a/docs/architecture.ko.md
+++ b/docs/architecture.ko.md
@@ -89,6 +89,7 @@ repository와 서비스별 AWS 연동 계층이다.
 패턴:
 
 - `repository.go`에서 SDK client 초기화
+- `inspector*.go`에서 Security Inspector 스캔 orchestration과 finding 모델 관리
 - `*_model.go`에서 UI 친화적 모델 정의
 - `*.go`에서 실제 서비스 로직 구현
 - 테스트에서는 AWS 서비스별 mock interface 사용
@@ -107,6 +108,7 @@ Bubble Tea 앱의 상태, 화면 전환, 렌더링을 담당한다.
 - `screen_cloudwatchlogs.go`
 - `screen_ecs.go`
 - `screen_s3.go`
+- `screen_inspector.go`
 - `screen_context.go`
 
 보조 파일로 `styles.go`, `filter.go`, `messages.go` 등이 있다.
@@ -155,6 +157,7 @@ UNIC은 현재 세 가지 인증 모드를 지원한다.
 - CloudWatch Logs group/stream/viewer
 - ECS cluster/service/task/container
 - S3 bucket/object/detail
+- Inspector home/scanning/results/detail
 - context picker, context add
 - loading, error
 

--- a/docs/project-overview.en.md
+++ b/docs/project-overview.en.md
@@ -19,6 +19,7 @@ Implemented service areas currently include:
 - CloudWatch Logs
 - ECS
 - S3
+- Inspector
 
 The application already includes interactive mutation flows, polling-based status flows, context helpers, and per-service drill-down screens.
 

--- a/docs/project-overview.ko.md
+++ b/docs/project-overview.ko.md
@@ -19,6 +19,7 @@ UNIC은 다음 세 가지를 결합한 Go 기반 AWS 터미널 콘솔이다.
 - CloudWatch Logs
 - ECS
 - S3
+- Inspector
 
 애플리케이션은 이미 상호작용형 변경 작업 플로우, polling 기반 상태 확인, context helper, 서비스별 drill-down 화면을 포함한다.
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -57,6 +57,10 @@ const (
 	screenS3BucketList
 	screenS3ObjectList
 	screenS3ObjectDetail
+	screenInspectorHome
+	screenInspectorScanning
+	screenInspectorResults
+	screenInspectorFindingDetail
 	screenContextPicker
 	screenContextAdd
 	screenLoading
@@ -215,6 +219,13 @@ type Model struct {
 	s3PrefixStack     []string
 	selectedS3Object  *awsservice.S3ObjectDetail
 
+	// Inspector browser state
+	inspectorReport          *awsservice.SecurityScanReport
+	inspectorFindings        []awsservice.SecurityFinding
+	inspectorIdx             int
+	inspectorSeverityFilter  awsservice.RuleSeverity
+	selectedInspectorFinding *awsservice.SecurityFinding
+
 	// Context picker
 	configPath         string
 	ctxList            []config.ContextInfo
@@ -338,7 +349,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case spinner.TickMsg:
-		if m.screen != screenLoading {
+		if m.screen != screenLoading && m.screen != screenInspectorScanning {
 			return m, nil
 		}
 		var cmd tea.Cmd
@@ -361,6 +372,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.handleCloudWatchLogsMsg,
 		m.handleECSMsg,
 		m.handleS3Msg,
+		m.handleInspectorMsg,
 		m.handleContextMsg,
 	} {
 		if newM, cmd, handled := h(msg); handled {
@@ -437,6 +449,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateS3ObjectList(msg)
 		case screenS3ObjectDetail:
 			return m.updateS3ObjectDetail(msg)
+		case screenInspectorHome:
+			return m.updateInspectorHome(msg)
+		case screenInspectorResults:
+			return m.updateInspectorResults(msg)
+		case screenInspectorFindingDetail:
+			return m.updateInspectorFindingDetail(msg)
 		case screenSecurityGroupList:
 			return m.updateSecurityGroupList(msg)
 		case screenSecurityGroupDetail:
@@ -568,6 +586,14 @@ func (m Model) updateFeatureList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m.startLoading(m.loadIAMKeys())
 			case domain.FeatureECSExec:
 				return m.startLoading(m.loadECSClusters())
+			case domain.FeatureSecurityScan:
+				m.inspectorReport = nil
+				m.inspectorFindings = nil
+				m.inspectorIdx = 0
+				m.inspectorSeverityFilter = ""
+				m.selectedInspectorFinding = nil
+				m.screen = screenInspectorHome
+				return m, nil
 			}
 		}
 	}
@@ -639,6 +665,14 @@ func (m Model) View() string {
 		v = m.viewS3ObjectList()
 	case screenS3ObjectDetail:
 		v = m.viewS3ObjectDetail()
+	case screenInspectorHome:
+		v = m.viewInspectorHome()
+	case screenInspectorScanning:
+		v = m.viewInspectorScanning()
+	case screenInspectorResults:
+		v = m.viewInspectorResults()
+	case screenInspectorFindingDetail:
+		v = m.viewInspectorFindingDetail()
 	case screenSecurityGroupList:
 		v = m.viewSecurityGroupList()
 	case screenSecurityGroupDetail:

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1181,6 +1181,115 @@ func TestS3FeatureStartsBucketLoading(t *testing.T) {
 	}
 }
 
+func TestInspectorFeatureEntersHomeScreen(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	for _, svc := range m.services {
+		if svc.Name == domain.ServiceInspector {
+			m.features = svc.Features
+			break
+		}
+	}
+	m.screen = screenFeatureList
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model := updated.(Model)
+	if model.screen != screenInspectorHome {
+		t.Fatalf("expected inspector home screen, got %d", model.screen)
+	}
+	if cmd != nil {
+		t.Fatal("expected no loading command when entering inspector home")
+	}
+}
+
+func TestInspectorHomeStartsDedicatedScanFlow(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenInspectorHome
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model := updated.(Model)
+	if model.screen != screenInspectorScanning {
+		t.Fatalf("expected inspector scanning screen, got %d", model.screen)
+	}
+	if cmd == nil {
+		t.Fatal("expected security scan command")
+	}
+}
+
+func TestHandleInspectorScanLoadedMsgShowsResults(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	report := &awsservice.SecurityScanReport{
+		ScannerCount: 1,
+		Findings: []awsservice.SecurityFinding{
+			{
+				RuleID:         "sg-public-ssh",
+				RuleName:       "SSH exposed to the internet",
+				Severity:       awsservice.RuleSeverityHigh,
+				ResourceType:   "SecurityGroup",
+				ResourceID:     "sg-123456",
+				Summary:        "Ingress rule allows TCP/22 from 0.0.0.0/0.",
+				Recommendation: "Restrict SSH to trusted sources.",
+			},
+		},
+	}
+
+	updated, _, handled := m.handleInspectorMsg(inspectorScanLoadedMsg{report: report})
+	if !handled {
+		t.Fatal("expected inspector scan message to be handled")
+	}
+
+	model := updated.(Model)
+	if model.screen != screenInspectorResults {
+		t.Fatalf("expected inspector results screen, got %d", model.screen)
+	}
+	if len(model.inspectorFindings) != 1 {
+		t.Fatalf("expected 1 filtered finding, got %d", len(model.inspectorFindings))
+	}
+}
+
+func TestInspectorResultsSeverityFilterNarrowsFindings(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenInspectorResults
+	m.inspectorReport = &awsservice.SecurityScanReport{
+		Findings: []awsservice.SecurityFinding{
+			{RuleName: "Critical finding", Severity: awsservice.RuleSeverityCritical, ResourceID: "sg-1"},
+			{RuleName: "Medium finding", Severity: awsservice.RuleSeverityMedium, ResourceID: "db-1"},
+		},
+	}
+	m.applyInspectorSeverityFilter()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	model := updated.(Model)
+	if model.inspectorSeverityFilter != awsservice.RuleSeverityCritical {
+		t.Fatalf("expected critical severity filter, got %q", model.inspectorSeverityFilter)
+	}
+	if len(model.inspectorFindings) != 1 || model.inspectorFindings[0].Severity != awsservice.RuleSeverityCritical {
+		t.Fatalf("expected only critical findings, got %+v", model.inspectorFindings)
+	}
+}
+
+func TestInspectorResultsEnterShowsDetail(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenInspectorResults
+	m.inspectorFindings = []awsservice.SecurityFinding{
+		{
+			RuleName:       "SSH exposed to the internet",
+			Severity:       awsservice.RuleSeverityHigh,
+			ResourceID:     "sg-123456",
+			Summary:        "Ingress rule allows SSH from anywhere.",
+			Recommendation: "Restrict SSH ingress to trusted sources.",
+		},
+	}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model := updated.(Model)
+	if model.screen != screenInspectorFindingDetail {
+		t.Fatalf("expected inspector detail screen, got %d", model.screen)
+	}
+	if model.selectedInspectorFinding == nil {
+		t.Fatal("expected selected inspector finding")
+	}
+}
+
 func TestS3ObjectListEscAtRootReturnsToBucketList(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenS3ObjectList

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -186,3 +186,7 @@ type ecsContainersLoadedMsg struct {
 type ecsExecDoneMsg struct {
 	err error
 }
+
+type inspectorScanLoadedMsg struct {
+	report *awsservice.SecurityScanReport
+}

--- a/internal/app/screen_inspector.go
+++ b/internal/app/screen_inspector.go
@@ -1,0 +1,346 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	awsservice "unic/internal/services/aws"
+)
+
+var (
+	inspectorSeverityCriticalStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)
+	inspectorSeverityHighStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("208")).Bold(true)
+	inspectorSeverityMediumStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("220")).Bold(true)
+	inspectorSeverityLowStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("114")).Bold(true)
+)
+
+var inspectorSeverityFilters = []awsservice.RuleSeverity{
+	"",
+	awsservice.RuleSeverityCritical,
+	awsservice.RuleSeverityHigh,
+	awsservice.RuleSeverityMedium,
+	awsservice.RuleSeverityLow,
+}
+
+func (m Model) handleInspectorMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
+	switch msg := msg.(type) {
+	case inspectorScanLoadedMsg:
+		m.inspectorReport = msg.report
+		m.selectedInspectorFinding = nil
+		m.applyInspectorSeverityFilter()
+		m.screen = screenInspectorResults
+		return m, nil, true
+	}
+	return m, nil, false
+}
+
+func (m Model) updateInspectorHome(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "esc":
+		m.screen = screenFeatureList
+	case "enter", "r":
+		return m.startInspectorScan()
+	}
+	return m, nil
+}
+
+func (m Model) updateInspectorResults(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "esc":
+		m.selectedInspectorFinding = nil
+		m.screen = screenInspectorHome
+	case "up", "k":
+		if m.inspectorIdx > 0 {
+			m.inspectorIdx--
+		}
+	case "down", "j":
+		if m.inspectorIdx < len(m.inspectorFindings)-1 {
+			m.inspectorIdx++
+		}
+	case "enter":
+		if len(m.inspectorFindings) > 0 && m.inspectorIdx < len(m.inspectorFindings) {
+			selected := m.inspectorFindings[m.inspectorIdx]
+			m.selectedInspectorFinding = &selected
+			m.screen = screenInspectorFindingDetail
+		}
+	case "r":
+		return m.startInspectorScan()
+	case "1", "2", "3", "4", "5":
+		idx := int(msg.String()[0] - '1')
+		if idx >= 0 && idx < len(inspectorSeverityFilters) {
+			m.inspectorSeverityFilter = inspectorSeverityFilters[idx]
+			m.applyInspectorSeverityFilter()
+		}
+	}
+	return m, nil
+}
+
+func (m Model) updateInspectorFindingDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "esc":
+		m.screen = screenInspectorResults
+	case "r":
+		return m.startInspectorScan()
+	}
+	return m, nil
+}
+
+func (m Model) startInspectorScan() (tea.Model, tea.Cmd) {
+	m.selectedInspectorFinding = nil
+	m.screen = screenInspectorScanning
+	m.loadingSpinner = newLoadingSpinner()
+	return m, tea.Batch(m.loadingSpinner.Tick, m.loadSecurityScan())
+}
+
+func (m Model) loadSecurityScan() tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
+		if err != nil {
+			return errMsg{err: err}
+		}
+
+		report, err := repo.RunSecurityScan(ctx)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		return inspectorScanLoadedMsg{report: report}
+	}
+}
+
+func (m *Model) applyInspectorSeverityFilter() {
+	m.inspectorIdx = 0
+	if m.inspectorReport == nil {
+		m.inspectorFindings = nil
+		return
+	}
+
+	var filtered []awsservice.SecurityFinding
+	for _, finding := range m.inspectorReport.Findings {
+		if finding.MatchesSeverity(m.inspectorSeverityFilter) {
+			filtered = append(filtered, finding)
+		}
+	}
+	m.inspectorFindings = filtered
+}
+
+func (m Model) viewInspectorHome() string {
+	var b strings.Builder
+	b.WriteString(m.renderStatusBar())
+	b.WriteString(titleStyle.Render("Inspector"))
+	b.WriteString("\n\n")
+	b.WriteString(normalStyle.Render("  Run built-in security scans against the active AWS context."))
+	b.WriteString("\n")
+	b.WriteString(normalStyle.Render("  This slice ships the service shell, scan orchestration, and finding browser."))
+	b.WriteString("\n")
+	b.WriteString(dimStyle.Render(fmt.Sprintf("  Registered rule packs: %d", awsservice.RegisteredSecurityInspectorScannerCount())))
+	b.WriteString("\n")
+	if m.inspectorReport != nil {
+		b.WriteString(dimStyle.Render(fmt.Sprintf(
+			"  Last scan: %s • findings:%d • warnings:%d",
+			m.inspectorReport.ScannedAt.Local().Format("2006-01-02 15:04:05"),
+			len(m.inspectorReport.Findings),
+			len(m.inspectorReport.Warnings),
+		)))
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+	b.WriteString(dimStyle.Render("enter/r: run security scan • esc: back • H: home"))
+	return b.String()
+}
+
+func (m Model) viewInspectorScanning() string {
+	var b strings.Builder
+	b.WriteString(m.renderStatusBar())
+	b.WriteString(titleStyle.Render("Inspector — Security Scan"))
+	b.WriteString("\n\n")
+	b.WriteString(titleStyle.Render(fmt.Sprintf("%s Running built-in rule packs...", m.loadingSpinner.View())))
+	b.WriteString("\n")
+	b.WriteString(dimStyle.Render("  The first rule packs land in follow-up issues."))
+	return b.String()
+}
+
+func (m Model) viewInspectorResults() string {
+	var b strings.Builder
+	b.WriteString(m.renderStatusBar())
+	b.WriteString(titleStyle.Render("Inspector Findings"))
+	b.WriteString("\n")
+
+	if m.inspectorReport != nil {
+		b.WriteString(dimStyle.Render(fmt.Sprintf(
+			"Scanned: %s  Rule Packs: %d  Findings: %d",
+			m.inspectorReport.ScannedAt.Local().Format("2006-01-02 15:04:05"),
+			m.inspectorReport.ScannerCount,
+			len(m.inspectorReport.Findings),
+		)))
+		b.WriteString("\n")
+	}
+
+	b.WriteString(m.renderInspectorSeveritySelector())
+	b.WriteString("\n\n")
+
+	if m.inspectorReport != nil && len(m.inspectorReport.Warnings) > 0 {
+		b.WriteString(errorStyle.Render(fmt.Sprintf("Warnings: %d rule pack(s) reported errors", len(m.inspectorReport.Warnings))))
+		b.WriteString("\n")
+		b.WriteString(dimStyle.Render("  " + m.inspectorReport.Warnings[0]))
+		b.WriteString("\n\n")
+	}
+
+	if len(m.inspectorFindings) == 0 {
+		b.WriteString(dimStyle.Render("  No matching findings"))
+		if m.inspectorReport != nil && len(m.inspectorReport.Findings) == 0 && m.inspectorReport.ScannerCount == 0 {
+			b.WriteString("\n")
+			b.WriteString(dimStyle.Render("  No built-in rule packs are registered yet."))
+		}
+		b.WriteString("\n")
+	} else {
+		resourceWidth := 24
+		for _, finding := range m.inspectorFindings {
+			resourceWidth = max(resourceWidth, len(inspectorFindingResource(finding)))
+		}
+		if resourceWidth > 36 {
+			resourceWidth = 36
+		}
+		resourceCol := lipgloss.NewStyle().Width(resourceWidth)
+
+		b.WriteString(dimStyle.Render("  SEVERITY   " + resourceCol.Render("RESOURCE") + "RULE"))
+		b.WriteString("\n")
+
+		visibleLines := max(m.height-11, 5)
+		start := 0
+		if m.inspectorIdx >= visibleLines {
+			start = m.inspectorIdx - visibleLines + 1
+		}
+		end := min(start+visibleLines, len(m.inspectorFindings))
+
+		for i := start; i < end; i++ {
+			finding := m.inspectorFindings[i]
+			cursor := "  "
+			textStyle := normalStyle
+			if i == m.inspectorIdx {
+				cursor = "> "
+				textStyle = selectedStyle
+			}
+
+			resource := inspectorShorten(inspectorFindingResource(finding), resourceWidth)
+			row := cursor +
+				padInspectorSeverity(renderInspectorSeverity(finding.Severity), 11) +
+				" " +
+				resourceCol.Inherit(textStyle).Render(resource) +
+				textStyle.Render(finding.RuleName)
+			b.WriteString(row)
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString("\n")
+	b.WriteString(dimStyle.Render("↑/↓: navigate • 1-5: severity • enter: detail • r: rescan • esc: back • H: home"))
+	return b.String()
+}
+
+func (m Model) viewInspectorFindingDetail() string {
+	if m.selectedInspectorFinding == nil {
+		return ""
+	}
+
+	finding := m.selectedInspectorFinding
+	var b strings.Builder
+	b.WriteString(m.renderStatusBar())
+	b.WriteString(titleStyle.Render("Inspector Finding Detail"))
+	b.WriteString("\n\n")
+
+	labelCol := lipgloss.NewStyle().Width(16)
+	b.WriteString(normalStyle.Render(fmt.Sprintf("  %s%s", labelCol.Render("Severity"), renderInspectorSeverity(finding.Severity))))
+	b.WriteString("\n")
+	b.WriteString(normalStyle.Render(fmt.Sprintf("  %s%s", labelCol.Render("Rule"), finding.RuleName)))
+	b.WriteString("\n")
+	if finding.RuleID != "" {
+		b.WriteString(normalStyle.Render(fmt.Sprintf("  %s%s", labelCol.Render("Rule ID"), finding.RuleID)))
+		b.WriteString("\n")
+	}
+	if finding.ResourceType != "" {
+		b.WriteString(normalStyle.Render(fmt.Sprintf("  %s%s", labelCol.Render("Resource Type"), finding.ResourceType)))
+		b.WriteString("\n")
+	}
+	b.WriteString(normalStyle.Render(fmt.Sprintf("  %s%s", labelCol.Render("Resource ID"), inspectorFindingResource(*finding))))
+	b.WriteString("\n\n")
+
+	width := 80
+	if m.width > 0 {
+		width = max(m.width-4, 40)
+	}
+	paragraph := lipgloss.NewStyle().Width(width)
+
+	b.WriteString(titleStyle.Render("Summary"))
+	b.WriteString("\n\n")
+	b.WriteString(paragraph.Render("  " + finding.Summary))
+	b.WriteString("\n\n")
+
+	b.WriteString(titleStyle.Render("Recommendation"))
+	b.WriteString("\n\n")
+	b.WriteString(paragraph.Render("  " + finding.Recommendation))
+	b.WriteString("\n\n")
+
+	b.WriteString(dimStyle.Render("esc: back • r: rescan • H: home"))
+	return b.String()
+}
+
+func (m Model) renderInspectorSeveritySelector() string {
+	parts := make([]string, 0, len(inspectorSeverityFilters))
+	for idx, severity := range inspectorSeverityFilters {
+		label := fmt.Sprintf("%d:%s", idx+1, severity.Label())
+		if severity == m.inspectorSeverityFilter {
+			parts = append(parts, selectedStyle.Render("["+label+"]"))
+		} else {
+			parts = append(parts, dimStyle.Render(" "+label+" "))
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func inspectorFindingResource(finding awsservice.SecurityFinding) string {
+	if finding.ResourceID != "" {
+		return finding.ResourceID
+	}
+	if finding.ResourceType != "" {
+		return finding.ResourceType
+	}
+	return "-"
+}
+
+func renderInspectorSeverity(severity awsservice.RuleSeverity) string {
+	switch severity {
+	case awsservice.RuleSeverityCritical:
+		return inspectorSeverityCriticalStyle.Render(string(severity))
+	case awsservice.RuleSeverityHigh:
+		return inspectorSeverityHighStyle.Render(string(severity))
+	case awsservice.RuleSeverityMedium:
+		return inspectorSeverityMediumStyle.Render(string(severity))
+	case awsservice.RuleSeverityLow:
+		return inspectorSeverityLowStyle.Render(string(severity))
+	default:
+		return dimStyle.Render(string(severity))
+	}
+}
+
+func padInspectorSeverity(value string, width int) string {
+	plainWidth := lipgloss.Width(value)
+	if plainWidth >= width {
+		return value
+	}
+	return value + strings.Repeat(" ", width-plainWidth)
+}
+
+func inspectorShorten(value string, width int) string {
+	if lipgloss.Width(value) <= width {
+		return value
+	}
+	if width <= 3 {
+		return value[:width]
+	}
+	return value[:width-3] + "..."
+}

--- a/internal/app/screen_inspector.go
+++ b/internal/app/screen_inspector.go
@@ -336,11 +336,38 @@ func padInspectorSeverity(value string, width int) string {
 }
 
 func inspectorShorten(value string, width int) string {
+	if width <= 0 {
+		return ""
+	}
 	if lipgloss.Width(value) <= width {
 		return value
 	}
+
+	suffix := ""
+	targetWidth := width
 	if width <= 3 {
-		return value[:width]
+		targetWidth = width
+	} else {
+		suffix = "..."
+		targetWidth = width - lipgloss.Width(suffix)
 	}
-	return value[:width-3] + "..."
+	if targetWidth <= 0 {
+		return suffix
+	}
+
+	var b strings.Builder
+	currentWidth := 0
+	for _, r := range value {
+		runeWidth := lipgloss.Width(string(r))
+		if currentWidth+runeWidth > targetWidth {
+			break
+		}
+		b.WriteRune(r)
+		currentWidth += runeWidth
+	}
+
+	if b.Len() == 0 {
+		return suffix
+	}
+	return b.String() + suffix
 }

--- a/internal/app/screen_inspector_test.go
+++ b/internal/app/screen_inspector_test.go
@@ -1,0 +1,34 @@
+package app
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+func TestInspectorShortenHandlesUnicodeSafely(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		width int
+	}{
+		{name: "cjk narrow", value: "보안점검", width: 2},
+		{name: "emoji narrow", value: "🔒security", width: 3},
+		{name: "cjk with ellipsis", value: "보안점검결과", width: 6},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := inspectorShorten(tc.value, tc.width)
+			if !utf8.ValidString(got) {
+				t.Fatalf("expected valid UTF-8, got %q", got)
+			}
+		})
+	}
+}
+
+func TestInspectorShortenUsesEllipsisForWiderColumns(t *testing.T) {
+	got := inspectorShorten("security-group-public-ssh", 10)
+	if got != "securit..." {
+		t.Fatalf("expected truncated value with ellipsis, got %q", got)
+	}
+}

--- a/internal/domain/catalog.go
+++ b/internal/domain/catalog.go
@@ -67,11 +67,11 @@ func Catalog() []Service {
 				{
 					Kind:        FeatureECSExec,
 					Description: "Browse ECS clusters, services, tasks, and launch exec sessions",
-        },
-      },
-    },
-    {
-      Name: ServiceS3,
+				},
+			},
+		},
+		{
+			Name: ServiceS3,
 			Features: []Feature{
 				{
 					Kind:        FeatureS3Browser,
@@ -93,6 +93,15 @@ func Catalog() []Service {
 				{
 					Kind:        FeatureRotateAccessKey,
 					Description: "Rotate the current session IAM access key with verify and cleanup steps",
+				},
+			},
+		},
+		{
+			Name: ServiceInspector,
+			Features: []Feature{
+				{
+					Kind:        FeatureSecurityScan,
+					Description: "Run built-in security scans and review findings by severity",
 				},
 			},
 		},

--- a/internal/domain/catalog_test.go
+++ b/internal/domain/catalog_test.go
@@ -159,3 +159,22 @@ func TestCatalogContainsS3BrowserFeature(t *testing.T) {
 
 	t.Error("S3 service not found in catalog")
 }
+
+func TestCatalogContainsInspectorSecurityScanFeature(t *testing.T) {
+	services := Catalog()
+
+	for _, svc := range services {
+		if svc.Name != ServiceInspector {
+			continue
+		}
+		if len(svc.Features) != 1 {
+			t.Fatalf("expected 1 Inspector feature, got %d", len(svc.Features))
+		}
+		if svc.Features[0].Kind != FeatureSecurityScan {
+			t.Fatalf("expected Security Scan feature, got %s", svc.Features[0].Kind)
+		}
+		return
+	}
+
+	t.Error("Inspector service not found in catalog")
+}

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -13,6 +13,7 @@ const (
 	ServiceCloudWatchLogs AwsService = "CloudWatch Logs"
 	ServiceECS            AwsService = "ECS"
 	ServiceS3             AwsService = "S3"
+	ServiceInspector      AwsService = "Inspector"
 )
 
 // FeatureKind represents a specific feature within a service.
@@ -31,6 +32,7 @@ const (
 	FeatureCloudWatchLogsBrowser FeatureKind = "CloudWatch Logs Browser"
 	FeatureECSExec               FeatureKind = "ECS Exec Sessions"
 	FeatureS3Browser             FeatureKind = "S3 Browser"
+	FeatureSecurityScan          FeatureKind = "Security Scan"
 )
 
 // Feature describes a selectable feature under an AWS service.

--- a/internal/services/aws/inspector.go
+++ b/internal/services/aws/inspector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"sync"
 	"time"
 )
 
@@ -12,7 +13,10 @@ type InspectorScanner struct {
 	Run  func(context.Context, *AwsRepository) ([]SecurityFinding, error)
 }
 
-var securityInspectorScanners []InspectorScanner
+var (
+	securityInspectorScanners   []InspectorScanner
+	securityInspectorScannersMu sync.RWMutex
+)
 
 func registerSecurityInspectorScanner(scanner InspectorScanner) {
 	if scanner.Name == "" {
@@ -21,11 +25,15 @@ func registerSecurityInspectorScanner(scanner InspectorScanner) {
 	if scanner.Run == nil {
 		panic(fmt.Sprintf("security inspector scanner %q cannot have a nil runner", scanner.Name))
 	}
+	securityInspectorScannersMu.Lock()
+	defer securityInspectorScannersMu.Unlock()
 	securityInspectorScanners = append(securityInspectorScanners, scanner)
 }
 
 func listSecurityInspectorScanners() []InspectorScanner {
+	securityInspectorScannersMu.RLock()
 	scanners := append([]InspectorScanner(nil), securityInspectorScanners...)
+	securityInspectorScannersMu.RUnlock()
 	sort.Slice(scanners, func(i, j int) bool {
 		return scanners[i].Name < scanners[j].Name
 	})

--- a/internal/services/aws/inspector.go
+++ b/internal/services/aws/inspector.go
@@ -52,6 +52,12 @@ func (r *AwsRepository) RunSecurityScan(ctx context.Context) (*SecurityScanRepor
 	}
 
 	for _, scanner := range scanners {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
 		findings, err := scanner.Run(ctx, r)
 		if err != nil {
 			report.Warnings = append(report.Warnings, fmt.Sprintf("%s: %v", scanner.Name, err))

--- a/internal/services/aws/inspector.go
+++ b/internal/services/aws/inspector.go
@@ -1,0 +1,73 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+)
+
+type InspectorScanner struct {
+	Name string
+	Run  func(context.Context, *AwsRepository) ([]SecurityFinding, error)
+}
+
+var securityInspectorScanners []InspectorScanner
+
+func registerSecurityInspectorScanner(scanner InspectorScanner) {
+	if scanner.Name == "" {
+		panic("security inspector scanner name cannot be empty")
+	}
+	if scanner.Run == nil {
+		panic(fmt.Sprintf("security inspector scanner %q cannot have a nil runner", scanner.Name))
+	}
+	securityInspectorScanners = append(securityInspectorScanners, scanner)
+}
+
+func listSecurityInspectorScanners() []InspectorScanner {
+	scanners := append([]InspectorScanner(nil), securityInspectorScanners...)
+	sort.Slice(scanners, func(i, j int) bool {
+		return scanners[i].Name < scanners[j].Name
+	})
+	return scanners
+}
+
+func RegisteredSecurityInspectorScannerCount() int {
+	return len(listSecurityInspectorScanners())
+}
+
+func (r *AwsRepository) RunSecurityScan(ctx context.Context) (*SecurityScanReport, error) {
+	scanners := listSecurityInspectorScanners()
+	report := &SecurityScanReport{
+		ScannerCount: len(scanners),
+		ScannedAt:    time.Now().UTC(),
+	}
+
+	for _, scanner := range scanners {
+		findings, err := scanner.Run(ctx, r)
+		if err != nil {
+			report.Warnings = append(report.Warnings, fmt.Sprintf("%s: %v", scanner.Name, err))
+			continue
+		}
+		report.Findings = append(report.Findings, findings...)
+	}
+
+	sort.Slice(report.Findings, func(i, j int) bool {
+		left := report.Findings[i]
+		right := report.Findings[j]
+		if left.Severity.Rank() != right.Severity.Rank() {
+			return left.Severity.Rank() < right.Severity.Rank()
+		}
+
+		leftKey := normalizedSortKey(left.ResourceID, left.ResourceType, left.RuleName, left.RuleID)
+		rightKey := normalizedSortKey(right.ResourceID, right.ResourceType, right.RuleName, right.RuleID)
+		if leftKey != rightKey {
+			return leftKey < rightKey
+		}
+
+		return normalizedSortKey(left.Summary, left.Recommendation) < normalizedSortKey(right.Summary, right.Recommendation)
+	})
+
+	sort.Strings(report.Warnings)
+	return report, nil
+}

--- a/internal/services/aws/inspector_model.go
+++ b/internal/services/aws/inspector_model.go
@@ -1,0 +1,93 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type RuleSeverity string
+
+const (
+	RuleSeverityCritical RuleSeverity = "CRITICAL"
+	RuleSeverityHigh     RuleSeverity = "HIGH"
+	RuleSeverityMedium   RuleSeverity = "MEDIUM"
+	RuleSeverityLow      RuleSeverity = "LOW"
+)
+
+func (s RuleSeverity) Rank() int {
+	switch s {
+	case RuleSeverityCritical:
+		return 0
+	case RuleSeverityHigh:
+		return 1
+	case RuleSeverityMedium:
+		return 2
+	case RuleSeverityLow:
+		return 3
+	default:
+		return 4
+	}
+}
+
+func (s RuleSeverity) Label() string {
+	if s == "" {
+		return "ALL"
+	}
+	return string(s)
+}
+
+type SecurityFinding struct {
+	RuleID         string
+	RuleName       string
+	Severity       RuleSeverity
+	ResourceType   string
+	ResourceID     string
+	Summary        string
+	Recommendation string
+}
+
+func (f SecurityFinding) DisplayTitle() string {
+	resource := f.ResourceID
+	if resource == "" {
+		resource = f.ResourceType
+	}
+	ruleName := f.RuleName
+	if ruleName == "" {
+		ruleName = f.RuleID
+	}
+	return fmt.Sprintf("[%s] %s — %s", f.Severity, resource, ruleName)
+}
+
+func (f SecurityFinding) FilterText() string {
+	return strings.ToLower(fmt.Sprintf("%s %s %s %s %s %s %s",
+		f.RuleID,
+		f.RuleName,
+		f.Severity,
+		f.ResourceType,
+		f.ResourceID,
+		f.Summary,
+		f.Recommendation,
+	))
+}
+
+func (f SecurityFinding) MatchesSeverity(severity RuleSeverity) bool {
+	return severity == "" || f.Severity == severity
+}
+
+type SecurityScanReport struct {
+	Findings     []SecurityFinding
+	ScannerCount int
+	Warnings     []string
+	ScannedAt    time.Time
+}
+
+func (r SecurityScanReport) FindingsForSeverity(severity RuleSeverity) int {
+	count := 0
+	for _, finding := range r.Findings {
+		if finding.MatchesSeverity(severity) {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/services/aws/inspector_test.go
+++ b/internal/services/aws/inspector_test.go
@@ -1,0 +1,115 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func withInspectorScanners(t *testing.T, scanners []InspectorScanner) {
+	t.Helper()
+	original := securityInspectorScanners
+	securityInspectorScanners = scanners
+	t.Cleanup(func() {
+		securityInspectorScanners = original
+	})
+}
+
+func TestRunSecurityScanSortsFindingsBySeverityAndResource(t *testing.T) {
+	withInspectorScanners(t, []InspectorScanner{
+		{
+			Name: "network",
+			Run: func(context.Context, *AwsRepository) ([]SecurityFinding, error) {
+				return []SecurityFinding{
+					{
+						RuleID:       "sg-public-ssh",
+						RuleName:     "SSH exposed to the internet",
+						Severity:     RuleSeverityHigh,
+						ResourceType: "SecurityGroup",
+						ResourceID:   "sg-zeta",
+					},
+					{
+						RuleID:       "sg-public-rdp",
+						RuleName:     "RDP exposed to the internet",
+						Severity:     RuleSeverityCritical,
+						ResourceType: "SecurityGroup",
+						ResourceID:   "sg-alpha",
+					},
+				}, nil
+			},
+		},
+		{
+			Name: "database",
+			Run: func(context.Context, *AwsRepository) ([]SecurityFinding, error) {
+				return []SecurityFinding{
+					{
+						RuleID:       "rds-no-backup",
+						RuleName:     "Automated backups disabled",
+						Severity:     RuleSeverityHigh,
+						ResourceType: "RDS",
+						ResourceID:   "db-alpha",
+					},
+				}, nil
+			},
+		},
+	})
+
+	report, err := (&AwsRepository{}).RunSecurityScan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.ScannerCount != 2 {
+		t.Fatalf("expected 2 scanners, got %d", report.ScannerCount)
+	}
+	if len(report.Findings) != 3 {
+		t.Fatalf("expected 3 findings, got %d", len(report.Findings))
+	}
+	if report.Findings[0].Severity != RuleSeverityCritical || report.Findings[0].ResourceID != "sg-alpha" {
+		t.Fatalf("expected critical finding first, got %+v", report.Findings[0])
+	}
+	if report.Findings[1].ResourceID != "db-alpha" {
+		t.Fatalf("expected high finding with alphabetical resource sort second, got %+v", report.Findings[1])
+	}
+	if report.Findings[2].ResourceID != "sg-zeta" {
+		t.Fatalf("expected remaining high finding last, got %+v", report.Findings[2])
+	}
+}
+
+func TestRunSecurityScanCollectsWarningsAndContinues(t *testing.T) {
+	withInspectorScanners(t, []InspectorScanner{
+		{
+			Name: "broken",
+			Run: func(context.Context, *AwsRepository) ([]SecurityFinding, error) {
+				return nil, fmt.Errorf("scan failed")
+			},
+		},
+		{
+			Name: "healthy",
+			Run: func(context.Context, *AwsRepository) ([]SecurityFinding, error) {
+				return []SecurityFinding{
+					{
+						RuleID:       "secret-rotation",
+						RuleName:     "Secret rotation overdue",
+						Severity:     RuleSeverityMedium,
+						ResourceType: "Secret",
+						ResourceID:   "/prod/db",
+					},
+				}, nil
+			},
+		},
+	})
+
+	report, err := (&AwsRepository{}).RunSecurityScan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(report.Findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(report.Findings))
+	}
+	if len(report.Warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d", len(report.Warnings))
+	}
+	if report.Warnings[0] != "broken: scan failed" {
+		t.Fatalf("unexpected warning text: %q", report.Warnings[0])
+	}
+}

--- a/internal/services/aws/inspector_test.go
+++ b/internal/services/aws/inspector_test.go
@@ -3,15 +3,24 @@ package aws
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 )
 
+var inspectorScannerTestMu sync.Mutex
+
 func withInspectorScanners(t *testing.T, scanners []InspectorScanner) {
 	t.Helper()
-	original := securityInspectorScanners
-	securityInspectorScanners = scanners
+	inspectorScannerTestMu.Lock()
+	securityInspectorScannersMu.Lock()
+	original := append([]InspectorScanner(nil), securityInspectorScanners...)
+	securityInspectorScanners = append([]InspectorScanner(nil), scanners...)
+	securityInspectorScannersMu.Unlock()
 	t.Cleanup(func() {
+		securityInspectorScannersMu.Lock()
 		securityInspectorScanners = original
+		securityInspectorScannersMu.Unlock()
+		inspectorScannerTestMu.Unlock()
 	})
 }
 

--- a/internal/services/aws/inspector_test.go
+++ b/internal/services/aws/inspector_test.go
@@ -122,3 +122,41 @@ func TestRunSecurityScanCollectsWarningsAndContinues(t *testing.T) {
 		t.Fatalf("unexpected warning text: %q", report.Warnings[0])
 	}
 }
+
+func TestRunSecurityScanStopsWhenContextCanceledBetweenScanners(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runCount := 0
+	withInspectorScanners(t, []InspectorScanner{
+		{
+			Name: "first",
+			Run: func(context.Context, *AwsRepository) ([]SecurityFinding, error) {
+				runCount++
+				cancel()
+				return nil, nil
+			},
+		},
+		{
+			Name: "second",
+			Run: func(context.Context, *AwsRepository) ([]SecurityFinding, error) {
+				runCount++
+				return nil, nil
+			},
+		},
+	})
+
+	report, err := (&AwsRepository{}).RunSecurityScan(ctx)
+	if err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+	if err != context.Canceled {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if report != nil {
+		t.Fatalf("expected nil report on cancellation, got %+v", report)
+	}
+	if runCount != 1 {
+		t.Fatalf("expected only the first scanner to run, got %d runs", runCount)
+	}
+}


### PR DESCRIPTION
### Summary

- add the Inspector service and Security Scan feature to the catalog
- add Security Inspector scan orchestration, findings models, and Bubble Tea home/scanning/results/detail screens
- add README plus architecture/project-overview updates so the new service is documented

### Related Issues

Closes #89

### Validation

- `GOCACHE=/tmp/unic-go-build make test`
- `GOCACHE=/tmp/unic-go-build make build`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed
- [x] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented
