### PR TITLE
feat: add inspector security rule packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It combines a Bubble Tea application, Cobra-based CLI commands, and AWS SDK v2 c
 - Drill down into resources with filters, detail views, and action screens
 - Show animated loading indicators while async AWS data is being fetched
 - Perform operational workflows such as SSM sessions, RDS control, Route53 record changes, ECS exec, and IAM access key rotation
-- Open the Security Inspector workflow and review scan results by severity as rule packs are added
+- Open the Security Inspector workflow and review built-in findings for Security Groups, RDS, IAM keys, Secrets Manager, and S3 buckets
 
 ## Documentation Map
 
@@ -185,7 +185,7 @@ CLI flags > selected context > config defaults > hardcoded default (us-east-1)
 | IAM | RotateAccessKey |
 | Inspector | Security Scan |
 
-The Inspector feature currently ships the service shell, scan orchestration, and results browser. The first built-in rule packs land in follow-up issues.
+The Inspector feature ships built-in rule packs for Security Group exposure, RDS encryption/public access/backups, IAM access key age, Secrets Manager rotation age, and S3 public access/versioning checks.
 
 ## TUI Navigation
 

--- a/internal/app/screen_inspector.go
+++ b/internal/app/screen_inspector.go
@@ -135,7 +135,7 @@ func (m Model) viewInspectorHome() string {
 	b.WriteString("\n\n")
 	b.WriteString(normalStyle.Render("  Run built-in security scans against the active AWS context."))
 	b.WriteString("\n")
-	b.WriteString(normalStyle.Render("  This slice ships the service shell, scan orchestration, and finding browser."))
+	b.WriteString(normalStyle.Render("  Built-in rule packs cover Security Groups, RDS, IAM access keys, Secrets Manager, and S3 buckets."))
 	b.WriteString("\n")
 	b.WriteString(dimStyle.Render(fmt.Sprintf("  Registered rule packs: %d", awsservice.RegisteredSecurityInspectorScannerCount())))
 	b.WriteString("\n")
@@ -160,7 +160,7 @@ func (m Model) viewInspectorScanning() string {
 	b.WriteString("\n\n")
 	b.WriteString(titleStyle.Render(fmt.Sprintf("%s Running built-in rule packs...", m.loadingSpinner.View())))
 	b.WriteString("\n")
-	b.WriteString(dimStyle.Render("  The first rule packs land in follow-up issues."))
+	b.WriteString(dimStyle.Render("  Checking network exposure, backups, key age, secret rotation, and S3 bucket posture."))
 	return b.String()
 }
 

--- a/internal/services/aws/inspector_rules_identity_secrets.go
+++ b/internal/services/aws/inspector_rules_identity_secrets.go
@@ -12,6 +12,7 @@ const (
 	inspectorIAMAccessKeyMediumAgeDays = 90
 	inspectorIAMAccessKeyHighAgeDays   = 180
 	inspectorSecretRotationAgeDays     = 90
+	inspectorSecretRotationHighAgeDays = 2 * inspectorSecretRotationAgeDays
 )
 
 func init() {
@@ -107,7 +108,7 @@ func buildIAMAccessKeyFinding(userName string, key AccessKey, now time.Time) (Se
 	}
 
 	severity := RuleSeverityMedium
-	if ageDays >= inspectorIAMAccessKeyHighAgeDays {
+	if ageDays >= inspectorSecretRotationHighAgeDays {
 		severity = RuleSeverityHigh
 	}
 

--- a/internal/services/aws/inspector_rules_identity_secrets.go
+++ b/internal/services/aws/inspector_rules_identity_secrets.go
@@ -108,7 +108,7 @@ func buildIAMAccessKeyFinding(userName string, key AccessKey, now time.Time) (Se
 	}
 
 	severity := RuleSeverityMedium
-	if ageDays >= inspectorSecretRotationHighAgeDays {
+	if ageDays >= inspectorIAMAccessKeyHighAgeDays {
 		severity = RuleSeverityHigh
 	}
 
@@ -169,7 +169,7 @@ func buildSecretsRotationFinding(secret Secret, now time.Time) (SecurityFinding,
 	}
 
 	severity := RuleSeverityMedium
-	if ageDays >= inspectorIAMAccessKeyHighAgeDays {
+	if ageDays >= inspectorSecretRotationHighAgeDays {
 		severity = RuleSeverityHigh
 	}
 

--- a/internal/services/aws/inspector_rules_identity_secrets.go
+++ b/internal/services/aws/inspector_rules_identity_secrets.go
@@ -1,0 +1,190 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	inspectorIAMAccessKeyMediumAgeDays = 90
+	inspectorIAMAccessKeyHighAgeDays   = 180
+	inspectorSecretRotationAgeDays     = 90
+)
+
+func init() {
+	registerSecurityInspectorScanner(InspectorScanner{
+		Name: "iam-access-key-age",
+		Run:  runIAMAccessKeyAgeScan,
+	})
+	registerSecurityInspectorScanner(InspectorScanner{
+		Name: "secrets-rotation-age",
+		Run:  runSecretsManagerRotationAgeScan,
+	})
+}
+
+func runIAMAccessKeyAgeScan(ctx context.Context, repo *AwsRepository) ([]SecurityFinding, error) {
+	return inspectIAMAccessKeyAges(ctx, repo, time.Now().UTC())
+}
+
+func runSecretsManagerRotationAgeScan(ctx context.Context, repo *AwsRepository) ([]SecurityFinding, error) {
+	return inspectSecretsManagerRotationAges(ctx, repo, time.Now().UTC())
+}
+
+func inspectIAMAccessKeyAges(ctx context.Context, repo *AwsRepository, now time.Time) ([]SecurityFinding, error) {
+	var findings []SecurityFinding
+	marker := ""
+
+	for {
+		page, err := repo.ListIAMUserSummariesPage(ctx, marker, 100)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, user := range page.Users {
+			keys, err := repo.listUserAccessKeys(ctx, user.UserName)
+			if err != nil {
+				return nil, err
+			}
+			for _, key := range keys {
+				if finding, ok := buildIAMAccessKeyFinding(user.UserName, key, now); ok {
+					findings = append(findings, finding)
+				}
+			}
+		}
+
+		if !page.HasMore || page.NextMarker == "" {
+			break
+		}
+		marker = page.NextMarker
+	}
+
+	sort.Slice(findings, func(i, j int) bool {
+		left := normalizedSortKey(findings[i].ResourceID, findings[i].RuleID, findings[i].RuleName)
+		right := normalizedSortKey(findings[j].ResourceID, findings[j].RuleID, findings[j].RuleName)
+		if left == right {
+			return findings[i].Severity.Rank() < findings[j].Severity.Rank()
+		}
+		return left < right
+	})
+	return findings, nil
+}
+
+func inspectSecretsManagerRotationAges(ctx context.Context, repo *AwsRepository, now time.Time) ([]SecurityFinding, error) {
+	secrets, err := repo.ListSecrets(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	findings := make([]SecurityFinding, 0, len(secrets))
+	for _, secret := range secrets {
+		if finding, ok := buildSecretsRotationFinding(secret, now); ok {
+			findings = append(findings, finding)
+		}
+	}
+
+	sort.Slice(findings, func(i, j int) bool {
+		left := normalizedSortKey(findings[i].ResourceID, findings[i].RuleID, findings[i].RuleName)
+		right := normalizedSortKey(findings[j].ResourceID, findings[j].RuleID, findings[j].RuleName)
+		if left == right {
+			return findings[i].Severity.Rank() < findings[j].Severity.Rank()
+		}
+		return left < right
+	})
+	return findings, nil
+}
+
+func buildIAMAccessKeyFinding(userName string, key AccessKey, now time.Time) (SecurityFinding, bool) {
+	if !strings.EqualFold(key.Status, "active") || key.CreateDate.IsZero() {
+		return SecurityFinding{}, false
+	}
+
+	ageDays := int(now.Sub(key.CreateDate).Hours() / 24)
+	if ageDays < inspectorIAMAccessKeyMediumAgeDays {
+		return SecurityFinding{}, false
+	}
+
+	severity := RuleSeverityMedium
+	if ageDays >= inspectorIAMAccessKeyHighAgeDays {
+		severity = RuleSeverityHigh
+	}
+
+	return SecurityFinding{
+		RuleID:       "iam-access-key-age",
+		RuleName:     "Stale IAM access keys",
+		Severity:     severity,
+		ResourceType: "IAM Access Key",
+		ResourceID:   fmt.Sprintf("%s/%s", userName, key.AccessKeyID),
+		Summary: fmt.Sprintf(
+			"Access key %s for %s is %d days old.",
+			key.AccessKeyID,
+			userName,
+			ageDays,
+		),
+		Recommendation: fmt.Sprintf(
+			"Rotate or remove access keys older than %d days and prefer short-lived credentials where possible.",
+			inspectorIAMAccessKeyMediumAgeDays,
+		),
+	}, true
+}
+
+func buildSecretsRotationFinding(secret Secret, now time.Time) (SecurityFinding, bool) {
+	if !secret.RotationEnabled {
+		return SecurityFinding{
+			RuleID:         "secret-rotation-disabled",
+			RuleName:       "Secrets Manager rotation disabled",
+			Severity:       RuleSeverityHigh,
+			ResourceType:   "Secret",
+			ResourceID:     secret.Name,
+			Summary:        "Automatic rotation is disabled for this secret.",
+			Recommendation: "Enable rotation for secrets that store credentials or other long-lived sensitive material.",
+		}, true
+	}
+
+	referenceTime := secret.LastRotatedDate
+	if referenceTime.IsZero() {
+		referenceTime = secret.LastChangedDate
+	}
+	if referenceTime.IsZero() {
+		referenceTime = secret.CreatedDate
+	}
+	if referenceTime.IsZero() {
+		return SecurityFinding{
+			RuleID:         "secret-rotation-unknown",
+			RuleName:       "Secrets rotation age unavailable",
+			Severity:       RuleSeverityMedium,
+			ResourceType:   "Secret",
+			ResourceID:     secret.Name,
+			Summary:        "Rotation is enabled, but no rotation timestamp is available.",
+			Recommendation: "Review the secret lifecycle and ensure rotation metadata is populated for ongoing monitoring.",
+		}, true
+	}
+
+	ageDays := int(now.Sub(referenceTime).Hours() / 24)
+	if ageDays < inspectorSecretRotationAgeDays {
+		return SecurityFinding{}, false
+	}
+
+	severity := RuleSeverityMedium
+	if ageDays >= inspectorIAMAccessKeyHighAgeDays {
+		severity = RuleSeverityHigh
+	}
+
+	return SecurityFinding{
+		RuleID:       "secret-rotation-age",
+		RuleName:     "Secrets Manager rotation overdue",
+		Severity:     severity,
+		ResourceType: "Secret",
+		ResourceID:   secret.Name,
+		Summary: fmt.Sprintf(
+			"Secret was last rotated or updated %d days ago.",
+			ageDays,
+		),
+		Recommendation: fmt.Sprintf(
+			"Rotate secrets at least every %d days and confirm the secret's rotation schedule is enforced.",
+			inspectorSecretRotationAgeDays,
+		),
+	}, true
+}

--- a/internal/services/aws/inspector_rules_identity_secrets_test.go
+++ b/internal/services/aws/inspector_rules_identity_secrets_test.go
@@ -179,6 +179,7 @@ func TestInspectIAMAccessKeysFlagsStaleActiveKeys(t *testing.T) {
 func TestInspectSecretsManagerRotationFlagsDisabledAndOverdueSecrets(t *testing.T) {
 	now := time.Date(2026, 4, 13, 12, 0, 0, 0, time.UTC)
 	oldRotated := now.AddDate(0, 0, -120)
+	veryOldRotated := now.AddDate(0, 0, -200)
 
 	mockSecrets := &inspectorSecretsMockClient{
 		listSecretsFunc: func(_ context.Context, _ *secretsmanager.ListSecretsInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error) {
@@ -193,6 +194,11 @@ func TestInspectSecretsManagerRotationFlagsDisabledAndOverdueSecrets(t *testing.
 						RotationEnabled: awssdk.Bool(true),
 						LastRotatedDate: &oldRotated,
 					},
+					{
+						Name:            awssdk.String("prod/very-stale-rotation"),
+						RotationEnabled: awssdk.Bool(true),
+						LastRotatedDate: &veryOldRotated,
+					},
 				},
 			}, nil
 		},
@@ -203,8 +209,8 @@ func TestInspectSecretsManagerRotationFlagsDisabledAndOverdueSecrets(t *testing.
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(findings) != 2 {
-		t.Fatalf("expected 2 secret findings, got %d", len(findings))
+	if len(findings) != 3 {
+		t.Fatalf("expected 3 secret findings, got %d", len(findings))
 	}
 
 	if findings[0].ResourceID != "prod/no-rotation" {
@@ -218,5 +224,11 @@ func TestInspectSecretsManagerRotationFlagsDisabledAndOverdueSecrets(t *testing.
 	}
 	if findings[1].Severity != RuleSeverityMedium {
 		t.Fatalf("expected medium severity for stale rotation, got %s", findings[1].Severity)
+	}
+	if findings[2].ResourceID != "prod/very-stale-rotation" {
+		t.Fatalf("expected very overdue rotation finding third, got %+v", findings[2])
+	}
+	if findings[2].Severity != RuleSeverityHigh {
+		t.Fatalf("expected high severity for very stale rotation, got %s", findings[2].Severity)
 	}
 }

--- a/internal/services/aws/inspector_rules_identity_secrets_test.go
+++ b/internal/services/aws/inspector_rules_identity_secrets_test.go
@@ -130,7 +130,7 @@ func TestListSecretsMapsRotationMetadata(t *testing.T) {
 
 func TestInspectIAMAccessKeysFlagsStaleActiveKeys(t *testing.T) {
 	now := time.Date(2026, 4, 13, 12, 0, 0, 0, time.UTC)
-	oldCreate := now.AddDate(0, 0, -200)
+	oldCreate := now.AddDate(0, 0, -inspectorIAMAccessKeyHighAgeDays)
 	recentCreate := now.AddDate(0, 0, -30)
 
 	mockIAM := &inspectorIAMMockClient{
@@ -172,14 +172,14 @@ func TestInspectIAMAccessKeysFlagsStaleActiveKeys(t *testing.T) {
 		t.Fatalf("unexpected resource id: %+v", finding)
 	}
 	if finding.Severity != RuleSeverityHigh {
-		t.Fatalf("expected high severity for 200-day-old key, got %s", finding.Severity)
+		t.Fatalf("expected high severity at the IAM high-age threshold, got %s", finding.Severity)
 	}
 }
 
 func TestInspectSecretsManagerRotationFlagsDisabledAndOverdueSecrets(t *testing.T) {
 	now := time.Date(2026, 4, 13, 12, 0, 0, 0, time.UTC)
 	oldRotated := now.AddDate(0, 0, -120)
-	veryOldRotated := now.AddDate(0, 0, -200)
+	veryOldRotated := now.AddDate(0, 0, -inspectorSecretRotationHighAgeDays)
 
 	mockSecrets := &inspectorSecretsMockClient{
 		listSecretsFunc: func(_ context.Context, _ *secretsmanager.ListSecretsInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error) {
@@ -229,6 +229,6 @@ func TestInspectSecretsManagerRotationFlagsDisabledAndOverdueSecrets(t *testing.
 		t.Fatalf("expected very overdue rotation finding third, got %+v", findings[2])
 	}
 	if findings[2].Severity != RuleSeverityHigh {
-		t.Fatalf("expected high severity for very stale rotation, got %s", findings[2].Severity)
+		t.Fatalf("expected high severity at the secrets high-age threshold, got %s", findings[2].Severity)
 	}
 }

--- a/internal/services/aws/inspector_rules_identity_secrets_test.go
+++ b/internal/services/aws/inspector_rules_identity_secrets_test.go
@@ -1,0 +1,222 @@
+package aws
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+)
+
+type inspectorIAMMockClient struct {
+	listUsersFunc            func(ctx context.Context, params *iam.ListUsersInput, optFns ...func(*iam.Options)) (*iam.ListUsersOutput, error)
+	listAccessKeysFunc       func(ctx context.Context, params *iam.ListAccessKeysInput, optFns ...func(*iam.Options)) (*iam.ListAccessKeysOutput, error)
+	getAccessKeyLastUsedFunc func(ctx context.Context, params *iam.GetAccessKeyLastUsedInput, optFns ...func(*iam.Options)) (*iam.GetAccessKeyLastUsedOutput, error)
+}
+
+func (m *inspectorIAMMockClient) ListUsers(ctx context.Context, params *iam.ListUsersInput, optFns ...func(*iam.Options)) (*iam.ListUsersOutput, error) {
+	if m.listUsersFunc != nil {
+		return m.listUsersFunc(ctx, params, optFns...)
+	}
+	return &iam.ListUsersOutput{}, nil
+}
+
+func (m *inspectorIAMMockClient) GetUser(context.Context, *iam.GetUserInput, ...func(*iam.Options)) (*iam.GetUserOutput, error) {
+	return &iam.GetUserOutput{}, nil
+}
+
+func (m *inspectorIAMMockClient) ListGroupsForUser(context.Context, *iam.ListGroupsForUserInput, ...func(*iam.Options)) (*iam.ListGroupsForUserOutput, error) {
+	return &iam.ListGroupsForUserOutput{}, nil
+}
+
+func (m *inspectorIAMMockClient) ListAttachedUserPolicies(context.Context, *iam.ListAttachedUserPoliciesInput, ...func(*iam.Options)) (*iam.ListAttachedUserPoliciesOutput, error) {
+	return &iam.ListAttachedUserPoliciesOutput{}, nil
+}
+
+func (m *inspectorIAMMockClient) ListMFADevices(context.Context, *iam.ListMFADevicesInput, ...func(*iam.Options)) (*iam.ListMFADevicesOutput, error) {
+	return &iam.ListMFADevicesOutput{}, nil
+}
+
+func (m *inspectorIAMMockClient) ListAccessKeys(ctx context.Context, params *iam.ListAccessKeysInput, optFns ...func(*iam.Options)) (*iam.ListAccessKeysOutput, error) {
+	if m.listAccessKeysFunc != nil {
+		return m.listAccessKeysFunc(ctx, params, optFns...)
+	}
+	return &iam.ListAccessKeysOutput{}, nil
+}
+
+func (m *inspectorIAMMockClient) GetAccessKeyLastUsed(ctx context.Context, params *iam.GetAccessKeyLastUsedInput, optFns ...func(*iam.Options)) (*iam.GetAccessKeyLastUsedOutput, error) {
+	if m.getAccessKeyLastUsedFunc != nil {
+		return m.getAccessKeyLastUsedFunc(ctx, params, optFns...)
+	}
+	return &iam.GetAccessKeyLastUsedOutput{}, nil
+}
+
+func (m *inspectorIAMMockClient) CreateAccessKey(context.Context, *iam.CreateAccessKeyInput, ...func(*iam.Options)) (*iam.CreateAccessKeyOutput, error) {
+	return &iam.CreateAccessKeyOutput{}, nil
+}
+
+func (m *inspectorIAMMockClient) UpdateAccessKey(context.Context, *iam.UpdateAccessKeyInput, ...func(*iam.Options)) (*iam.UpdateAccessKeyOutput, error) {
+	return &iam.UpdateAccessKeyOutput{}, nil
+}
+
+func (m *inspectorIAMMockClient) DeleteAccessKey(context.Context, *iam.DeleteAccessKeyInput, ...func(*iam.Options)) (*iam.DeleteAccessKeyOutput, error) {
+	return &iam.DeleteAccessKeyOutput{}, nil
+}
+
+type inspectorSecretsMockClient struct {
+	listSecretsFunc func(ctx context.Context, params *secretsmanager.ListSecretsInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error)
+}
+
+func (m *inspectorSecretsMockClient) ListSecrets(ctx context.Context, params *secretsmanager.ListSecretsInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error) {
+	if m.listSecretsFunc != nil {
+		return m.listSecretsFunc(ctx, params, optFns...)
+	}
+	return &secretsmanager.ListSecretsOutput{}, nil
+}
+
+func (m *inspectorSecretsMockClient) GetSecretValue(context.Context, *secretsmanager.GetSecretValueInput, ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+	return &secretsmanager.GetSecretValueOutput{}, nil
+}
+
+func TestListSecretsMapsRotationMetadata(t *testing.T) {
+	created := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	lastChanged := time.Date(2026, 2, 1, 12, 0, 0, 0, time.UTC)
+	lastRotated := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	nextRotation := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	mock := &inspectorSecretsMockClient{
+		listSecretsFunc: func(_ context.Context, _ *secretsmanager.ListSecretsInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error) {
+			return &secretsmanager.ListSecretsOutput{
+				SecretList: []smtypes.SecretListEntry{
+					{
+						Name:             awssdk.String("prod/db"),
+						ARN:              awssdk.String("arn:aws:secretsmanager:ap-northeast-2:123456789012:secret:prod/db"),
+						Description:      awssdk.String("database credentials"),
+						KmsKeyId:         awssdk.String("key-123"),
+						RotationEnabled:  awssdk.Bool(true),
+						CreatedDate:      &created,
+						LastChangedDate:  &lastChanged,
+						LastRotatedDate:  &lastRotated,
+						NextRotationDate: &nextRotation,
+					},
+				},
+			}, nil
+		},
+	}
+
+	repo := &AwsRepository{SecretsManagerClient: mock}
+	secrets, err := repo.ListSecrets(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(secrets) != 1 {
+		t.Fatalf("expected 1 secret, got %d", len(secrets))
+	}
+
+	secret := secrets[0]
+	if !secret.RotationEnabled {
+		t.Fatal("expected rotation enabled")
+	}
+	if !secret.CreatedDate.Equal(created) || !secret.LastChangedDate.Equal(lastChanged) || !secret.LastRotatedDate.Equal(lastRotated) {
+		t.Fatalf("unexpected rotation metadata: %+v", secret)
+	}
+	if !secret.NextRotationDate.Equal(nextRotation) {
+		t.Fatalf("unexpected next rotation date: %+v", secret)
+	}
+}
+
+func TestInspectIAMAccessKeysFlagsStaleActiveKeys(t *testing.T) {
+	now := time.Date(2026, 4, 13, 12, 0, 0, 0, time.UTC)
+	oldCreate := now.AddDate(0, 0, -200)
+	recentCreate := now.AddDate(0, 0, -30)
+
+	mockIAM := &inspectorIAMMockClient{
+		listUsersFunc: func(_ context.Context, _ *iam.ListUsersInput, _ ...func(*iam.Options)) (*iam.ListUsersOutput, error) {
+			return &iam.ListUsersOutput{
+				Users: []iamtypes.User{
+					{UserName: awssdk.String("alice")},
+				},
+			}, nil
+		},
+		listAccessKeysFunc: func(_ context.Context, params *iam.ListAccessKeysInput, _ ...func(*iam.Options)) (*iam.ListAccessKeysOutput, error) {
+			if awssdk.ToString(params.UserName) != "alice" {
+				t.Fatalf("unexpected user: %q", awssdk.ToString(params.UserName))
+			}
+			return &iam.ListAccessKeysOutput{
+				AccessKeyMetadata: []iamtypes.AccessKeyMetadata{
+					{AccessKeyId: awssdk.String("AKIAOLD"), Status: iamtypes.StatusTypeActive, CreateDate: &oldCreate},
+					{AccessKeyId: awssdk.String("AKIARECENT"), Status: iamtypes.StatusTypeActive, CreateDate: &recentCreate},
+					{AccessKeyId: awssdk.String("AKIAINACTIVE"), Status: iamtypes.StatusTypeInactive, CreateDate: &oldCreate},
+				},
+			}, nil
+		},
+		getAccessKeyLastUsedFunc: func(_ context.Context, _ *iam.GetAccessKeyLastUsedInput, _ ...func(*iam.Options)) (*iam.GetAccessKeyLastUsedOutput, error) {
+			return &iam.GetAccessKeyLastUsedOutput{}, nil
+		},
+	}
+
+	repo := &AwsRepository{IAMClient: mockIAM}
+	findings, err := inspectIAMAccessKeyAges(context.Background(), repo, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 stale access key finding, got %d", len(findings))
+	}
+
+	finding := findings[0]
+	if finding.ResourceID != "alice/AKIAOLD" {
+		t.Fatalf("unexpected resource id: %+v", finding)
+	}
+	if finding.Severity != RuleSeverityHigh {
+		t.Fatalf("expected high severity for 200-day-old key, got %s", finding.Severity)
+	}
+}
+
+func TestInspectSecretsManagerRotationFlagsDisabledAndOverdueSecrets(t *testing.T) {
+	now := time.Date(2026, 4, 13, 12, 0, 0, 0, time.UTC)
+	oldRotated := now.AddDate(0, 0, -120)
+
+	mockSecrets := &inspectorSecretsMockClient{
+		listSecretsFunc: func(_ context.Context, _ *secretsmanager.ListSecretsInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error) {
+			return &secretsmanager.ListSecretsOutput{
+				SecretList: []smtypes.SecretListEntry{
+					{
+						Name:            awssdk.String("prod/no-rotation"),
+						RotationEnabled: awssdk.Bool(false),
+					},
+					{
+						Name:            awssdk.String("prod/stale-rotation"),
+						RotationEnabled: awssdk.Bool(true),
+						LastRotatedDate: &oldRotated,
+					},
+				},
+			}, nil
+		},
+	}
+
+	repo := &AwsRepository{SecretsManagerClient: mockSecrets}
+	findings, err := inspectSecretsManagerRotationAges(context.Background(), repo, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 secret findings, got %d", len(findings))
+	}
+
+	if findings[0].ResourceID != "prod/no-rotation" {
+		t.Fatalf("expected disabled-rotation finding first, got %+v", findings[0])
+	}
+	if findings[0].Severity != RuleSeverityHigh {
+		t.Fatalf("expected high severity for disabled rotation, got %s", findings[0].Severity)
+	}
+	if findings[1].ResourceID != "prod/stale-rotation" {
+		t.Fatalf("expected overdue rotation finding second, got %+v", findings[1])
+	}
+	if findings[1].Severity != RuleSeverityMedium {
+		t.Fatalf("expected medium severity for stale rotation, got %s", findings[1].Severity)
+	}
+}

--- a/internal/services/aws/inspector_rules_network_rds.go
+++ b/internal/services/aws/inspector_rules_network_rds.go
@@ -1,0 +1,163 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+)
+
+const (
+	inspectorScannerNetworkRDSName = "network-rds"
+
+	inspectorRuleIDSecurityGroupPublicSSH = "sg-public-ssh"
+	inspectorRuleIDSecurityGroupPublicRDP = "sg-public-rdp"
+	inspectorRuleIDSecurityGroupPublicAll = "sg-public-all-traffic"
+	inspectorRuleIDRDSUnencrypted         = "rds-storage-unencrypted"
+	inspectorRuleIDRDSPublic              = "rds-publicly-accessible"
+	inspectorRuleIDRDSBackupsDisabled     = "rds-backups-disabled"
+
+	inspectorPublicIPv4 = "0.0.0.0/0"
+	inspectorPublicIPv6 = "::/0"
+)
+
+func init() {
+	registerSecurityInspectorScanner(InspectorScanner{
+		Name: inspectorScannerNetworkRDSName,
+		Run:  runNetworkRDSInspectorScan,
+	})
+}
+
+func runNetworkRDSInspectorScan(ctx context.Context, r *AwsRepository) ([]SecurityFinding, error) {
+	securityGroups, err := r.ListSecurityGroups(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	instances, err := r.ListDBInstances(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	findings := inspectSecurityGroupExposure(securityGroups)
+	findings = append(findings, inspectRDSMisconfigurations(instances)...)
+	return findings, nil
+}
+
+func inspectSecurityGroupExposure(groups []SecurityGroup) []SecurityFinding {
+	var findings []SecurityFinding
+	for _, group := range groups {
+		for _, rule := range group.IngressRules {
+			if !isInternetIngressRule(rule) {
+				continue
+			}
+
+			switch {
+			case isAllTrafficRule(rule):
+				findings = append(findings, SecurityFinding{
+					RuleID:         inspectorRuleIDSecurityGroupPublicAll,
+					RuleName:       "Unrestricted internet ingress",
+					Severity:       RuleSeverityCritical,
+					ResourceType:   "SecurityGroup",
+					ResourceID:     group.GroupID,
+					Summary:        fmt.Sprintf("Security group %s allows all traffic from %s.", inspectorSecurityGroupLabel(group), inspectorRuleSource(rule)),
+					Recommendation: "Limit ingress to specific protocols, ports, and trusted source CIDRs.",
+				})
+			case allowsTCPPort(rule, 22):
+				findings = append(findings, SecurityFinding{
+					RuleID:         inspectorRuleIDSecurityGroupPublicSSH,
+					RuleName:       "SSH exposed to the internet",
+					Severity:       RuleSeverityHigh,
+					ResourceType:   "SecurityGroup",
+					ResourceID:     group.GroupID,
+					Summary:        fmt.Sprintf("Security group %s allows SSH from %s.", inspectorSecurityGroupLabel(group), inspectorRuleSource(rule)),
+					Recommendation: "Restrict SSH ingress to administrative networks or remove the public rule.",
+				})
+			case allowsTCPPort(rule, 3389):
+				findings = append(findings, SecurityFinding{
+					RuleID:         inspectorRuleIDSecurityGroupPublicRDP,
+					RuleName:       "RDP exposed to the internet",
+					Severity:       RuleSeverityHigh,
+					ResourceType:   "SecurityGroup",
+					ResourceID:     group.GroupID,
+					Summary:        fmt.Sprintf("Security group %s allows RDP from %s.", inspectorSecurityGroupLabel(group), inspectorRuleSource(rule)),
+					Recommendation: "Restrict RDP ingress to trusted networks or remove the public rule.",
+				})
+			}
+		}
+	}
+	return findings
+}
+
+func inspectRDSMisconfigurations(instances []RDSInstance) []SecurityFinding {
+	var findings []SecurityFinding
+	for _, instance := range instances {
+		if !instance.StorageEncrypted {
+			findings = append(findings, SecurityFinding{
+				RuleID:         inspectorRuleIDRDSUnencrypted,
+				RuleName:       "RDS storage encryption disabled",
+				Severity:       RuleSeverityHigh,
+				ResourceType:   "RDSInstance",
+				ResourceID:     instance.DBInstanceID,
+				Summary:        fmt.Sprintf("RDS instance %s does not have storage encryption enabled.", instance.DBInstanceID),
+				Recommendation: "Enable storage encryption for the instance or restore it from an encrypted snapshot.",
+			})
+		}
+		if instance.PubliclyAccessible {
+			findings = append(findings, SecurityFinding{
+				RuleID:         inspectorRuleIDRDSPublic,
+				RuleName:       "RDS instance publicly accessible",
+				Severity:       RuleSeverityHigh,
+				ResourceType:   "RDSInstance",
+				ResourceID:     instance.DBInstanceID,
+				Summary:        fmt.Sprintf("RDS instance %s is marked as publicly accessible.", instance.DBInstanceID),
+				Recommendation: "Disable public accessibility unless the database must be reachable from the internet.",
+			})
+		}
+		if instance.BackupRetentionPeriod <= 0 {
+			findings = append(findings, SecurityFinding{
+				RuleID:         inspectorRuleIDRDSBackupsDisabled,
+				RuleName:       "RDS automated backups disabled",
+				Severity:       RuleSeverityMedium,
+				ResourceType:   "RDSInstance",
+				ResourceID:     instance.DBInstanceID,
+				Summary:        fmt.Sprintf("RDS instance %s has automated backups disabled.", instance.DBInstanceID),
+				Recommendation: "Set a backup retention period to keep automated recoverable snapshots.",
+			})
+		}
+	}
+	return findings
+}
+
+func isInternetIngressRule(rule SecurityGroupRule) bool {
+	return rule.ReferencedSGID == "" && (rule.CIDRV4 == inspectorPublicIPv4 || rule.CIDRV6 == inspectorPublicIPv6)
+}
+
+func isAllTrafficRule(rule SecurityGroupRule) bool {
+	return rule.Protocol == "-1"
+}
+
+func allowsTCPPort(rule SecurityGroupRule, port int32) bool {
+	if rule.Protocol != "tcp" {
+		return false
+	}
+	return rule.FromPort <= port && rule.ToPort >= port
+}
+
+func inspectorRuleSource(rule SecurityGroupRule) string {
+	if rule.CIDRV4 != "" {
+		return rule.CIDRV4
+	}
+	if rule.CIDRV6 != "" {
+		return rule.CIDRV6
+	}
+	return "the internet"
+}
+
+func inspectorSecurityGroupLabel(group SecurityGroup) string {
+	if group.Name == "" {
+		return group.GroupID
+	}
+	if group.GroupID == "" {
+		return group.Name
+	}
+	return fmt.Sprintf("%s (%s)", group.Name, group.GroupID)
+}

--- a/internal/services/aws/inspector_rules_network_rds_test.go
+++ b/internal/services/aws/inspector_rules_network_rds_test.go
@@ -1,0 +1,73 @@
+package aws
+
+import "testing"
+
+func TestInspectSecurityGroupExposure(t *testing.T) {
+	groups := []SecurityGroup{
+		{
+			GroupID: "sg-web",
+			Name:    "web",
+			IngressRules: []SecurityGroupRule{
+				{Protocol: "tcp", FromPort: 22, ToPort: 22, CIDRV4: "0.0.0.0/0"},
+				{Protocol: "tcp", FromPort: 3389, ToPort: 3389, CIDRV4: "0.0.0.0/0"},
+				{Protocol: "-1", CIDRV4: "0.0.0.0/0"},
+				{Protocol: "tcp", FromPort: 443, ToPort: 443, CIDRV4: "10.0.0.0/8"},
+			},
+		},
+		{
+			GroupID: "sg-ipv6",
+			Name:    "ipv6-admin",
+			IngressRules: []SecurityGroupRule{
+				{Protocol: "tcp", FromPort: 22, ToPort: 22, CIDRV6: "::/0"},
+			},
+		},
+	}
+
+	findings := inspectSecurityGroupExposure(groups)
+	if len(findings) != 4 {
+		t.Fatalf("expected 4 findings, got %d", len(findings))
+	}
+	if findings[0].RuleID != inspectorRuleIDSecurityGroupPublicSSH {
+		t.Fatalf("expected first finding to be SSH exposure, got %+v", findings[0])
+	}
+	if findings[1].RuleID != inspectorRuleIDSecurityGroupPublicRDP {
+		t.Fatalf("expected second finding to be RDP exposure, got %+v", findings[1])
+	}
+	if findings[2].RuleID != inspectorRuleIDSecurityGroupPublicAll || findings[2].Severity != RuleSeverityCritical {
+		t.Fatalf("expected third finding to be critical all-traffic exposure, got %+v", findings[2])
+	}
+	if findings[3].RuleID != inspectorRuleIDSecurityGroupPublicSSH || findings[3].ResourceID != "sg-ipv6" {
+		t.Fatalf("expected IPv6 SSH exposure finding last, got %+v", findings[3])
+	}
+}
+
+func TestInspectRDSMisconfigurations(t *testing.T) {
+	instances := []RDSInstance{
+		{
+			DBInstanceID:          "db-prod",
+			StorageEncrypted:      false,
+			PubliclyAccessible:    true,
+			BackupRetentionPeriod: 0,
+		},
+		{
+			DBInstanceID:          "db-ok",
+			StorageEncrypted:      true,
+			PubliclyAccessible:    false,
+			BackupRetentionPeriod: 7,
+		},
+	}
+
+	findings := inspectRDSMisconfigurations(instances)
+	if len(findings) != 3 {
+		t.Fatalf("expected 3 findings, got %d", len(findings))
+	}
+	if findings[0].RuleID != inspectorRuleIDRDSUnencrypted || findings[0].Severity != RuleSeverityHigh {
+		t.Fatalf("unexpected first finding: %+v", findings[0])
+	}
+	if findings[1].RuleID != inspectorRuleIDRDSPublic || findings[1].Severity != RuleSeverityHigh {
+		t.Fatalf("unexpected second finding: %+v", findings[1])
+	}
+	if findings[2].RuleID != inspectorRuleIDRDSBackupsDisabled || findings[2].Severity != RuleSeverityMedium {
+		t.Fatalf("unexpected third finding: %+v", findings[2])
+	}
+}

--- a/internal/services/aws/inspector_rules_s3.go
+++ b/internal/services/aws/inspector_rules_s3.go
@@ -1,0 +1,132 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+const (
+	s3PublicAllUsersURI           = "http://acs.amazonaws.com/groups/global/AllUsers"
+	s3PublicAuthenticatedUsersURI = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
+)
+
+func init() {
+	registerSecurityInspectorScanner(InspectorScanner{
+		Name: "s3",
+		Run:  runS3InspectorScan,
+	})
+}
+
+func runS3InspectorScan(ctx context.Context, r *AwsRepository) ([]SecurityFinding, error) {
+	buckets, err := r.ListBuckets(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list S3 buckets: %w", err)
+	}
+
+	findings := make([]SecurityFinding, 0)
+	for _, bucket := range buckets {
+		findings = append(findings, inspectS3BucketPublicACL(ctx, r, bucket)...)
+		findings = append(findings, inspectS3BucketPolicy(ctx, r, bucket)...)
+		findings = append(findings, inspectS3BucketVersioning(ctx, r, bucket)...)
+	}
+
+	return findings, nil
+}
+
+func inspectS3BucketPublicACL(ctx context.Context, r *AwsRepository, bucket S3Bucket) []SecurityFinding {
+	output, err := r.S3Client.GetBucketAcl(ctx, &s3.GetBucketAclInput{
+		Bucket: awssdk.String(bucket.Name),
+	})
+	if err != nil || output == nil {
+		return nil
+	}
+	if !bucketAclIsPublic(output) {
+		return nil
+	}
+
+	return []SecurityFinding{
+		newS3InspectorFinding(
+			"s3-bucket-public-acl",
+			"S3 bucket ACL grants public access",
+			RuleSeverityHigh,
+			bucket.Name,
+			"Bucket ACL grants access to a public S3 group.",
+			"Remove the public ACL grant or enable S3 Block Public Access for the bucket.",
+		),
+	}
+}
+
+func inspectS3BucketPolicy(ctx context.Context, r *AwsRepository, bucket S3Bucket) []SecurityFinding {
+	output, err := r.S3Client.GetBucketPolicyStatus(ctx, &s3.GetBucketPolicyStatusInput{
+		Bucket: awssdk.String(bucket.Name),
+	})
+	if err != nil || output == nil || output.PolicyStatus == nil {
+		return nil
+	}
+	if !awssdk.ToBool(output.PolicyStatus.IsPublic) {
+		return nil
+	}
+
+	return []SecurityFinding{
+		newS3InspectorFinding(
+			"s3-bucket-public-policy",
+			"S3 bucket policy allows public access",
+			RuleSeverityCritical,
+			bucket.Name,
+			"Bucket policy is public.",
+			"Restrict the bucket policy to trusted principals or enable S3 Block Public Access.",
+		),
+	}
+}
+
+func inspectS3BucketVersioning(ctx context.Context, r *AwsRepository, bucket S3Bucket) []SecurityFinding {
+	output, err := r.S3Client.GetBucketVersioning(ctx, &s3.GetBucketVersioningInput{
+		Bucket: awssdk.String(bucket.Name),
+	})
+	if err != nil || output == nil {
+		return nil
+	}
+	if output.Status == s3types.BucketVersioningStatusEnabled {
+		return nil
+	}
+
+	return []SecurityFinding{
+		newS3InspectorFinding(
+			"s3-bucket-versioning-disabled",
+			"S3 bucket versioning is disabled",
+			RuleSeverityMedium,
+			bucket.Name,
+			"Bucket versioning is not enabled.",
+			"Enable bucket versioning to protect against accidental deletion and overwrites.",
+		),
+	}
+}
+
+func bucketAclIsPublic(output *s3.GetBucketAclOutput) bool {
+	for _, grant := range output.Grants {
+		if grant.Grantee == nil || grant.Grantee.Type != s3types.TypeGroup || grant.Grantee.URI == nil {
+			continue
+		}
+		switch awssdk.ToString(grant.Grantee.URI) {
+		case s3PublicAllUsersURI, s3PublicAuthenticatedUsersURI:
+			return true
+		}
+	}
+	return false
+}
+
+func newS3InspectorFinding(ruleID, ruleName string, severity RuleSeverity, resourceID, summary, recommendation string) SecurityFinding {
+	return SecurityFinding{
+		RuleID:         ruleID,
+		RuleName:       ruleName,
+		Severity:       severity,
+		ResourceType:   "S3 Bucket",
+		ResourceID:     resourceID,
+		Summary:        summary,
+		Recommendation: recommendation,
+	}
+}

--- a/internal/services/aws/inspector_rules_s3_test.go
+++ b/internal/services/aws/inspector_rules_s3_test.go
@@ -1,0 +1,105 @@
+package aws
+
+import (
+	"context"
+	"testing"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+func TestRunS3InspectorScan_FindsPublicACLPolicyAndVersioning(t *testing.T) {
+	mock := &mockS3Client{
+		listBucketsFunc: func(_ context.Context, _ *s3.ListBucketsInput, _ ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
+			return &s3.ListBucketsOutput{
+				Buckets: []s3types.Bucket{
+					{Name: awssdk.String("public-bucket")},
+				},
+			}, nil
+		},
+		getBucketAclFunc: func(_ context.Context, in *s3.GetBucketAclInput, _ ...func(*s3.Options)) (*s3.GetBucketAclOutput, error) {
+			if awssdk.ToString(in.Bucket) != "public-bucket" {
+				t.Fatalf("unexpected bucket for ACL lookup: %q", awssdk.ToString(in.Bucket))
+			}
+			return &s3.GetBucketAclOutput{
+				Grants: []s3types.Grant{
+					{
+						Grantee: &s3types.Grantee{
+							Type: s3types.TypeGroup,
+							URI:  awssdk.String(s3PublicAllUsersURI),
+						},
+						Permission: s3types.PermissionRead,
+					},
+				},
+			}, nil
+		},
+		getBucketPolicyStatusFunc: func(_ context.Context, in *s3.GetBucketPolicyStatusInput, _ ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error) {
+			if awssdk.ToString(in.Bucket) != "public-bucket" {
+				t.Fatalf("unexpected bucket for policy lookup: %q", awssdk.ToString(in.Bucket))
+			}
+			return &s3.GetBucketPolicyStatusOutput{
+				PolicyStatus: &s3types.PolicyStatus{IsPublic: awssdk.Bool(true)},
+			}, nil
+		},
+		getBucketVersioningFunc: func(_ context.Context, in *s3.GetBucketVersioningInput, _ ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error) {
+			if awssdk.ToString(in.Bucket) != "public-bucket" {
+				t.Fatalf("unexpected bucket for versioning lookup: %q", awssdk.ToString(in.Bucket))
+			}
+			return &s3.GetBucketVersioningOutput{
+				Status: s3types.BucketVersioningStatusSuspended,
+			}, nil
+		},
+	}
+
+	findings, err := runS3InspectorScan(context.Background(), &AwsRepository{S3Client: mock})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 3 {
+		t.Fatalf("expected 3 findings, got %d", len(findings))
+	}
+
+	if findings[0].RuleID != "s3-bucket-public-acl" || findings[0].Severity != RuleSeverityHigh {
+		t.Fatalf("unexpected ACL finding: %+v", findings[0])
+	}
+	if findings[1].RuleID != "s3-bucket-public-policy" || findings[1].Severity != RuleSeverityCritical {
+		t.Fatalf("unexpected policy finding: %+v", findings[1])
+	}
+	if findings[2].RuleID != "s3-bucket-versioning-disabled" || findings[2].Severity != RuleSeverityMedium {
+		t.Fatalf("unexpected versioning finding: %+v", findings[2])
+	}
+}
+
+func TestRunS3InspectorScan_IgnoresPrivateBuckets(t *testing.T) {
+	mock := &mockS3Client{
+		listBucketsFunc: func(_ context.Context, _ *s3.ListBucketsInput, _ ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
+			return &s3.ListBucketsOutput{
+				Buckets: []s3types.Bucket{
+					{Name: awssdk.String("private-bucket")},
+				},
+			}, nil
+		},
+		getBucketAclFunc: func(_ context.Context, _ *s3.GetBucketAclInput, _ ...func(*s3.Options)) (*s3.GetBucketAclOutput, error) {
+			return &s3.GetBucketAclOutput{}, nil
+		},
+		getBucketPolicyStatusFunc: func(_ context.Context, _ *s3.GetBucketPolicyStatusInput, _ ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error) {
+			return &s3.GetBucketPolicyStatusOutput{
+				PolicyStatus: &s3types.PolicyStatus{IsPublic: awssdk.Bool(false)},
+			}, nil
+		},
+		getBucketVersioningFunc: func(_ context.Context, _ *s3.GetBucketVersioningInput, _ ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error) {
+			return &s3.GetBucketVersioningOutput{
+				Status: s3types.BucketVersioningStatusEnabled,
+			}, nil
+		},
+	}
+
+	findings, err := runS3InspectorScan(context.Background(), &AwsRepository{S3Client: mock})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}

--- a/internal/services/aws/rds.go
+++ b/internal/services/aws/rds.go
@@ -22,14 +22,17 @@ func (r *AwsRepository) ListDBInstances(ctx context.Context) ([]RDSInstance, err
 	instances := make([]RDSInstance, 0, len(output.DBInstances))
 	for _, db := range output.DBInstances {
 		inst := RDSInstance{
-			DBInstanceID:  awssdk.ToString(db.DBInstanceIdentifier),
-			Engine:        awssdk.ToString(db.Engine),
-			EngineVersion: awssdk.ToString(db.EngineVersion),
-			Status:        awssdk.ToString(db.DBInstanceStatus),
-			InstanceClass: awssdk.ToString(db.DBInstanceClass),
-			MultiAZ:       awssdk.ToBool(db.MultiAZ),
-			StorageGB:     awssdk.ToInt32(db.AllocatedStorage),
-			ClusterID:     awssdk.ToString(db.DBClusterIdentifier),
+			DBInstanceID:          awssdk.ToString(db.DBInstanceIdentifier),
+			Engine:                awssdk.ToString(db.Engine),
+			EngineVersion:         awssdk.ToString(db.EngineVersion),
+			Status:                awssdk.ToString(db.DBInstanceStatus),
+			InstanceClass:         awssdk.ToString(db.DBInstanceClass),
+			MultiAZ:               awssdk.ToBool(db.MultiAZ),
+			StorageGB:             awssdk.ToInt32(db.AllocatedStorage),
+			StorageEncrypted:      awssdk.ToBool(db.StorageEncrypted),
+			PubliclyAccessible:    awssdk.ToBool(db.PubliclyAccessible),
+			BackupRetentionPeriod: awssdk.ToInt32(db.BackupRetentionPeriod),
+			ClusterID:             awssdk.ToString(db.DBClusterIdentifier),
 		}
 
 		// Endpoint may be nil for stopped instances
@@ -65,14 +68,17 @@ func (r *AwsRepository) DescribeDBInstance(ctx context.Context, dbInstanceID str
 
 	db := output.DBInstances[0]
 	inst := &RDSInstance{
-		DBInstanceID:  awssdk.ToString(db.DBInstanceIdentifier),
-		Engine:        awssdk.ToString(db.Engine),
-		EngineVersion: awssdk.ToString(db.EngineVersion),
-		Status:        awssdk.ToString(db.DBInstanceStatus),
-		InstanceClass: awssdk.ToString(db.DBInstanceClass),
-		MultiAZ:       awssdk.ToBool(db.MultiAZ),
-		StorageGB:     awssdk.ToInt32(db.AllocatedStorage),
-		ClusterID:     awssdk.ToString(db.DBClusterIdentifier),
+		DBInstanceID:          awssdk.ToString(db.DBInstanceIdentifier),
+		Engine:                awssdk.ToString(db.Engine),
+		EngineVersion:         awssdk.ToString(db.EngineVersion),
+		Status:                awssdk.ToString(db.DBInstanceStatus),
+		InstanceClass:         awssdk.ToString(db.DBInstanceClass),
+		MultiAZ:               awssdk.ToBool(db.MultiAZ),
+		StorageGB:             awssdk.ToInt32(db.AllocatedStorage),
+		StorageEncrypted:      awssdk.ToBool(db.StorageEncrypted),
+		PubliclyAccessible:    awssdk.ToBool(db.PubliclyAccessible),
+		BackupRetentionPeriod: awssdk.ToInt32(db.BackupRetentionPeriod),
+		ClusterID:             awssdk.ToString(db.DBClusterIdentifier),
 	}
 	if db.Endpoint != nil {
 		inst.Endpoint = fmt.Sprintf("%s:%d", awssdk.ToString(db.Endpoint.Address), awssdk.ToInt32(db.Endpoint.Port))

--- a/internal/services/aws/rds_model.go
+++ b/internal/services/aws/rds_model.go
@@ -7,15 +7,18 @@ import (
 
 // RDSInstance holds essential information about an RDS database instance.
 type RDSInstance struct {
-	DBInstanceID  string
-	Engine        string
-	EngineVersion string
-	Status        string
-	InstanceClass string
-	MultiAZ       bool
-	StorageGB     int32
-	Endpoint      string
-	ClusterID     string
+	DBInstanceID          string
+	Engine                string
+	EngineVersion         string
+	Status                string
+	InstanceClass         string
+	MultiAZ               bool
+	StorageGB             int32
+	StorageEncrypted      bool
+	PubliclyAccessible    bool
+	BackupRetentionPeriod int32
+	Endpoint              string
+	ClusterID             string
 }
 
 // DisplayTitle returns a formatted string for list display.

--- a/internal/services/aws/rds_test.go
+++ b/internal/services/aws/rds_test.go
@@ -254,13 +254,16 @@ func TestDescribeDBInstance_Success(t *testing.T) {
 			return &rds.DescribeDBInstancesOutput{
 				DBInstances: []rdstypes.DBInstance{
 					{
-						DBInstanceIdentifier: awssdk.String("my-db"),
-						Engine:               awssdk.String("mysql"),
-						EngineVersion:        awssdk.String("8.0.35"),
-						DBInstanceStatus:     awssdk.String("available"),
-						DBInstanceClass:      awssdk.String("db.t3.micro"),
-						MultiAZ:              awssdk.Bool(false),
-						AllocatedStorage:     awssdk.Int32(20),
+						DBInstanceIdentifier:  awssdk.String("my-db"),
+						Engine:                awssdk.String("mysql"),
+						EngineVersion:         awssdk.String("8.0.35"),
+						DBInstanceStatus:      awssdk.String("available"),
+						DBInstanceClass:       awssdk.String("db.t3.micro"),
+						MultiAZ:               awssdk.Bool(false),
+						AllocatedStorage:      awssdk.Int32(20),
+						StorageEncrypted:      awssdk.Bool(true),
+						PubliclyAccessible:    awssdk.Bool(true),
+						BackupRetentionPeriod: awssdk.Int32(7),
 						Endpoint: &rdstypes.Endpoint{
 							Address: awssdk.String("my-db.abc123.us-east-1.rds.amazonaws.com"),
 							Port:    awssdk.Int32(3306),
@@ -278,6 +281,50 @@ func TestDescribeDBInstance_Success(t *testing.T) {
 	}
 	if inst.DBInstanceID != "my-db" {
 		t.Errorf("expected 'my-db', got %q", inst.DBInstanceID)
+	}
+	if !inst.StorageEncrypted {
+		t.Error("expected storage encryption to be mapped")
+	}
+	if !inst.PubliclyAccessible {
+		t.Error("expected public accessibility to be mapped")
+	}
+	if inst.BackupRetentionPeriod != 7 {
+		t.Errorf("expected backup retention period 7, got %d", inst.BackupRetentionPeriod)
+	}
+}
+
+func TestListDBInstances_MapsInspectorFields(t *testing.T) {
+	mock := &mockRDSClient{
+		describeDBInstancesFunc: func(_ context.Context, _ *rds.DescribeDBInstancesInput, _ ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error) {
+			return &rds.DescribeDBInstancesOutput{
+				DBInstances: []rdstypes.DBInstance{
+					{
+						DBInstanceIdentifier:  awssdk.String("my-db"),
+						StorageEncrypted:      awssdk.Bool(true),
+						PubliclyAccessible:    awssdk.Bool(false),
+						BackupRetentionPeriod: awssdk.Int32(14),
+					},
+				},
+			}, nil
+		},
+	}
+
+	repo := &AwsRepository{RDSClient: mock}
+	instances, err := repo.ListDBInstances(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(instances) != 1 {
+		t.Fatalf("expected 1 instance, got %d", len(instances))
+	}
+	if !instances[0].StorageEncrypted {
+		t.Error("expected storage encryption to be mapped")
+	}
+	if instances[0].PubliclyAccessible {
+		t.Error("expected public accessibility to be false")
+	}
+	if instances[0].BackupRetentionPeriod != 14 {
+		t.Errorf("expected backup retention period 14, got %d", instances[0].BackupRetentionPeriod)
 	}
 }
 

--- a/internal/services/aws/repository.go
+++ b/internal/services/aws/repository.go
@@ -125,6 +125,9 @@ type S3ClientAPI interface {
 	ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
 	HeadObject(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
 	GetBucketLocation(ctx context.Context, params *s3.GetBucketLocationInput, optFns ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error)
+	GetBucketAcl(ctx context.Context, params *s3.GetBucketAclInput, optFns ...func(*s3.Options)) (*s3.GetBucketAclOutput, error)
+	GetBucketPolicyStatus(ctx context.Context, params *s3.GetBucketPolicyStatusInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error)
+	GetBucketVersioning(ctx context.Context, params *s3.GetBucketVersioningInput, optFns ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error)
 }
 
 // EC2ClientAPI is the interface for EC2 operations used by AwsRepository.

--- a/internal/services/aws/s3_test.go
+++ b/internal/services/aws/s3_test.go
@@ -13,10 +13,13 @@ import (
 )
 
 type mockS3Client struct {
-	listBucketsFunc       func(ctx context.Context, params *s3.ListBucketsInput, optFns ...func(*s3.Options)) (*s3.ListBucketsOutput, error)
-	listObjectsV2Func     func(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
-	headObjectFunc        func(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
-	getBucketLocationFunc func(ctx context.Context, params *s3.GetBucketLocationInput, optFns ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error)
+	listBucketsFunc           func(ctx context.Context, params *s3.ListBucketsInput, optFns ...func(*s3.Options)) (*s3.ListBucketsOutput, error)
+	listObjectsV2Func         func(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+	headObjectFunc            func(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
+	getBucketLocationFunc     func(ctx context.Context, params *s3.GetBucketLocationInput, optFns ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error)
+	getBucketAclFunc          func(ctx context.Context, params *s3.GetBucketAclInput, optFns ...func(*s3.Options)) (*s3.GetBucketAclOutput, error)
+	getBucketPolicyStatusFunc func(ctx context.Context, params *s3.GetBucketPolicyStatusInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error)
+	getBucketVersioningFunc   func(ctx context.Context, params *s3.GetBucketVersioningInput, optFns ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error)
 }
 
 func (m *mockS3Client) ListBuckets(ctx context.Context, params *s3.ListBucketsInput, optFns ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
@@ -32,7 +35,31 @@ func (m *mockS3Client) HeadObject(ctx context.Context, params *s3.HeadObjectInpu
 }
 
 func (m *mockS3Client) GetBucketLocation(ctx context.Context, params *s3.GetBucketLocationInput, optFns ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error) {
-	return m.getBucketLocationFunc(ctx, params, optFns...)
+	if m.getBucketLocationFunc != nil {
+		return m.getBucketLocationFunc(ctx, params, optFns...)
+	}
+	return &s3.GetBucketLocationOutput{}, nil
+}
+
+func (m *mockS3Client) GetBucketAcl(ctx context.Context, params *s3.GetBucketAclInput, optFns ...func(*s3.Options)) (*s3.GetBucketAclOutput, error) {
+	if m.getBucketAclFunc != nil {
+		return m.getBucketAclFunc(ctx, params, optFns...)
+	}
+	return &s3.GetBucketAclOutput{}, nil
+}
+
+func (m *mockS3Client) GetBucketPolicyStatus(ctx context.Context, params *s3.GetBucketPolicyStatusInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error) {
+	if m.getBucketPolicyStatusFunc != nil {
+		return m.getBucketPolicyStatusFunc(ctx, params, optFns...)
+	}
+	return &s3.GetBucketPolicyStatusOutput{}, nil
+}
+
+func (m *mockS3Client) GetBucketVersioning(ctx context.Context, params *s3.GetBucketVersioningInput, optFns ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error) {
+	if m.getBucketVersioningFunc != nil {
+		return m.getBucketVersioningFunc(ctx, params, optFns...)
+	}
+	return &s3.GetBucketVersioningOutput{}, nil
 }
 
 func TestListBuckets_Success(t *testing.T) {

--- a/internal/services/aws/secretsmanager.go
+++ b/internal/services/aws/secretsmanager.go
@@ -22,10 +22,15 @@ func (r *AwsRepository) ListSecrets(ctx context.Context) ([]Secret, error) {
 	secrets := make([]Secret, 0, len(output.SecretList))
 	for _, s := range output.SecretList {
 		secrets = append(secrets, Secret{
-			Name:        awssdk.ToString(s.Name),
-			ARN:         awssdk.ToString(s.ARN),
-			Description: awssdk.ToString(s.Description),
-			KMSKeyID:    awssdk.ToString(s.KmsKeyId),
+			Name:             awssdk.ToString(s.Name),
+			ARN:              awssdk.ToString(s.ARN),
+			Description:      awssdk.ToString(s.Description),
+			KMSKeyID:         awssdk.ToString(s.KmsKeyId),
+			RotationEnabled:  awssdk.ToBool(s.RotationEnabled),
+			CreatedDate:      awssdk.ToTime(s.CreatedDate),
+			LastChangedDate:  awssdk.ToTime(s.LastChangedDate),
+			LastRotatedDate:  awssdk.ToTime(s.LastRotatedDate),
+			NextRotationDate: awssdk.ToTime(s.NextRotationDate),
 		})
 	}
 	return secrets, nil

--- a/internal/services/aws/secretsmanager_model.go
+++ b/internal/services/aws/secretsmanager_model.go
@@ -3,14 +3,20 @@ package aws
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 // Secret holds essential information about an AWS Secrets Manager secret.
 type Secret struct {
-	Name        string
-	ARN         string
-	Description string
-	KMSKeyID    string
+	Name             string
+	ARN              string
+	Description      string
+	KMSKeyID         string
+	CreatedDate      time.Time
+	LastChangedDate  time.Time
+	LastRotatedDate  time.Time
+	NextRotationDate time.Time
+	RotationEnabled  bool
 }
 
 // SecretDetail holds the full detail of a secret including its key/value pairs.


### PR DESCRIPTION
### Summary

This PR adds the first built-in Security Inspector rule packs with these checks:

- Security Groups: SSH exposed to 0.0.0.0/0 or ::/0, RDP exposed to 0.0.0.0/0 or ::/0, and unrestricted all-traffic ingress from the internet
- RDS: storage encryption disabled, public accessibility enabled, and automated backups disabled
- IAM: stale active access keys
- Secrets Manager: rotation disabled and rotation overdue
- S3: public ACL grants, public bucket policies, and disabled bucket versioning

It also enriches the RDS and Secrets models plus the S3 client interface so the scanners can evaluate live AWS state, and it updates Inspector UI copy and README to reflect the shipped rule coverage.

### Related Issues

Closes #90
Closes #91
Closes #92

### Validation

- GOCACHE=/tmp/unic-go-build make test
- GOCACHE=/tmp/unic-go-build make build

### Checklist

- [x] Scope is focused
- [x] Branch name follows docs/branch-naming-harness.md
- [x] Documentation harness reviewed (docs/documentation-harness.md)
- [x] README updated if user-facing behavior changed
- [x] Relevant docs/ pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented