### PR TITLE
fix: improve CloudWatch pagination and Reachability Analyzer UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,13 +208,13 @@ CLI flags > selected context > config defaults > hardcoded default (us-east-1)
 | RDS | `s` start, `x` stop, `f` failover, `r` refresh |
 | Route53 | `c` create, `e` edit, `d` delete |
 | IAM Key Rotation | `r` rotate, `c` copy exports, `a` apply and verify, `d` deactivate old key, `x` delete old key |
-| CloudWatch Logs | `1`-`6` time presets, `t` live tail, `f` filter pattern, `w` wrap toggle, `h/l` horizontal scroll, `n` load more |
+| CloudWatch Logs | log groups/streams load 10 at a time, `n` load more, `1`-`6` time presets, `t` live tail, `f` filter pattern, `w` wrap toggle, `h/l` horizontal scroll |
 | ECS Exec | `r` refresh, `Enter` drill down / exec |
 | Context Picker | `a` add context, `/` filter |
 
 Filtering is currently available on EC2 instances, IAM users, VPCs/subnets, RDS instances, Route53 zones/records, CloudWatch log groups/streams, Secrets Manager resources, ECS clusters/services, S3 buckets/objects, and the context picker.
 
-Reachability Analyzer starts with a region selection step, defaults to the current context region, and now surfaces the AWS-documented source and destination resource types that unic supports: EC2 instances, Internet gateways, Network interfaces, Transit gateways, Transit gateway attachments, Virtual private gateways, VPC endpoint services, VPC endpoints, VPC peering connections, plus IP addresses as destinations. The source and destination pickers support type tabs, keyword filtering, IPv4 destination validation, and automatic cleanup of temporary Network Insights resources after each analysis.
+Reachability Analyzer starts with a region selection step, defaults to the current context region, and now surfaces the AWS-documented source and destination resource types that unic supports: EC2 instances, Internet gateways, Network interfaces, Transit gateways, Transit gateway attachments, Virtual private gateways, VPC endpoint services, VPC endpoints, VPC peering connections, plus IP addresses as destinations. The source and destination pickers support type tabs, keyword filtering, IPv4 destination validation, and automatic cleanup of temporary Network Insights resources after each analysis. During analysis, the loading screen shows a vertical source-to-destination flow and intent summary, and the result view renders path hops and findings in a more readable layout.
 
 ## Development
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -228,9 +228,11 @@ type Model struct {
 	cwLogStreamIdx          int
 	cwLogStreamFilter       string
 	cwLogStreamFilterActive bool
+	cwLogStreamNextToken    *string
 	selectedCWLogStream     *awsservice.LogStream
 	cwLogEvents             []awsservice.LogEvent
 	cwLogScrollOffset       int
+	cwLogGroupNextToken     *string
 	cwLogNextToken          *string
 	cwLogTimeRange          int // index into preset time ranges
 	cwLogFilterPattern      string
@@ -281,6 +283,8 @@ type Model struct {
 
 	// Loading state
 	loadingSpinner spinner.Model
+	loadingTitle   string
+	loadingDetails []string
 	filterTI       textinput.Model
 	activeFilter   filterTarget
 	filters        map[filterTarget]string
@@ -349,8 +353,14 @@ func (m Model) loadCallerIdentity() tea.Cmd {
 }
 
 func (m Model) startLoading(cmd tea.Cmd) (tea.Model, tea.Cmd) {
+	return m.startLoadingWithMessage("Loading...", nil, cmd)
+}
+
+func (m Model) startLoadingWithMessage(title string, details []string, cmd tea.Cmd) (tea.Model, tea.Cmd) {
 	m.screen = screenLoading
 	m.loadingSpinner = newLoadingSpinner()
+	m.loadingTitle = title
+	m.loadingDetails = append([]string(nil), details...)
 	if cmd == nil {
 		return m, m.loadingSpinner.Tick
 	}
@@ -383,6 +393,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	case errMsg:
 		m.errMsg = msg.err.Error()
+		m.loadingTitle = ""
+		m.loadingDetails = nil
 		m.screen = screenError
 		return m, nil
 	}
@@ -620,7 +632,7 @@ func (m Model) updateFeatureList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			case domain.FeatureSecretsBrowser:
 				return m.startLoading(m.loadSecrets())
 			case domain.FeatureCloudWatchLogsBrowser:
-				return m.startLoading(m.loadCWLogGroups())
+				return m.startLoading(m.loadCWLogGroups(false))
 			case domain.FeatureS3Browser:
 				return m.startLoading(m.loadS3Buckets())
 			case domain.FeatureSecurityGroupBrowser:

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -91,6 +91,20 @@ func TestLoadingViewShowsSpinner(t *testing.T) {
 	}
 }
 
+func TestLoadingViewShowsCustomLoadingDetails(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenLoading
+	m.loadingTitle = "Finding Network Path"
+	m.loadingDetails = []string{"src-eni", "->", "dst-eni", "Intent: TCP/443"}
+
+	v := m.View()
+	for _, want := range []string{"Finding Network Path", "src-eni", "dst-eni", "Intent: TCP/443"} {
+		if !strings.Contains(v, want) {
+			t.Fatalf("expected loading view to contain %q, got %q", want, v)
+		}
+	}
+}
+
 func TestViewEmptyWhenQuitting(t *testing.T) {
 	m := Model{quitting: true}
 	v := m.View()
@@ -1438,6 +1452,155 @@ func TestCWLogTailAppendDoesNotOverwritePaginationToken(t *testing.T) {
 	}
 	if got := derefString(model.cwLogTailToken); got != "new-tail-token" {
 		t.Fatalf("expected tail token to update, got %q", got)
+	}
+}
+
+func TestCWLogGroupsLoadedReplacesInitialPageAndStoresNextToken(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+
+	updated, _, handled := m.handleCloudWatchLogsMsg(cwLogGroupsLoadedMsg{
+		groups: []awsservice.LogGroup{
+			{Name: "/aws/lambda/a"},
+			{Name: "/aws/lambda/b"},
+		},
+		nextToken: stringPtr("page-2"),
+	})
+	if !handled {
+		t.Fatal("expected CloudWatch log groups message to be handled")
+	}
+
+	model := updated.(Model)
+	if len(model.cwLogGroups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(model.cwLogGroups))
+	}
+	if got := derefString(model.cwLogGroupNextToken); got != "page-2" {
+		t.Fatalf("expected next token page-2, got %q", got)
+	}
+}
+
+func TestCWLogGroupsLoadedAppendExtendsExistingList(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.cwLogGroups = []awsservice.LogGroup{{Name: "/aws/lambda/a"}}
+
+	updated, _, handled := m.handleCloudWatchLogsMsg(cwLogGroupsLoadedMsg{
+		append: true,
+		groups: []awsservice.LogGroup{
+			{Name: "/aws/lambda/b"},
+			{Name: "/aws/lambda/c"},
+		},
+	})
+	if !handled {
+		t.Fatal("expected CloudWatch log groups message to be handled")
+	}
+
+	model := updated.(Model)
+	if len(model.cwLogGroups) != 3 {
+		t.Fatalf("expected 3 groups, got %d", len(model.cwLogGroups))
+	}
+	if model.cwLogGroups[2].Name != "/aws/lambda/c" {
+		t.Fatalf("expected appended group /aws/lambda/c, got %q", model.cwLogGroups[2].Name)
+	}
+}
+
+func TestCWLogStreamsLoadedAppendExtendsExistingList(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.cwLogStreams = []awsservice.LogStream{{Name: "stream-a"}}
+
+	updated, _, handled := m.handleCloudWatchLogsMsg(cwLogStreamsLoadedMsg{
+		append: true,
+		streams: []awsservice.LogStream{
+			{Name: "stream-b"},
+			{Name: "stream-c"},
+		},
+		nextToken: stringPtr("stream-page-3"),
+	})
+	if !handled {
+		t.Fatal("expected CloudWatch log streams message to be handled")
+	}
+
+	model := updated.(Model)
+	if len(model.cwLogStreams) != 3 {
+		t.Fatalf("expected 3 streams, got %d", len(model.cwLogStreams))
+	}
+	if got := derefString(model.cwLogStreamNextToken); got != "stream-page-3" {
+		t.Fatalf("expected next token stream-page-3, got %q", got)
+	}
+}
+
+func TestReachabilityResultLinesUseReadableSections(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.reachabilityResult = &awsservice.ReachabilityAnalysisResult{
+		Status:           "failed",
+		NetworkPathFound: false,
+		Source:           awsservice.ReachabilityTarget{Name: "src", ID: "eni-1"},
+		Destination:      awsservice.ReachabilityTarget{Name: "dst", ID: "eni-2"},
+		Protocol:         "TCP",
+		DestinationPort:  443,
+		ForwardPath: []awsservice.ReachabilityPathComponent{
+			{Sequence: 1, Title: "eni-1", Details: []string{"subnet subnet-1"}, Explanations: []string{"security group blocked"}},
+		},
+		Explanations: []awsservice.ReachabilityExplanation{
+			{Summary: "ENI_SG_RULES_MISMATCH at eni-1", Details: []string{"security group: sg-1"}},
+		},
+	}
+
+	lines := m.reachabilityResultLines()
+	rendered := strings.Join(lines, "\n")
+	if !strings.Contains(rendered, "Summary") {
+		t.Fatalf("expected Summary section, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "● eni-1") {
+		t.Fatalf("expected visual path node, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "Findings") {
+		t.Fatalf("expected Findings section, got %q", rendered)
+	}
+}
+
+func TestReachabilityLoadingDetailsShowSourceAndDestination(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.reachabilityRegion = "ap-northeast-2"
+	m.reachabilitySource = &awsservice.ReachabilityTarget{Name: "source-eni", ID: "eni-1"}
+	m.reachabilityDestination = &awsservice.ReachabilityTarget{Name: "dest-eni", ID: "eni-2"}
+	m.reachabilityProtocolIdx = 0
+	m.reachabilityPortInput = "443"
+
+	details := m.reachabilityLoadingDetails()
+	if len(details) < 4 {
+		t.Fatalf("expected vertical loading details, got %#v", details)
+	}
+	if !strings.Contains(details[1], "source-eni") {
+		t.Fatalf("expected source line, got %#v", details)
+	}
+	if !strings.Contains(details[2], "│") {
+		t.Fatalf("expected connector line, got %#v", details)
+	}
+	if !strings.Contains(details[3], "↓") {
+		t.Fatalf("expected arrow line, got %#v", details)
+	}
+	if !strings.Contains(details[4], "dest-eni") {
+		t.Fatalf("expected destination line, got %#v", details)
+	}
+	rendered := strings.Join(details, "\n")
+	for _, want := range []string{"Region: ap-northeast-2", "source-eni", "dest-eni", "Intent: TCP/443"} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("expected loading details to contain %q, got %q", want, rendered)
+		}
+	}
+}
+
+func TestReachabilityLoadingDetailsTruncateLongLabelsForNarrowWidth(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.width = 30
+	m.reachabilitySource = &awsservice.ReachabilityTarget{Name: strings.Repeat("source-", 8), ID: "eni-1"}
+	m.reachabilityDestination = &awsservice.ReachabilityTarget{Name: strings.Repeat("dest-", 8), ID: "eni-2"}
+
+	details := m.reachabilityLoadingDetails()
+	if !strings.Contains(details[1], "…") {
+		t.Fatalf("expected truncated source label, got %#v", details)
+	}
+	if !strings.Contains(details[4], "…") {
+		t.Fatalf("expected truncated destination label, got %#v", details)
 	}
 }
 

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -97,11 +97,15 @@ type route53ChangeStatusMsg struct {
 type route53PollTickMsg struct{}
 
 type cwLogGroupsLoadedMsg struct {
-	groups []awsservice.LogGroup
+	groups    []awsservice.LogGroup
+	nextToken *string
+	append    bool
 }
 
 type cwLogStreamsLoadedMsg struct {
-	streams []awsservice.LogStream
+	streams   []awsservice.LogStream
+	nextToken *string
+	append    bool
 }
 
 type cwLogEventsLoadedMsg struct {

--- a/internal/app/screen_cloudwatchlogs.go
+++ b/internal/app/screen_cloudwatchlogs.go
@@ -82,16 +82,36 @@ func appendUniqueCWLogEvents(existing, incoming []awsservice.LogEvent) []awsserv
 func (m Model) handleCloudWatchLogsMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 	switch msg := msg.(type) {
 	case cwLogGroupsLoadedMsg:
-		m.cwLogGroups = msg.groups
-		m.filteredCWLogGroups = msg.groups
-		m.cwLogGroupIdx = 0
+		if msg.append {
+			m.cwLogGroups = append(m.cwLogGroups, msg.groups...)
+		} else {
+			m.cwLogGroups = msg.groups
+			m.cwLogGroupIdx = 0
+		}
+		m.cwLogGroupNextToken = msg.nextToken
+		m.filteredCWLogGroups = applyFilter(m.cwLogGroups, m.filterValue(filterCWLogGroups))
+		if len(m.filteredCWLogGroups) == 0 {
+			m.cwLogGroupIdx = 0
+		} else if m.cwLogGroupIdx >= len(m.filteredCWLogGroups) {
+			m.cwLogGroupIdx = len(m.filteredCWLogGroups) - 1
+		}
 		m.screen = screenCWLogGroupList
 		return m, nil, true
 
 	case cwLogStreamsLoadedMsg:
-		m.cwLogStreams = msg.streams
-		m.filteredCWLogStreams = msg.streams
-		m.cwLogStreamIdx = 0
+		if msg.append {
+			m.cwLogStreams = append(m.cwLogStreams, msg.streams...)
+		} else {
+			m.cwLogStreams = msg.streams
+			m.cwLogStreamIdx = 0
+		}
+		m.cwLogStreamNextToken = msg.nextToken
+		m.filteredCWLogStreams = applyFilter(m.cwLogStreams, m.filterValue(filterCWLogStreams))
+		if len(m.filteredCWLogStreams) == 0 {
+			m.cwLogStreamIdx = 0
+		} else if m.cwLogStreamIdx >= len(m.filteredCWLogStreams) {
+			m.cwLogStreamIdx = len(m.filteredCWLogStreams) - 1
+		}
 		m.screen = screenCWLogStreamList
 		return m, nil, true
 
@@ -150,11 +170,15 @@ func (m Model) updateCWLogGroupList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "/":
 		return m, m.activateFilter(filterCWLogGroups)
+	case "n":
+		if m.cwLogGroupNextToken != nil {
+			return m.startLoading(m.loadCWLogGroups(true))
+		}
 	case "enter":
 		if len(m.filteredCWLogGroups) > 0 && m.cwLogGroupIdx < len(m.filteredCWLogGroups) {
 			selected := m.filteredCWLogGroups[m.cwLogGroupIdx]
 			m.selectedCWLogGroup = &selected
-			return m.startLoading(m.loadCWLogStreams(selected.Name))
+			return m.startLoading(m.loadCWLogStreams(selected.Name, false))
 		}
 	}
 	return m, nil
@@ -220,11 +244,15 @@ func (m Model) viewCWLogGroupList() string {
 		}
 
 		b.WriteString("\n")
-		b.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d log groups", len(m.filteredCWLogGroups), len(m.cwLogGroups))))
+		countLine := fmt.Sprintf("  %d/%d log groups", len(m.filteredCWLogGroups), len(m.cwLogGroups))
+		if m.cwLogGroupNextToken != nil {
+			countLine += " • more available"
+		}
+		b.WriteString(dimStyle.Render(countLine))
 	}
 
 	b.WriteString("\n")
-	b.WriteString(dimStyle.Render("↑/↓: navigate • /: filter • enter: streams • esc: back • H: home"))
+	b.WriteString(dimStyle.Render("↑/↓: navigate • /: filter • n: load more • enter: streams • esc: back • H: home"))
 	return b.String()
 }
 
@@ -251,6 +279,10 @@ func (m Model) updateCWLogStreamList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "/":
 		return m, m.activateFilter(filterCWLogStreams)
+	case "n":
+		if m.selectedCWLogGroup != nil && m.cwLogStreamNextToken != nil {
+			return m.startLoading(m.loadCWLogStreams(m.selectedCWLogGroup.Name, true))
+		}
 	case "enter":
 		if len(m.filteredCWLogStreams) > 0 && m.cwLogStreamIdx < len(m.filteredCWLogStreams) {
 			selected := m.filteredCWLogStreams[m.cwLogStreamIdx]
@@ -330,11 +362,15 @@ func (m Model) viewCWLogStreamList() string {
 		}
 
 		b.WriteString("\n")
-		b.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d streams", len(m.filteredCWLogStreams), len(m.cwLogStreams))))
+		countLine := fmt.Sprintf("  %d/%d streams", len(m.filteredCWLogStreams), len(m.cwLogStreams))
+		if m.cwLogStreamNextToken != nil {
+			countLine += " • more available"
+		}
+		b.WriteString(dimStyle.Render(countLine))
 	}
 
 	b.WriteString("\n")
-	b.WriteString(dimStyle.Render("↑/↓: navigate • /: filter • enter: view logs • esc: back • H: home"))
+	b.WriteString(dimStyle.Render("↑/↓: navigate • /: filter • n: load more • enter: view logs • esc: back • H: home"))
 	return b.String()
 }
 
@@ -615,7 +651,7 @@ func sliceCWLogMessage(message string, offset int) string {
 
 // --- Commands ---
 
-func (m Model) loadCWLogGroups() tea.Cmd {
+func (m Model) loadCWLogGroups(appendMode bool) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
@@ -624,18 +660,23 @@ func (m Model) loadCWLogGroups() tea.Cmd {
 		}
 		m.awsRepo = repo
 
-		groups, err := repo.ListLogGroups(ctx)
+		var nextToken *string
+		if appendMode {
+			nextToken = m.cwLogGroupNextToken
+		}
+
+		groups, token, err := repo.ListLogGroupsPage(ctx, nextToken, 10)
 		if err != nil {
 			return errMsg{err: err}
 		}
-		if len(groups) == 0 {
+		if !appendMode && len(groups) == 0 {
 			return errMsg{err: fmt.Errorf("no log groups found")}
 		}
-		return cwLogGroupsLoadedMsg{groups: groups}
+		return cwLogGroupsLoadedMsg{groups: groups, nextToken: token, append: appendMode}
 	}
 }
 
-func (m Model) loadCWLogStreams(logGroupName string) tea.Cmd {
+func (m Model) loadCWLogStreams(logGroupName string, appendMode bool) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
 		repo := m.awsRepo
@@ -647,14 +688,19 @@ func (m Model) loadCWLogStreams(logGroupName string) tea.Cmd {
 			}
 		}
 
-		streams, err := repo.ListLogStreams(ctx, logGroupName)
+		var nextToken *string
+		if appendMode {
+			nextToken = m.cwLogStreamNextToken
+		}
+
+		streams, token, err := repo.ListLogStreamsPage(ctx, logGroupName, nextToken, 10)
 		if err != nil {
 			return errMsg{err: err}
 		}
-		if len(streams) == 0 {
+		if !appendMode && len(streams) == 0 {
 			return errMsg{err: fmt.Errorf("no log streams found in %s", logGroupName)}
 		}
-		return cwLogStreamsLoadedMsg{streams: streams}
+		return cwLogStreamsLoadedMsg{streams: streams, nextToken: token, append: appendMode}
 	}
 }
 

--- a/internal/app/screen_reachability.go
+++ b/internal/app/screen_reachability.go
@@ -84,7 +84,14 @@ func (m Model) updateReachabilityRegionList(msg tea.KeyMsg) (tea.Model, tea.Cmd)
 		m.reachabilityFilter = ""
 		m.reachabilityFilterActive = false
 		m.awsRepo = nil
-		return m.startLoading(m.loadReachabilityTargets())
+		return m.startLoadingWithMessage(
+			"Loading reachability targets...",
+			[]string{
+				fmt.Sprintf("Region: %s", m.activeReachabilityRegion()),
+				"Collecting source and destination candidates for Reachability Analyzer.",
+			},
+			m.loadReachabilityTargets(),
+		)
 	}
 	return m, nil
 }
@@ -187,7 +194,13 @@ func (m Model) updateReachabilitySourceList(msg tea.KeyMsg) (tea.Model, tea.Cmd)
 	case "/":
 		m.reachabilityFilterActive = true
 	case "r":
-		return m.startLoading(m.loadReachabilityTargets())
+		return m.startLoadingWithMessage(
+			"Refreshing reachability targets...",
+			[]string{
+				fmt.Sprintf("Region: %s", m.activeReachabilityRegion()),
+			},
+			m.loadReachabilityTargets(),
+		)
 	case "enter":
 		if len(m.filteredReachabilityTargets) == 0 {
 			return m, nil
@@ -254,7 +267,13 @@ func (m Model) updateReachabilityDestinationList(msg tea.KeyMsg) (tea.Model, tea
 	case "/":
 		m.reachabilityFilterActive = true
 	case "r":
-		return m.startLoading(m.loadReachabilityTargets())
+		return m.startLoadingWithMessage(
+			"Refreshing reachability targets...",
+			[]string{
+				fmt.Sprintf("Region: %s", m.activeReachabilityRegion()),
+			},
+			m.loadReachabilityTargets(),
+		)
 	case "enter":
 		if len(m.filteredReachabilityTargets) == 0 {
 			return m, nil
@@ -320,7 +339,11 @@ func (m Model) updateReachabilityConfig(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 		}
-		return m.startLoading(m.runReachabilityAnalysis())
+		return m.startLoadingWithMessage(
+			"Finding Network Path",
+			m.reachabilityLoadingDetails(),
+			m.runReachabilityAnalysis(),
+		)
 	default:
 		if len(msg.String()) == 1 {
 			switch m.reachabilityConfigField {
@@ -345,7 +368,11 @@ func (m Model) updateReachabilityResult(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "esc":
 		m.screen = screenReachabilityConfig
 	case "r":
-		return m.startLoading(m.runReachabilityAnalysis())
+		return m.startLoadingWithMessage(
+			"Finding Network Path",
+			m.reachabilityLoadingDetails(),
+			m.runReachabilityAnalysis(),
+		)
 	case "up", "k":
 		if m.reachabilityScrollOffset > 0 {
 			m.reachabilityScrollOffset--
@@ -549,55 +576,63 @@ func (m Model) reachabilityResultLines() []string {
 
 	r := m.reachabilityResult
 	lines := make([]string, 0, 64)
-	status := "NOT REACHABLE"
+	status := "Not reachable"
 	statusStyle := errorStyle
 	if r.NetworkPathFound {
-		status = "REACHABLE"
-		statusStyle = titleStyle
+		status = "Reachable"
+		statusStyle = successStyle
 	}
-	lines = append(lines, statusStyle.Render(status))
-	lines = append(lines, normalStyle.Render(fmt.Sprintf("Status       : %s", r.Status)))
-	lines = append(lines, normalStyle.Render(fmt.Sprintf("Region       : %s", m.activeReachabilityRegion())))
+	lines = append(lines, titleStyle.Render("Summary"))
+	lines = append(lines, statusStyle.Render("  "+status))
+	lines = append(lines, dimStyle.Render("  Analysis status : "+r.Status))
+	lines = append(lines, dimStyle.Render("  Region          : "+m.activeReachabilityRegion()))
 	if r.StatusMessage != "" {
-		lines = append(lines, normalStyle.Render(fmt.Sprintf("Message      : %s", r.StatusMessage)))
+		lines = append(lines, normalStyle.Render("  Message         : "+r.StatusMessage))
 	}
-	lines = append(lines, normalStyle.Render(fmt.Sprintf("Source       : %s", r.Source.DisplayTitle())))
+	lines = append(lines, normalStyle.Render("  Source          : "+r.Source.DisplayTitle()))
 	if r.DestinationIP != "" {
-		lines = append(lines, normalStyle.Render(fmt.Sprintf("Destination  : %s", r.DestinationIP)))
+		lines = append(lines, normalStyle.Render("  Destination     : "+r.DestinationIP))
 	} else {
-		lines = append(lines, normalStyle.Render(fmt.Sprintf("Destination  : %s", r.Destination.DisplayTitle())))
+		lines = append(lines, normalStyle.Render("  Destination     : "+r.Destination.DisplayTitle()))
 	}
-	lines = append(lines, normalStyle.Render(fmt.Sprintf("Intent       : %s/%d", strings.ToUpper(r.Protocol), r.DestinationPort)))
+	lines = append(lines, normalStyle.Render(fmt.Sprintf("  Intent          : %s/%d", strings.ToUpper(r.Protocol), r.DestinationPort)))
 	if r.WarningMessage != "" {
-		lines = append(lines, errorStyle.Render("Warning      : "+r.WarningMessage))
+		lines = append(lines, errorStyle.Render("  Warning         : "+r.WarningMessage))
 	}
 
 	lines = append(lines, "")
-	lines = append(lines, titleStyle.Render("Forward Path"))
+	lines = append(lines, titleStyle.Render("Path"))
 	if len(r.ForwardPath) == 0 {
-		lines = append(lines, dimStyle.Render("  No forward path components returned"))
+		lines = append(lines, dimStyle.Render("  No path components returned"))
 	} else {
-		for _, component := range r.ForwardPath {
-			lines = append(lines, normalStyle.Render(fmt.Sprintf("  %02d. %s", component.Sequence, component.Title)))
+		for i, component := range r.ForwardPath {
+			lines = append(lines, pathNodeStyle.Render(fmt.Sprintf("  ● %s", component.Title)))
 			for _, detail := range component.Details {
-				lines = append(lines, dimStyle.Render("      "+detail))
+				lines = append(lines, infoStyle.Render("  │   "+detail))
 			}
 			for _, explanation := range component.Explanations {
-				lines = append(lines, errorStyle.Render("      blocker: "+explanation))
+				lines = append(lines, warningStyle.Render("  │   blocker: "+explanation))
+			}
+			if i < len(r.ForwardPath)-1 {
+				lines = append(lines, pathLineStyle.Render("  │"))
 			}
 		}
 	}
 
 	lines = append(lines, "")
-	lines = append(lines, titleStyle.Render("Explanations"))
+	lines = append(lines, titleStyle.Render("Findings"))
 	if len(r.Explanations) == 0 {
-		lines = append(lines, dimStyle.Render("  No explanation codes returned"))
+		lines = append(lines, dimStyle.Render("  No blocker explanations returned"))
 	} else {
-		for _, explanation := range r.Explanations {
-			lines = append(lines, errorStyle.Render("  "+explanation.Summary))
+		for idx, explanation := range r.Explanations {
+			lines = append(lines, warningStyle.Render(fmt.Sprintf("  %d) %s", idx+1, explanation.Summary)))
 			for _, detail := range explanation.Details {
-				lines = append(lines, dimStyle.Render("      "+detail))
+				lines = append(lines, dimStyle.Render("     - "+detail))
 			}
+			lines = append(lines, "")
+		}
+		if lines[len(lines)-1] == "" {
+			lines = lines[:len(lines)-1]
 		}
 	}
 
@@ -738,4 +773,60 @@ func indexOfString(items []string, target string) int {
 		}
 	}
 	return -1
+}
+
+func (m Model) reachabilityLoadingDetails() []string {
+	source := "source pending"
+	if m.reachabilitySource != nil {
+		source = m.reachabilitySource.DisplayTitle()
+	}
+
+	destination := "destination pending"
+	if strings.TrimSpace(m.reachabilityDestinationIP) != "" {
+		destination = strings.TrimSpace(m.reachabilityDestinationIP)
+	} else if m.reachabilityDestination != nil {
+		destination = m.reachabilityDestination.DisplayTitle()
+	}
+
+	protocol := ""
+	if m.reachabilityProtocolIdx >= 0 && m.reachabilityProtocolIdx < len(reachabilityProtocols) {
+		protocol = reachabilityProtocols[m.reachabilityProtocolIdx]
+	}
+
+	intent := protocol
+	if strings.TrimSpace(m.reachabilityPortInput) != "" {
+		intent = fmt.Sprintf("%s/%s", protocol, strings.TrimSpace(m.reachabilityPortInput))
+	}
+
+	source = truncateReachabilityLoadingLabel(source, m.width)
+	destination = truncateReachabilityLoadingLabel(destination, m.width)
+
+	return []string{
+		dimStyle.Render(fmt.Sprintf("Region: %s", m.activeReachabilityRegion())),
+		pathNodeStyle.Render(source),
+		pathLineStyle.Render("  │"),
+		pathLineStyle.Render("  ↓"),
+		pathNodeStyle.Render(destination),
+		infoStyle.Render(fmt.Sprintf("Intent: %s", intent)),
+	}
+}
+
+func truncateReachabilityLoadingLabel(label string, width int) string {
+	if width <= 0 {
+		return label
+	}
+
+	maxWidth := width - 6
+	if maxWidth < 24 {
+		maxWidth = 24
+	}
+
+	runes := []rune(label)
+	if len(runes) <= maxWidth {
+		return label
+	}
+	if maxWidth <= 1 {
+		return string(runes[:maxWidth])
+	}
+	return string(runes[:maxWidth-1]) + "…"
 }

--- a/internal/app/styles.go
+++ b/internal/app/styles.go
@@ -15,6 +15,11 @@ var (
 	normalStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
 	dimStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
 	errorStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)
+	successStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("42")).Bold(true)
+	warningStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true)
+	infoStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("117"))
+	pathNodeStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("81")).Bold(true)
+	pathLineStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("67"))
 	filterStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
 	statusBarStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Background(lipgloss.Color("236"))
 )
@@ -93,7 +98,24 @@ func (m Model) fitToHeight(s string) string {
 }
 
 func (m Model) viewLoading() string {
-	return titleStyle.Render(fmt.Sprintf("%s Loading...", m.loadingSpinner.View()))
+	title := m.loadingTitle
+	if strings.TrimSpace(title) == "" {
+		title = "Loading..."
+	}
+
+	var b strings.Builder
+	b.WriteString(titleStyle.Render(fmt.Sprintf("%s %s", m.loadingSpinner.View(), title)))
+	if len(m.loadingDetails) > 0 {
+		b.WriteString("\n\n")
+		for _, detail := range m.loadingDetails {
+			if strings.TrimSpace(detail) == "" {
+				continue
+			}
+			b.WriteString(detail)
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
 }
 
 func (m Model) viewError() string {

--- a/internal/services/aws/cloudwatch_logs.go
+++ b/internal/services/aws/cloudwatch_logs.go
@@ -11,6 +11,40 @@ import (
 	uniclog "unic/internal/log"
 )
 
+const cwLogGroupPageSize int32 = 10
+const cwLogStreamPageSize int32 = 10
+
+// ListLogGroupsPage returns a single page of CloudWatch Logs log groups.
+func (r *AwsRepository) ListLogGroupsPage(ctx context.Context, nextToken *string, limit int32) ([]LogGroup, *string, error) {
+	uniclog.Debug("aws", "ListLogGroupsPage called", "limit", limit)
+
+	output, err := r.CloudWatchLogsClient.DescribeLogGroups(ctx, &cloudwatchlogs.DescribeLogGroupsInput{
+		NextToken: nextToken,
+		Limit:     awssdk.Int32(limit),
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to describe log groups: %w", err)
+	}
+
+	groups := make([]LogGroup, 0, len(output.LogGroups))
+	for _, lg := range output.LogGroups {
+		group := LogGroup{
+			Name:        awssdk.ToString(lg.LogGroupName),
+			ARN:         awssdk.ToString(lg.Arn),
+			StoredBytes: awssdk.ToInt64(lg.StoredBytes),
+		}
+		if lg.RetentionInDays != nil {
+			group.RetentionDays = *lg.RetentionInDays
+		}
+		if lg.CreationTime != nil {
+			group.CreationTime = time.UnixMilli(*lg.CreationTime)
+		}
+		groups = append(groups, group)
+	}
+
+	return groups, output.NextToken, nil
+}
+
 // ListLogGroups returns all CloudWatch Logs log groups in the current account/region.
 func (r *AwsRepository) ListLogGroups(ctx context.Context) ([]LogGroup, error) {
 	uniclog.Debug("aws", "ListLogGroups called")
@@ -18,32 +52,15 @@ func (r *AwsRepository) ListLogGroups(ctx context.Context) ([]LogGroup, error) {
 	var nextToken *string
 
 	for {
-		output, err := r.CloudWatchLogsClient.DescribeLogGroups(ctx, &cloudwatchlogs.DescribeLogGroupsInput{
-			NextToken: nextToken,
-		})
+		page, token, err := r.ListLogGroupsPage(ctx, nextToken, cwLogGroupPageSize)
 		if err != nil {
-			return nil, fmt.Errorf("failed to describe log groups: %w", err)
+			return nil, err
 		}
-
-		for _, lg := range output.LogGroups {
-			group := LogGroup{
-				Name:        awssdk.ToString(lg.LogGroupName),
-				ARN:         awssdk.ToString(lg.Arn),
-				StoredBytes: awssdk.ToInt64(lg.StoredBytes),
-			}
-			if lg.RetentionInDays != nil {
-				group.RetentionDays = *lg.RetentionInDays
-			}
-			if lg.CreationTime != nil {
-				group.CreationTime = time.UnixMilli(*lg.CreationTime)
-			}
-			groups = append(groups, group)
-		}
-
-		if output.NextToken == nil {
+		groups = append(groups, page...)
+		if token == nil {
 			break
 		}
-		nextToken = output.NextToken
+		nextToken = token
 	}
 
 	return groups, nil
@@ -56,36 +73,51 @@ func (r *AwsRepository) ListLogStreams(ctx context.Context, logGroupName string)
 	var nextToken *string
 
 	for {
-		output, err := r.CloudWatchLogsClient.DescribeLogStreams(ctx, &cloudwatchlogs.DescribeLogStreamsInput{
-			LogGroupName: awssdk.String(logGroupName),
-			OrderBy:      "LastEventTime",
-			Descending:   awssdk.Bool(true),
-			NextToken:    nextToken,
-		})
+		page, token, err := r.ListLogStreamsPage(ctx, logGroupName, nextToken, cwLogStreamPageSize)
 		if err != nil {
-			return nil, fmt.Errorf("failed to describe log streams for %s: %w", logGroupName, err)
+			return nil, err
 		}
+		streams = append(streams, page...)
 
-		for _, ls := range output.LogStreams {
-			stream := LogStream{
-				Name: awssdk.ToString(ls.LogStreamName),
-			}
-			if ls.LastEventTimestamp != nil {
-				stream.LastEventTime = time.UnixMilli(*ls.LastEventTimestamp)
-			}
-			if ls.CreationTime != nil {
-				stream.CreationTime = time.UnixMilli(*ls.CreationTime)
-			}
-			streams = append(streams, stream)
-		}
-
-		if output.NextToken == nil {
+		if token == nil {
 			break
 		}
-		nextToken = output.NextToken
+		nextToken = token
 	}
 
 	return streams, nil
+}
+
+// ListLogStreamsPage returns a single page of log streams for a log group.
+func (r *AwsRepository) ListLogStreamsPage(ctx context.Context, logGroupName string, nextToken *string, limit int32) ([]LogStream, *string, error) {
+	uniclog.Debug("aws", "ListLogStreamsPage called", "log_group", logGroupName, "limit", limit)
+
+	output, err := r.CloudWatchLogsClient.DescribeLogStreams(ctx, &cloudwatchlogs.DescribeLogStreamsInput{
+		LogGroupName: awssdk.String(logGroupName),
+		OrderBy:      "LastEventTime",
+		Descending:   awssdk.Bool(true),
+		NextToken:    nextToken,
+		Limit:        awssdk.Int32(limit),
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to describe log streams for %s: %w", logGroupName, err)
+	}
+
+	streams := make([]LogStream, 0, len(output.LogStreams))
+	for _, ls := range output.LogStreams {
+		stream := LogStream{
+			Name: awssdk.ToString(ls.LogStreamName),
+		}
+		if ls.LastEventTimestamp != nil {
+			stream.LastEventTime = time.UnixMilli(*ls.LastEventTimestamp)
+		}
+		if ls.CreationTime != nil {
+			stream.CreationTime = time.UnixMilli(*ls.CreationTime)
+		}
+		streams = append(streams, stream)
+	}
+
+	return streams, output.NextToken, nil
 }
 
 // FilterLogEvents returns log events matching the given criteria.

--- a/internal/services/aws/cloudwatch_logs_test.go
+++ b/internal/services/aws/cloudwatch_logs_test.go
@@ -14,7 +14,7 @@ import (
 // mockCloudWatchLogsClient implements CloudWatchLogsClientAPI for testing.
 type mockCloudWatchLogsClient struct {
 	describeLogGroupsFunc  func(ctx context.Context, params *cloudwatchlogs.DescribeLogGroupsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error)
-	describeLogStreamsFunc  func(ctx context.Context, params *cloudwatchlogs.DescribeLogStreamsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogStreamsOutput, error)
+	describeLogStreamsFunc func(ctx context.Context, params *cloudwatchlogs.DescribeLogStreamsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogStreamsOutput, error)
 	filterLogEventsFunc    func(ctx context.Context, params *cloudwatchlogs.FilterLogEventsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.FilterLogEventsOutput, error)
 }
 
@@ -37,7 +37,10 @@ func (m *mockCloudWatchLogsClient) FilterLogEvents(ctx context.Context, params *
 
 func TestListLogGroups_Success(t *testing.T) {
 	mock := &mockCloudWatchLogsClient{
-		describeLogGroupsFunc: func(_ context.Context, _ *cloudwatchlogs.DescribeLogGroupsInput, _ ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+		describeLogGroupsFunc: func(_ context.Context, params *cloudwatchlogs.DescribeLogGroupsInput, _ ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+			if awssdk.ToInt32(params.Limit) != cwLogGroupPageSize {
+				t.Fatalf("expected limit %d, got %d", cwLogGroupPageSize, awssdk.ToInt32(params.Limit))
+			}
 			var retention int32 = 30
 			var creationTime int64 = 1700000000000
 			return &cloudwatchlogs.DescribeLogGroupsOutput{
@@ -118,6 +121,41 @@ func TestListLogGroups_Error(t *testing.T) {
 	}
 }
 
+func TestListLogGroupsPage_WithToken(t *testing.T) {
+	token := "next-page"
+	mock := &mockCloudWatchLogsClient{
+		describeLogGroupsFunc: func(_ context.Context, params *cloudwatchlogs.DescribeLogGroupsInput, _ ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+			if got := awssdk.ToString(params.NextToken); got != token {
+				t.Fatalf("expected token %q, got %q", token, got)
+			}
+			if awssdk.ToInt32(params.Limit) != 10 {
+				t.Fatalf("expected limit 10, got %d", awssdk.ToInt32(params.Limit))
+			}
+			return &cloudwatchlogs.DescribeLogGroupsOutput{
+				LogGroups: []cwltypes.LogGroup{
+					{LogGroupName: awssdk.String("/aws/lambda/page-2")},
+				},
+				NextToken: awssdk.String("page-3"),
+			}, nil
+		},
+	}
+
+	repo := &AwsRepository{CloudWatchLogsClient: mock}
+	groups, next, err := repo.ListLogGroupsPage(context.Background(), &token, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+	if groups[0].Name != "/aws/lambda/page-2" {
+		t.Fatalf("expected page-2 group, got %q", groups[0].Name)
+	}
+	if next == nil || *next != "page-3" {
+		t.Fatalf("expected next token page-3, got %v", next)
+	}
+}
+
 // --- ListLogStreams tests ---
 
 func TestListLogStreams_Success(t *testing.T) {
@@ -125,6 +163,9 @@ func TestListLogStreams_Success(t *testing.T) {
 		describeLogStreamsFunc: func(_ context.Context, params *cloudwatchlogs.DescribeLogStreamsInput, _ ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogStreamsOutput, error) {
 			if awssdk.ToString(params.LogGroupName) != "/aws/lambda/my-function" {
 				t.Errorf("expected log group '/aws/lambda/my-function', got %q", awssdk.ToString(params.LogGroupName))
+			}
+			if awssdk.ToInt32(params.Limit) != cwLogStreamPageSize {
+				t.Fatalf("expected limit %d, got %d", cwLogStreamPageSize, awssdk.ToInt32(params.Limit))
 			}
 			var lastEvent int64 = 1700000000000
 			return &cloudwatchlogs.DescribeLogStreamsOutput{
@@ -189,6 +230,41 @@ func TestListLogStreams_Error(t *testing.T) {
 	_, err := repo.ListLogStreams(context.Background(), "/nonexistent")
 	if err == nil {
 		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestListLogStreamsPage_WithToken(t *testing.T) {
+	token := "stream-page-2"
+	mock := &mockCloudWatchLogsClient{
+		describeLogStreamsFunc: func(_ context.Context, params *cloudwatchlogs.DescribeLogStreamsInput, _ ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogStreamsOutput, error) {
+			if got := awssdk.ToString(params.NextToken); got != token {
+				t.Fatalf("expected token %q, got %q", token, got)
+			}
+			if awssdk.ToInt32(params.Limit) != 10 {
+				t.Fatalf("expected limit 10, got %d", awssdk.ToInt32(params.Limit))
+			}
+			return &cloudwatchlogs.DescribeLogStreamsOutput{
+				LogStreams: []cwltypes.LogStream{
+					{LogStreamName: awssdk.String("page-2-stream")},
+				},
+				NextToken: awssdk.String("stream-page-3"),
+			}, nil
+		},
+	}
+
+	repo := &AwsRepository{CloudWatchLogsClient: mock}
+	streams, next, err := repo.ListLogStreamsPage(context.Background(), "/aws/lambda/my-function", &token, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(streams) != 1 {
+		t.Fatalf("expected 1 stream, got %d", len(streams))
+	}
+	if streams[0].Name != "page-2-stream" {
+		t.Fatalf("expected page-2-stream, got %q", streams[0].Name)
+	}
+	if next == nil || *next != "stream-page-3" {
+		t.Fatalf("expected next token stream-page-3, got %v", next)
 	}
 }
 


### PR DESCRIPTION
### Summary

- paginate CloudWatch log groups and log streams in batches of 10 so the initial browser screens load faster
- improve Reachability Analyzer loading and result UX with clearer loading context, vertical source-to-destination flow, truncation for narrow terminals, and more readable colored path/findings output
- fix CloudWatch horizontal scrolling behavior so the maximum offset matches the visible viewport width
- update README to reflect the shipped CloudWatch and Reachability Analyzer behavior

### Related Issues

No dedicated issue was referenced for this UX follow-up; shipping as a focused fix/UX PR requested directly from the current repo state.

### Validation

- `make test`
- `make build`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed
- [ ] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [ ] Breaking changes documented
