### PR TITLE
feat: use bubbles table for context picker

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/table"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -270,6 +271,7 @@ type Model struct {
 	ctxList            []config.ContextInfo
 	filteredCtxList    []config.ContextInfo
 	ctxIdx             int
+	contextTable       table.Model
 	ctxPrevScreen      screen
 	pendingContextName string
 
@@ -320,6 +322,7 @@ func New(cfg *config.Config, configPath string, version string) Model {
 		loadingSpinner: newLoadingSpinner(),
 		filterTI:       filterTI,
 		filters:        make(map[filterTarget]string),
+		contextTable:   newContextTable(),
 	}
 }
 
@@ -386,6 +389,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m.syncFilterInputWidth()
+		m.syncContextTable()
 		return m, nil
 	case callerIdentityMsg:
 		m.callerIdentity = msg.identity

--- a/internal/app/context_table.go
+++ b/internal/app/context_table.go
@@ -1,0 +1,133 @@
+package app
+
+import (
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/table"
+	"github.com/charmbracelet/lipgloss"
+
+	"unic/internal/config"
+)
+
+const (
+	defaultContextTableWidth  = 52
+	defaultContextTableHeight = 4
+)
+
+func newContextTable() table.Model {
+	km := table.DefaultKeyMap()
+	km.PageUp.Unbind()
+	km.PageDown.Unbind()
+	km.HalfPageUp.Unbind()
+	km.HalfPageDown.Unbind()
+	km.GotoTop.Unbind()
+	km.GotoBottom.Unbind()
+	km.LineUp = key.NewBinding(
+		key.WithKeys("up", "k"),
+		key.WithHelp("↑/k", "up"),
+	)
+	km.LineDown = key.NewBinding(
+		key.WithKeys("down", "j"),
+		key.WithHelp("↓/j", "down"),
+	)
+
+	styles := table.DefaultStyles()
+	styles.Header = dimStyle.Copy().Bold(true).Padding(0, 1)
+	styles.Cell = table.DefaultStyles().Cell.Copy()
+	styles.Selected = selectedStyle.Copy().
+		Bold(true).
+		Background(lipgloss.Color("236"))
+
+	t := table.New(
+		table.WithColumns(contextTableColumns(0)),
+		table.WithHeight(defaultContextTableHeight),
+		table.WithWidth(defaultContextTableWidth),
+		table.WithFocused(true),
+		table.WithKeyMap(km),
+		table.WithStyles(styles),
+	)
+	t.Focus()
+	return t
+}
+
+func (m *Model) syncContextTable() {
+	m.contextTable.SetColumns(contextTableColumns(m.width))
+	m.contextTable.SetWidth(contextTableWidth(m.width))
+	m.contextTable.SetHeight(contextTableHeight(m.height))
+	m.contextTable.SetRows(contextTableRows(m.filteredCtxList))
+	m.contextTable.Focus()
+	m.contextTable.SetCursor(m.ctxIdx)
+	if cursor := m.contextTable.Cursor(); cursor >= 0 {
+		m.ctxIdx = cursor
+	}
+}
+
+func contextTableRows(contexts []config.ContextInfo) []table.Row {
+	rows := make([]table.Row, 0, len(contexts))
+	for _, ctx := range contexts {
+		current := ""
+		if ctx.Current {
+			current = "*"
+		}
+		authType := ctx.AuthType
+		if authType == "" {
+			authType = "default"
+		}
+		rows = append(rows, table.Row{
+			ctx.Name,
+			ctx.Region,
+			authType,
+			current,
+		})
+	}
+	return rows
+}
+
+func contextTableWidth(terminalWidth int) int {
+	if terminalWidth <= 0 {
+		return defaultContextTableWidth
+	}
+	return max(terminalWidth-4, 28)
+}
+
+func contextTableHeight(terminalHeight int) int {
+	if terminalHeight <= 0 {
+		return defaultContextTableHeight
+	}
+	visibleRows := max(terminalHeight-6, 3)
+	return visibleRows + 1
+}
+
+func contextTableColumns(terminalWidth int) []table.Column {
+	available := contextTableWidth(terminalWidth)
+
+	currentWidth := 7
+	regionWidth := 12
+	authWidth := 12
+	minNameWidth := 12
+
+	nameWidth := available - regionWidth - authWidth - currentWidth
+	if nameWidth < minNameWidth {
+		deficit := minNameWidth - nameWidth
+		if authWidth > 8 {
+			shrink := min(deficit, authWidth-8)
+			authWidth -= shrink
+			deficit -= shrink
+		}
+		if deficit > 0 && regionWidth > 8 {
+			shrink := min(deficit, regionWidth-8)
+			regionWidth -= shrink
+			deficit -= shrink
+		}
+		if deficit > 0 && currentWidth > 3 {
+			currentWidth = max(currentWidth-deficit, 3)
+		}
+		nameWidth = max(available-regionWidth-authWidth-currentWidth, 6)
+	}
+
+	return []table.Column{
+		{Title: lipgloss.NewStyle().Render("NAME"), Width: nameWidth},
+		{Title: lipgloss.NewStyle().Render("REGION"), Width: regionWidth},
+		{Title: lipgloss.NewStyle().Render("AUTH TYPE"), Width: authWidth},
+		{Title: lipgloss.NewStyle().Render("CURRENT"), Width: currentWidth},
+	}
+}

--- a/internal/app/filter.go
+++ b/internal/app/filter.go
@@ -192,6 +192,7 @@ func (m *Model) applyFilterTarget(target filterTarget) {
 	case filterContexts:
 		m.filteredCtxList = applyFilter(m.ctxList, m.filterValue(target))
 		m.ctxIdx = 0
+		m.syncContextTable()
 	}
 }
 

--- a/internal/app/screen_context.go
+++ b/internal/app/screen_context.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 
 	"unic/internal/auth"
 	"unic/internal/config"
@@ -26,6 +25,7 @@ func (m Model) handleContextMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 				break
 			}
 		}
+		m.syncContextTable()
 		m.screen = screenContextPicker
 		return m, nil, true
 
@@ -78,19 +78,12 @@ func (m Model) updateContextPicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.quitting = true
 			return m, tea.Quit
 		}
-	case "up", "k":
-		if m.ctxIdx > 0 {
-			m.ctxIdx--
-		}
-	case "down", "j":
-		if m.ctxIdx < len(m.filteredCtxList)-1 {
-			m.ctxIdx++
-		}
 	case "/":
 		return m, m.activateFilter(filterContexts)
 	case "enter":
-		if len(m.filteredCtxList) > 0 && m.ctxIdx < len(m.filteredCtxList) {
-			selected := m.filteredCtxList[m.ctxIdx]
+		cursor := m.contextTable.Cursor()
+		if len(m.filteredCtxList) > 0 && cursor >= 0 && cursor < len(m.filteredCtxList) {
+			selected := m.filteredCtxList[cursor]
 			m.pendingContextName = selected.Name
 			return m.startLoading(m.switchContext(selected.Name))
 		}
@@ -102,6 +95,16 @@ func (m Model) updateContextPicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.addInput = ""
 		m.addValues = make(map[string]string)
 		m.screen = screenContextAdd
+	default:
+		if len(m.filteredCtxList) == 0 {
+			return m, nil
+		}
+		var cmd tea.Cmd
+		m.contextTable, cmd = m.contextTable.Update(msg)
+		if cursor := m.contextTable.Cursor(); cursor >= 0 {
+			m.ctxIdx = cursor
+		}
+		return m, cmd
 	}
 	return m, nil
 }
@@ -184,48 +187,8 @@ func (m Model) viewContextPicker() string {
 		b.WriteString(dimStyle.Render("  No matching contexts"))
 		b.WriteString("\n")
 	} else {
-		// Measure max widths for alignment
-		maxName, maxRegion := 4, 6 // "NAME", "REGION"
-		for _, ctx := range m.filteredCtxList {
-			if len(ctx.Name) > maxName {
-				maxName = len(ctx.Name)
-			}
-			if len(ctx.Region) > maxRegion {
-				maxRegion = len(ctx.Region)
-			}
-		}
-
-		nameCol := lipgloss.NewStyle().Width(maxName + 2)
-		regionCol := lipgloss.NewStyle().Width(maxRegion + 2)
-
-		// Header
-		b.WriteString(dimStyle.Render("  " + nameCol.Render("NAME") + regionCol.Render("REGION") + "AUTH"))
+		b.WriteString(m.contextTable.View())
 		b.WriteString("\n")
-
-		// overhead: title (1) + filter (1) + blank (1) + table header (1) + blank (1) + footer (1) = 6
-		visibleLines := max(m.height-6, 3)
-		start := 0
-		if m.ctxIdx >= visibleLines {
-			start = m.ctxIdx - visibleLines + 1
-		}
-		end := min(start+visibleLines, len(m.filteredCtxList))
-
-		for i := start; i < end; i++ {
-			ctx := m.filteredCtxList[i]
-			cursor := "  "
-			style := normalStyle
-			if i == m.ctxIdx {
-				cursor = "> "
-				style = selectedStyle
-			}
-
-			row := cursor + nameCol.Inherit(style).Render(ctx.Name) + regionCol.Inherit(style).Render(ctx.Region) + style.Render(ctx.AuthType)
-			if ctx.Current {
-				row += dimStyle.Render(" *")
-			}
-			b.WriteString(row)
-			b.WriteString("\n")
-		}
 	}
 
 	b.WriteString("\n")

--- a/internal/app/screen_context_test.go
+++ b/internal/app/screen_context_test.go
@@ -1,0 +1,120 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"unic/internal/config"
+)
+
+func testContexts() []config.ContextInfo {
+	return []config.ContextInfo{
+		{Name: "dev", Region: "us-east-1", AuthType: "credential"},
+		{Name: "prod", Region: "us-west-2", AuthType: "sso", Current: true},
+		{Name: "staging", Region: "ap-northeast-2", AuthType: "assume_role"},
+	}
+}
+
+func TestContextsLoadedSyncsContextTable(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.width = 80
+	m.height = 20
+
+	updated, _ := m.Update(contextsLoadedMsg{contexts: testContexts()})
+	model := updated.(Model)
+
+	if model.screen != screenContextPicker {
+		t.Fatalf("expected context picker screen, got %v", model.screen)
+	}
+	if got := len(model.contextTable.Rows()); got != 3 {
+		t.Fatalf("expected 3 context rows, got %d", got)
+	}
+	if model.ctxIdx != 1 {
+		t.Fatalf("expected current context cursor at index 1, got %d", model.ctxIdx)
+	}
+	if model.contextTable.Cursor() != 1 {
+		t.Fatalf("expected table cursor at index 1, got %d", model.contextTable.Cursor())
+	}
+	selected := model.contextTable.SelectedRow()
+	if len(selected) != 4 || selected[0] != "prod" || selected[3] != "*" {
+		t.Fatalf("expected selected row for current context, got %#v", selected)
+	}
+
+	view := model.viewContextPicker()
+	for _, want := range []string{"NAME", "AUTH TYPE", "CURRENT", "prod"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected context picker view to contain %q, got %q", want, view)
+		}
+	}
+}
+
+func TestContextPickerNavigationUsesTableModel(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.width = 80
+	m.height = 20
+
+	updated, _ := m.Update(contextsLoadedMsg{contexts: testContexts()})
+	model := updated.(Model)
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	model = updated.(Model)
+
+	if model.ctxIdx != 2 {
+		t.Fatalf("expected cursor to move to index 2, got %d", model.ctxIdx)
+	}
+	if model.contextTable.Cursor() != 2 {
+		t.Fatalf("expected table cursor to move to index 2, got %d", model.contextTable.Cursor())
+	}
+}
+
+func TestContextPickerFilterUpdatesTableRows(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.width = 80
+	m.height = 20
+
+	updated, _ := m.Update(contextsLoadedMsg{contexts: testContexts()})
+	model := updated.(Model)
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	model = updated.(Model)
+	for _, ch := range []rune("prod") {
+		updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{ch}})
+		model = updated.(Model)
+	}
+
+	if got := len(model.filteredCtxList); got != 1 {
+		t.Fatalf("expected 1 filtered context, got %d", got)
+	}
+	if got := len(model.contextTable.Rows()); got != 1 {
+		t.Fatalf("expected table to show 1 filtered row, got %d", got)
+	}
+	if selected := model.contextTable.SelectedRow(); len(selected) == 0 || selected[0] != "prod" {
+		t.Fatalf("expected filtered table row for prod, got %#v", selected)
+	}
+}
+
+func TestContextPickerEnterUsesSelectedTableRow(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.width = 80
+	m.height = 20
+
+	updated, _ := m.Update(contextsLoadedMsg{contexts: testContexts()})
+	model := updated.(Model)
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	model = updated.(Model)
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+
+	if cmd == nil {
+		t.Fatal("expected context switch command on enter")
+	}
+	if model.pendingContextName != "staging" {
+		t.Fatalf("expected pending context staging, got %q", model.pendingContextName)
+	}
+	if model.screen != screenLoading {
+		t.Fatalf("expected loading screen after selecting context, got %v", model.screen)
+	}
+}


### PR DESCRIPTION
### Summary

- replace the manual context picker rows with a bubbles/table model for cleaner layout and built-in scrolling behavior
- keep the existing context-picker workflow intact, including filter mode, add-context, enter-to-switch, and quit/back behavior
- add focused tests for current-context selection, table-driven navigation, filtering, and selection dispatch

### Related Issues

Closes #63

### Validation

- GOCACHE=/tmp/unic-go-build go test ./internal/app -run TestContextsLoadedSyncsContextTable|TestContextPickerNavigationUsesTableModel|TestContextPickerFilterUpdatesTableRows|TestContextPickerEnterUsesSelectedTableRow
- GOCACHE=/tmp/unic-go-build go test ./internal/app
- GOCACHE=/tmp/unic-go-build make test
- GOCACHE=/tmp/unic-go-build make build

### Checklist

- [x] Scope is focused
- [x] Branch name follows docs/branch-naming-harness.md
- [x] Documentation harness reviewed (docs/documentation-harness.md)
- [x] README updated if user-facing behavior changed
- [x] Relevant docs/ pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented