### PR TITLE
feat: add keyboard shortcut help screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ It combines a Bubble Tea application, Cobra-based CLI commands, and AWS SDK v2 c
 - Switch between credential, assume-role, and SSO contexts
 - Export shell environment variables for the active context
 - Drill down into resources with filters, detail views, and action screens
+- Open a context-aware keyboard shortcut help screen with `?`
 - Show animated loading indicators while async AWS data is being fetched
 - Perform operational workflows such as SSM sessions, RDS control, Route53 record changes, ECS exec, and IAM access key rotation
 - Open the Security Inspector workflow and review built-in findings for Security Groups, RDS, IAM keys, Secrets Manager, and S3 buckets
@@ -200,6 +201,7 @@ The Inspector feature ships built-in rule packs for Security Group exposure, RDS
 | `H` | Jump to service list |
 | `C` | Open context picker |
 | `/` | Toggle filter mode on supported screens |
+| `?` | Toggle context-aware shortcut help |
 | `Ctrl+C` | Force quit |
 
 ### Service-specific highlights

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -295,6 +295,7 @@ type Model struct {
 	filterTI       textinput.Model
 	activeFilter   filterTarget
 	filters        map[filterTarget]string
+	helpVisible    bool
 
 	// Terminal size
 	width  int
@@ -423,6 +424,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.String() == "ctrl+c" {
 			m.quitting = true
 			return m, tea.Quit
+		}
+		if msg.String() == "?" {
+			m.helpVisible = !m.helpVisible
+			return m, nil
+		}
+		if m.helpVisible {
+			switch msg.String() {
+			case "esc", "enter":
+				m.helpVisible = false
+			}
+			return m, nil
 		}
 		// Global home — return to service list from any screen (skip text-input screens)
 		if msg.String() == "H" && m.screen != screenServiceList && m.screen != screenContextPicker &&
@@ -682,6 +694,10 @@ func (m Model) updateError(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m Model) View() string {
 	if m.quitting {
 		return ""
+	}
+
+	if m.helpVisible {
+		return m.fitToHeight(m.viewHelp())
 	}
 
 	var v string

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -210,6 +210,89 @@ func TestFeatureListEscGoesBack(t *testing.T) {
 	}
 }
 
+func TestHelpToggleAndClose(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenServiceList
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	model := updated.(Model)
+	if !model.helpVisible {
+		t.Fatal("expected help overlay to open")
+	}
+	if model.screen != screenServiceList {
+		t.Fatalf("expected screen to stay on service list, got %v", model.screen)
+	}
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	model = updated.(Model)
+	if model.helpVisible {
+		t.Fatal("expected help overlay to close on esc")
+	}
+}
+
+func TestHelpBlocksNavigationWhileOpen(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenServiceList
+	m.svcIdx = 0
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	model := updated.(Model)
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	model = updated.(Model)
+
+	if model.svcIdx != 0 {
+		t.Fatalf("expected selection to stay unchanged while help is open, got %d", model.svcIdx)
+	}
+	if !model.helpVisible {
+		t.Fatal("expected help overlay to remain open on non-close keys")
+	}
+}
+
+func TestHelpViewShowsContextAwareRDSActions(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenRDSDetail
+	m.selectedRDS = &awsservice.RDSInstance{
+		DBInstanceID:  "db-1",
+		Status:        "available",
+		MultiAZ:       true,
+		ClusterID:     "",
+		InstanceClass: "db.t3.micro",
+	}
+	m.helpVisible = true
+
+	view := m.View()
+	for _, want := range []string{
+		"Keyboard Shortcuts",
+		"Screen: RDS Detail",
+		"Stop the selected instance or cluster",
+		"Trigger failover for the selected instance or cluster",
+		"Refresh the selected instance status",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected help view to contain %q, got %q", want, view)
+		}
+	}
+}
+
+func TestHelpViewShowsFilterModeShortcuts(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenSecretList
+	_ = m.activateFilter(filterSecrets)
+	m.helpVisible = true
+
+	view := m.View()
+	for _, want := range []string{
+		"Current Mode",
+		"Update the filter query",
+		"Delete the previous character",
+		"Close filter mode",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected filter help to contain %q, got %q", want, view)
+		}
+	}
+}
+
 // --- RDS screen tests ---
 
 func TestRDSListNavigation(t *testing.T) {

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -1,0 +1,606 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+)
+
+type helpShortcut struct {
+	keys        string
+	description string
+}
+
+type helpSection struct {
+	title     string
+	shortcuts []helpShortcut
+}
+
+func (m Model) viewHelp() string {
+	var b strings.Builder
+	b.WriteString(m.renderStatusBar())
+	b.WriteString(titleStyle.Render("Keyboard Shortcuts"))
+	b.WriteString("\n")
+	b.WriteString(dimStyle.Render(fmt.Sprintf("Screen: %s", m.helpScreenTitle())))
+	b.WriteString("\n\n")
+
+	keyWidth := 22
+	for _, section := range m.helpSections() {
+		if len(section.shortcuts) == 0 {
+			continue
+		}
+		b.WriteString(titleStyle.Render(section.title))
+		b.WriteString("\n")
+		for _, shortcut := range section.shortcuts {
+			b.WriteString(normalStyle.Render(fmt.Sprintf("  %-*s %s", keyWidth, shortcut.keys, shortcut.description)))
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString(dimStyle.Render("?: close help • esc: close help • enter: close help"))
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func (m Model) helpSections() []helpSection {
+	sections := []helpSection{
+		{
+			title: "Help",
+			shortcuts: []helpShortcut{
+				{"ctrl+c", "Force quit unic"},
+			},
+		},
+	}
+
+	if global := m.globalHelpShortcuts(); len(global) > 0 {
+		sections = append(sections, helpSection{title: "Global", shortcuts: global})
+	}
+	if mode := m.helpModeShortcuts(); len(mode) > 0 {
+		sections = append(sections, helpSection{title: "Current Mode", shortcuts: mode})
+	}
+	if current := m.currentScreenShortcuts(); len(current) > 0 {
+		sections = append(sections, helpSection{title: "Current Screen", shortcuts: current})
+	}
+
+	return sections
+}
+
+func (m Model) globalHelpShortcuts() []helpShortcut {
+	var shortcuts []helpShortcut
+	if m.screen != screenServiceList && m.screen != screenContextPicker &&
+		m.screen != screenSecurityGroupAddRule && m.screen != screenSecurityGroupDeleteConfirm {
+		shortcuts = append(shortcuts, helpShortcut{"H", "Jump to the service list"})
+	}
+	if m.screen != screenContextPicker &&
+		m.screen != screenSecurityGroupAddRule && m.screen != screenSecurityGroupDeleteConfirm {
+		shortcuts = append(shortcuts, helpShortcut{"C", "Open the context picker"})
+	}
+	return shortcuts
+}
+
+func (m Model) helpModeShortcuts() []helpShortcut {
+	switch {
+	case m.filterTI.Focused():
+		shortcuts := []helpShortcut{
+			{"type", "Update the filter query"},
+			{"backspace", "Delete the previous character"},
+		}
+		if m.screen == screenCWLogViewer {
+			shortcuts = append(shortcuts, helpShortcut{"enter", "Apply the log filter and reload events"})
+		} else {
+			shortcuts = append(shortcuts, helpShortcut{"enter", "Close filter mode"})
+		}
+		shortcuts = append(shortcuts, helpShortcut{"esc", "Close filter mode"})
+		return shortcuts
+	case m.screen == screenReachabilityRegionList && m.reachabilityRegionFiltering:
+		return []helpShortcut{
+			{"type", "Update the region filter"},
+			{"backspace", "Delete the previous character"},
+			{"enter / esc", "Close region filter mode"},
+		}
+	case (m.screen == screenReachabilitySourceList || m.screen == screenReachabilityDestinationList) && m.reachabilityFilterActive:
+		return []helpShortcut{
+			{"type", "Update the target filter"},
+			{"backspace", "Delete the previous character"},
+			{"enter / esc", "Close target filter mode"},
+		}
+	}
+	return nil
+}
+
+func (m Model) currentScreenShortcuts() []helpShortcut {
+	switch m.screen {
+	case screenServiceList:
+		return []helpShortcut{
+			{"↑/↓, j/k", "Move between AWS services"},
+			{"enter", "Open the selected service"},
+			{"esc", "Open the context picker"},
+			{"q", "Quit unic"},
+		}
+	case screenFeatureList:
+		return []helpShortcut{
+			{"↑/↓, j/k", "Move between features"},
+			{"enter", "Open the selected feature"},
+			{"esc", "Go back to the service list"},
+		}
+	case screenInstanceList:
+		return listScreenShortcuts("connect to the selected instance", "go back to the feature list", true, true)
+	case screenVPCList:
+		return []helpShortcut{
+			{"↑/↓, j/k", "Move between VPCs"},
+			{"enter", "Open the subnet list for the selected VPC"},
+			{"q / esc", "Go back to the feature list"},
+		}
+	case screenSubnetList:
+		return []helpShortcut{
+			{"↑/↓, j/k", "Move between subnets"},
+			{"enter", "Open subnet IP details"},
+			{"q / esc", "Go back to the VPC list"},
+		}
+	case screenSubnetDetail:
+		return []helpShortcut{
+			{"↑/↓, j/k", "Scroll available IP addresses"},
+			{"/", "Start filtering available IPs"},
+			{"q / esc", "Go back to the subnet list"},
+		}
+	case screenReachabilityRegionList:
+		return []helpShortcut{
+			{"↑/↓, j/k", "Move between supported regions"},
+			{"/", "Start filtering regions"},
+			{"enter", "Load reachability targets for the selected region"},
+			{"q / esc", "Go back to the feature list"},
+		}
+	case screenReachabilitySourceList:
+		return reachabilityTargetShortcuts("source", true)
+	case screenReachabilityDestinationList:
+		return []helpShortcut{
+			{"←/→, h/l, tab", "Switch destination resource type"},
+			{"↑/↓, j/k", "Move between destinations"},
+			{"/", "Start filtering destinations"},
+			{"r", "Reload reachability targets"},
+			{"enter", "Select the destination and continue"},
+			{"esc", "Go back to the source picker"},
+			{"q", "Go back to the feature list"},
+		}
+	case screenReachabilityConfig:
+		shortcuts := []helpShortcut{
+			{"↑/↓, j/k, tab", "Move between analysis fields"},
+			{"←/→, h/l", "Change the selected protocol"},
+			{"type", "Edit the active port or destination IP field"},
+			{"backspace", "Delete the previous character"},
+			{"enter", "Advance fields or run the analysis"},
+			{"esc", "Go back to the destination picker"},
+			{"q", "Go back to the feature list"},
+		}
+		return shortcuts
+	case screenReachabilityResult:
+		return []helpShortcut{
+			{"↑/↓, j/k", "Scroll the analysis result"},
+			{"r", "Run the reachability analysis again"},
+			{"esc", "Go back to the analysis config"},
+			{"q", "Go back to the feature list"},
+		}
+	case screenRDSList:
+		return listScreenShortcuts("open the selected instance", "go back to the feature list", true, false)
+	case screenRDSDetail:
+		shortcuts := []helpShortcut{
+			{"r", "Refresh the selected instance status"},
+			{"q / esc", "Go back to the instance list"},
+		}
+		if m.selectedRDS != nil && m.selectedRDS.CanStart() {
+			shortcuts = append([]helpShortcut{{"s", "Start the selected instance or cluster"}}, shortcuts...)
+		}
+		if m.selectedRDS != nil && m.selectedRDS.CanStop() {
+			shortcuts = append([]helpShortcut{{"x", "Stop the selected instance or cluster"}}, shortcuts...)
+		}
+		if m.selectedRDS != nil && m.selectedRDS.CanFailover() {
+			shortcuts = append([]helpShortcut{{"f", "Trigger failover for the selected instance or cluster"}}, shortcuts...)
+		}
+		return shortcuts
+	case screenRDSConfirm:
+		if m.rdsAction == "start" {
+			return []helpShortcut{
+				{"y / enter", "Confirm the start action"},
+				{"n / esc", "Cancel and return to the detail screen"},
+			}
+		}
+		target := "instance identifier"
+		if m.selectedRDS != nil && m.selectedRDS.IsClusterMember() {
+			target = "cluster identifier"
+		}
+		return []helpShortcut{
+			{"type", fmt.Sprintf("Enter the %s to confirm", target)},
+			{"backspace", "Delete the previous character"},
+			{"enter", "Confirm when the typed identifier matches"},
+			{"esc", "Cancel and return to the detail screen"},
+		}
+	case screenRoute53ZoneList:
+		return listScreenShortcuts("open the selected hosted zone", "go back to the feature list", true, false)
+	case screenRoute53RecordList:
+		shortcuts := listScreenShortcuts("open the selected record", "go back to the hosted zone list", true, false)
+		return append(shortcuts[:3], append([]helpShortcut{{"c", "Create a new DNS record"}}, shortcuts[3:]...)...)
+	case screenRoute53RecordDetail:
+		shortcuts := []helpShortcut{
+			{"c", "Create a new DNS record"},
+			{"q / esc", "Go back to the record list"},
+		}
+		if m.selectedRoute53Record != nil {
+			canEdit := m.selectedRoute53Record.AliasTarget == "" &&
+				(m.selectedRoute53Record.Type == "A" || m.selectedRoute53Record.Type == "CNAME")
+			canDelete := m.selectedRoute53Record.Type != "NS" && m.selectedRoute53Record.Type != "SOA"
+			if canEdit {
+				shortcuts = append([]helpShortcut{{"e", "Edit the selected DNS record"}}, shortcuts...)
+			}
+			if canDelete {
+				shortcuts = append(shortcuts[:len(shortcuts)-1], append([]helpShortcut{{"d", "Delete the selected DNS record"}}, shortcuts[len(shortcuts)-1:]...)...)
+			}
+		}
+		return shortcuts
+	case screenRoute53RecordCreate:
+		return route53FormShortcuts(m.route53EditField == 1)
+	case screenRoute53RecordEdit:
+		return []helpShortcut{
+			{"type", "Edit the current record field"},
+			{"backspace", "Delete the previous character"},
+			{"enter", "Advance to the next field or save the update"},
+			{"esc", "Cancel and return to the record detail"},
+		}
+	case screenRoute53RecordDeleteConfirm:
+		return []helpShortcut{
+			{"type", "Enter the record name to confirm deletion"},
+			{"backspace", "Delete the previous character"},
+			{"enter", "Delete the record when the typed name matches"},
+			{"esc", "Cancel and return to the record detail"},
+		}
+	case screenSecretList:
+		return listScreenShortcuts("open the selected secret", "go back to the feature list", true, false)
+	case screenSecretDetail:
+		return []helpShortcut{
+			{"q / esc", "Go back to the secret list"},
+		}
+	case screenSecurityGroupList:
+		return listScreenShortcuts("open the selected security group", "go back to the feature list", true, true)
+	case screenSecurityGroupDetail:
+		return []helpShortcut{
+			{"↑/↓, j/k", "Move between rules in the active section"},
+			{"tab", "Switch between ingress and egress rules"},
+			{"a", "Add a rule to the security group"},
+			{"d", "Delete the selected rule"},
+			{"q / esc", "Go back to the security group list"},
+		}
+	case screenSecurityGroupAddRule:
+		if m.sgAddField == 0 || m.sgAddField == 1 {
+			return []helpShortcut{
+				{"↑/↓, j/k", "Move between the available options"},
+				{"enter", "Confirm the selected option and continue"},
+				{"esc", "Cancel and return to the security group detail"},
+			}
+		}
+		return []helpShortcut{
+			{"type", "Edit the current field"},
+			{"backspace", "Delete the previous character"},
+			{"enter", "Confirm the current field and continue"},
+			{"esc", "Cancel and return to the security group detail"},
+		}
+	case screenSecurityGroupDeleteConfirm:
+		return []helpShortcut{
+			{"type", "Enter the security group ID to confirm deletion"},
+			{"backspace", "Delete the previous character"},
+			{"enter", "Delete the rule when the typed ID matches"},
+			{"esc", "Cancel and return to the security group detail"},
+		}
+	case screenIAMUserList:
+		shortcuts := listScreenShortcuts("open the selected IAM user", "go back to the feature list", true, false)
+		return append(shortcuts[:3], append([]helpShortcut{{"n", "Load the next page of IAM users"}}, shortcuts[3:]...)...)
+	case screenIAMUserDetail:
+		return []helpShortcut{
+			{"q / esc", "Go back to the IAM user list"},
+		}
+	case screenIAMKeyList:
+		return []helpShortcut{
+			{"↑/↓, j/k", "Move between access keys"},
+			{"enter", "Open the selected access key detail"},
+			{"q / esc", "Go back to the feature list"},
+		}
+	case screenIAMKeyDetail:
+		shortcuts := []helpShortcut{
+			{"q / esc", "Go back to the access key list"},
+		}
+		if m.iamRotationEnabled && m.selectedIAMKey != nil && m.selectedIAMKey.Status == "Active" {
+			shortcuts = append([]helpShortcut{{"r", "Start rotating the selected access key"}}, shortcuts...)
+		}
+		return shortcuts
+	case screenIAMKeyRotateConfirm:
+		return []helpShortcut{
+			{"type", "Enter the access key ID to confirm rotation"},
+			{"backspace", "Delete the previous character"},
+			{"enter", "Create the new key when the typed ID matches"},
+			{"esc", "Cancel and return to the access key detail"},
+		}
+	case screenIAMKeyRotateResult:
+		return []helpShortcut{
+			{"c", "Copy export commands for the new credentials"},
+			{"a", "Apply and verify the new credentials when supported"},
+			{"d", "Deactivate the old access key when allowed"},
+			{"x", "Delete the old access key after deactivation"},
+			{"q / esc", "Return to the access key list"},
+		}
+	case screenCWLogGroupList:
+		return listScreenShortcuts("open log streams for the selected group", "go back to the feature list", true, false)
+	case screenCWLogStreamList:
+		return listScreenShortcuts("open the log viewer for the selected stream", "go back to the log group list", true, false)
+	case screenCWLogViewer:
+		shortcuts := []helpShortcut{
+			{"↑/↓, j/k", "Scroll the log viewer"},
+			{"pgup / pgdn", "Scroll by one page"},
+			{"1-6", "Switch the time-range preset"},
+			{"f", "Edit the CloudWatch filter pattern"},
+			{"t", "Toggle live tail"},
+			{"w", "Toggle line wrapping"},
+			{"n", "Load older log events"},
+			{"q / esc", "Go back to the stream list"},
+		}
+		if !m.cwLogWrap {
+			shortcuts = append(shortcuts[:6], append([]helpShortcut{{"h / l", "Scroll horizontally through long log lines"}}, shortcuts[6:]...)...)
+		}
+		return shortcuts
+	case screenECSClusterList:
+		return listScreenShortcuts("open the selected ECS cluster", "go back to the feature list", true, true)
+	case screenECSServiceList:
+		return listScreenShortcuts("open the selected ECS service", "go back to the cluster list", true, true)
+	case screenECSTaskList:
+		return []helpShortcut{
+			{"↑/↓, j/k", "Move between tasks"},
+			{"r", "Refresh the task list"},
+			{"enter", "Open the selected task"},
+			{"q / esc", "Go back to the service list"},
+		}
+	case screenECSContainerList:
+		return []helpShortcut{
+			{"↑/↓, j/k", "Move between containers"},
+			{"enter", "Start an ECS exec session for the selected container"},
+			{"q / esc", "Go back to the task list"},
+		}
+	case screenS3BucketList:
+		return listScreenShortcuts("browse the selected bucket", "go back to the feature list", true, false)
+	case screenS3ObjectList:
+		return []helpShortcut{
+			{"↑/↓, j/k", "Move between prefixes and objects"},
+			{"/", "Start filtering objects and prefixes"},
+			{"enter", "Open the selected prefix or object"},
+			{"esc", "Go up one prefix level or back to the bucket list"},
+			{"q", "Go back to the feature list"},
+		}
+	case screenS3ObjectDetail:
+		return []helpShortcut{
+			{"esc", "Go back to the object list"},
+			{"q", "Go back to the feature list"},
+		}
+	case screenInspectorHome:
+		return []helpShortcut{
+			{"enter / r", "Run the security scan"},
+			{"q / esc", "Go back to the feature list"},
+		}
+	case screenInspectorScanning:
+		return []helpShortcut{
+			{"Wait", "The security scan is still running"},
+		}
+	case screenInspectorResults:
+		return []helpShortcut{
+			{"↑/↓, j/k", "Move between findings"},
+			{"1-5", "Filter findings by severity"},
+			{"enter", "Open the selected finding detail"},
+			{"r", "Run the security scan again"},
+			{"q / esc", "Go back to the Inspector home screen"},
+		}
+	case screenInspectorFindingDetail:
+		return []helpShortcut{
+			{"r", "Run the security scan again"},
+			{"q / esc", "Go back to the findings list"},
+		}
+	case screenContextPicker:
+		shortcuts := []helpShortcut{
+			{"↑/↓, j/k", "Move between contexts"},
+			{"/", "Start filtering contexts"},
+			{"enter", "Switch to the selected context"},
+			{"a", "Open the add-context wizard"},
+			{"q", "Quit unic"},
+		}
+		if m.cfg.ContextName != "" {
+			shortcuts = append(shortcuts[:4], append([]helpShortcut{{"esc", "Return to the previous screen"}}, shortcuts[4:]...)...)
+		}
+		return shortcuts
+	case screenContextAdd:
+		if m.addStep == 0 {
+			return []helpShortcut{
+				{"↑/↓, j/k", "Move between auth types"},
+				{"enter", "Select the auth type and continue"},
+				{"esc", "Cancel and return to the context picker"},
+			}
+		}
+		if m.addStep == -1 {
+			return []helpShortcut{
+				{"enter", "Save the new context"},
+				{"esc", "Cancel and return to the context picker"},
+			}
+		}
+		return []helpShortcut{
+			{"type", "Edit the current context field"},
+			{"backspace", "Delete the previous character"},
+			{"enter", "Save the current field and continue"},
+			{"esc", "Go back to the previous field or auth type"},
+		}
+	case screenLoading:
+		return []helpShortcut{
+			{"Wait", "The current AWS request is still loading"},
+		}
+	case screenError:
+		return []helpShortcut{
+			{"enter / esc", "Return to the service list"},
+			{"q", "Quit unic"},
+		}
+	default:
+		return nil
+	}
+}
+
+func listScreenShortcuts(selectAction, backAction string, filter, refresh bool) []helpShortcut {
+	shortcuts := []helpShortcut{
+		{"↑/↓, j/k", "Move between rows"},
+	}
+	if filter {
+		shortcuts = append(shortcuts, helpShortcut{"/", "Start filtering the list"})
+	}
+	if refresh {
+		shortcuts = append(shortcuts, helpShortcut{"r", "Refresh the list"})
+	}
+	shortcuts = append(shortcuts,
+		helpShortcut{"enter", capitalizeFirst(selectAction)},
+		helpShortcut{"q / esc", capitalizeFirst(backAction)},
+	)
+	return shortcuts
+}
+
+func reachabilityTargetShortcuts(label string, includeQuitBack bool) []helpShortcut {
+	shortcuts := []helpShortcut{
+		{"←/→, h/l, tab", fmt.Sprintf("Switch %s resource type", label)},
+		{"↑/↓, j/k", fmt.Sprintf("Move between %s targets", label)},
+		{"/", fmt.Sprintf("Start filtering %s targets", label)},
+		{"r", "Reload reachability targets"},
+		{"enter", fmt.Sprintf("Select the %s and continue", label)},
+	}
+	if includeQuitBack {
+		shortcuts = append(shortcuts, helpShortcut{"q / esc", "Go back to the previous step"})
+	}
+	return shortcuts
+}
+
+func route53FormShortcuts(typeSelection bool) []helpShortcut {
+	shortcuts := []helpShortcut{
+		{"enter", "Advance to the next field or save the record"},
+		{"esc", "Cancel and return to the record list"},
+	}
+	if typeSelection {
+		return append([]helpShortcut{{"↑/↓, j/k", "Move between record types"}}, shortcuts...)
+	}
+	return append([]helpShortcut{
+		{"type", "Edit the current field"},
+		{"backspace", "Delete the previous character"},
+	}, shortcuts...)
+}
+
+func capitalizeFirst(value string) string {
+	if value == "" {
+		return value
+	}
+	return strings.ToUpper(value[:1]) + value[1:]
+}
+
+func (m Model) helpScreenTitle() string {
+	switch m.screen {
+	case screenServiceList:
+		return "Service List"
+	case screenFeatureList:
+		if len(m.services) > 0 && m.svcIdx < len(m.services) {
+			return fmt.Sprintf("%s Feature List", m.services[m.svcIdx].Name)
+		}
+		return "Feature List"
+	case screenInstanceList:
+		return "EC2 Instances"
+	case screenVPCList:
+		return "VPC List"
+	case screenSubnetList:
+		return "Subnet List"
+	case screenSubnetDetail:
+		return "Subnet Detail"
+	case screenReachabilityRegionList:
+		return "Reachability Region Picker"
+	case screenReachabilitySourceList:
+		return "Reachability Source Picker"
+	case screenReachabilityDestinationList:
+		return "Reachability Destination Picker"
+	case screenReachabilityConfig:
+		return "Reachability Analysis Config"
+	case screenReachabilityResult:
+		return "Reachability Result"
+	case screenRDSList:
+		return "RDS Instances"
+	case screenRDSDetail:
+		return "RDS Detail"
+	case screenRDSConfirm:
+		return "RDS Confirmation"
+	case screenRoute53ZoneList:
+		return "Route53 Hosted Zones"
+	case screenRoute53RecordList:
+		return "Route53 Records"
+	case screenRoute53RecordDetail:
+		return "Route53 Record Detail"
+	case screenRoute53RecordCreate:
+		return "Create Route53 Record"
+	case screenRoute53RecordEdit:
+		return "Edit Route53 Record"
+	case screenRoute53RecordDeleteConfirm:
+		return "Delete Route53 Record"
+	case screenSecretList:
+		return "Secrets Manager"
+	case screenSecretDetail:
+		return "Secret Detail"
+	case screenSecurityGroupList:
+		return "Security Groups"
+	case screenSecurityGroupDetail:
+		return "Security Group Detail"
+	case screenSecurityGroupAddRule:
+		return "Add Security Group Rule"
+	case screenSecurityGroupDeleteConfirm:
+		return "Delete Security Group Rule"
+	case screenIAMUserList:
+		return "IAM Users"
+	case screenIAMUserDetail:
+		return "IAM User Detail"
+	case screenIAMKeyList:
+		return "IAM Access Keys"
+	case screenIAMKeyDetail:
+		return "IAM Access Key Detail"
+	case screenIAMKeyRotateConfirm:
+		return "IAM Access Key Rotation Confirm"
+	case screenIAMKeyRotateResult:
+		return "IAM Access Key Rotation Result"
+	case screenCWLogGroupList:
+		return "CloudWatch Log Groups"
+	case screenCWLogStreamList:
+		return "CloudWatch Log Streams"
+	case screenCWLogViewer:
+		return "CloudWatch Log Viewer"
+	case screenECSClusterList:
+		return "ECS Clusters"
+	case screenECSServiceList:
+		return "ECS Services"
+	case screenECSTaskList:
+		return "ECS Tasks"
+	case screenECSContainerList:
+		return "ECS Containers"
+	case screenS3BucketList:
+		return "S3 Buckets"
+	case screenS3ObjectList:
+		return "S3 Objects"
+	case screenS3ObjectDetail:
+		return "S3 Object Detail"
+	case screenInspectorHome:
+		return "Inspector Home"
+	case screenInspectorScanning:
+		return "Inspector Scanning"
+	case screenInspectorResults:
+		return "Inspector Findings"
+	case screenInspectorFindingDetail:
+		return "Inspector Finding Detail"
+	case screenContextPicker:
+		return "Context Picker"
+	case screenContextAdd:
+		return "Add Context"
+	case screenLoading:
+		return "Loading"
+	case screenError:
+		return "Error"
+	default:
+		return "Current Screen"
+	}
+}


### PR DESCRIPTION
### Summary

- add a global help overlay toggled by ? from the TUI
- generate context-aware shortcut sections for the active screen and input mode instead of hard-coding one static help page
- update README and add app-level tests for help toggling, context-aware content, and filter-mode behavior

### Related Issues

Closes #32

### Validation

- GOCACHE=/tmp/unic-go-build go test ./internal/app -run TestHelpToggleAndClose|TestHelpBlocksNavigationWhileOpen|TestHelpViewShowsContextAwareRDSActions|TestHelpViewShowsFilterModeShortcuts
- GOCACHE=/tmp/unic-go-build make test
- GOCACHE=/tmp/unic-go-build make build

### Checklist

- [x] Scope is focused
- [x] Branch name follows docs/branch-naming-harness.md
- [x] Documentation harness reviewed (docs/documentation-harness.md)
- [x] README updated if user-facing behavior changed
- [x] Relevant docs/ pages updated if architecture, auth, config, or workflow changed (not applicable beyond README for this UI-only shortcut overlay)
- [x] Tests/validation included
- [x] Breaking changes documented