### PR TITLE
feat: add context picker terminal actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ unic context unset
 
 `unic context setup` writes its prompts to `stderr` and copies the generated shell commands to the clipboard.
 `unic env` prints shell commands to `stdout` so it can be used with `eval`.
+Both flows now include a `UNIC_CONTEXT` marker in the generated exports so the TUI can show which shell context is currently active.
 
 ## Configuration
 
@@ -217,7 +218,7 @@ The Inspector feature ships built-in rule packs for Security Group exposure, RDS
 | CloudWatch Logs | log groups/streams load 10 at a time, `n` load more, `1`-`6` time presets, `t` live tail, `f` filter pattern, `w` wrap toggle, `h/l` horizontal scroll |
 | ECS Exec | `r` refresh, `Enter` drill down / exec |
 | Inspector | `r` run/rescan, `1`-`5` severity filter, `Enter` finding detail |
-| Context Picker | `a` add context, `/` filter |
+| Context Picker | `a` add context, `/` filter, `s` setup selected context and quit, `y` copy selected exports and quit, `u` clear shell context and quit with a final confirmation message |
 
 Filtering is currently available on EC2 instances, IAM users, VPCs/subnets, RDS instances, Route53 zones/records, CloudWatch log groups/streams, Secrets Manager resources, ECS clusters/services, S3 buckets/objects, and the context picker.
 

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -56,7 +56,9 @@ Owns `~/.config/unic/config.yaml` handling:
 Owns shell export and interactive setup workflows:
 
 - build shell exports for `credential`, `assume_role`, and concrete `sso` contexts
+- include a `UNIC_CONTEXT` marker in shell exports and cleanup commands
 - run interactive setup for SSO base contexts
+- share SSO account / role resolution helpers across CLI and TUI flows
 - discover available SSO accounts and roles
 - return clipboard-friendly export strings
 
@@ -158,7 +160,8 @@ Current screen families include:
 - ECS cluster/service/task/container flows
 - S3 bucket/object/detail flows
 - Inspector home/scanning/results/detail flows
-- context picker and context add flows
+- context picker, context add, and TUI-native context setup/export/unset flows
+- SSO account / role selection and exit notice flows
 - loading and error screens
 
 ## Extension Pattern

--- a/docs/architecture.ko.md
+++ b/docs/architecture.ko.md
@@ -56,7 +56,9 @@ cmd/unic/main.go
 쉘 export와 interactive setup 흐름을 담당한다.
 
 - `credential`, `assume_role`, concrete `sso` context용 export 문자열 생성
+- 쉘 export와 cleanup command에 `UNIC_CONTEXT` marker 포함
 - SSO base context setup 실행
+- CLI와 TUI에서 함께 쓰는 SSO account / role resolution helper 제공
 - 사용 가능한 SSO account / role 조회
 - clipboard에 붙여넣기 쉬운 export 문자열 반환
 
@@ -158,7 +160,8 @@ UNIC은 현재 세 가지 인증 모드를 지원한다.
 - ECS cluster/service/task/container
 - S3 bucket/object/detail
 - Inspector home/scanning/results/detail
-- context picker, context add
+- context picker, context add, TUI-native context setup/export/unset
+- SSO account / role selection, exit notice
 - loading, error
 
 ## 기능 확장 패턴

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -67,16 +67,21 @@ const (
 	screenInspectorFindingDetail
 	screenContextPicker
 	screenContextAdd
+	screenContextSSOAccountList
+	screenContextSSORoleList
 	screenLoading
 	screenError
+	screenExitNotice
 )
 
 // Model is the root Bubbletea model.
 type Model struct {
-	cfg      *config.Config
-	awsRepo  *awsservice.AwsRepository
-	screen   screen
-	quitting bool
+	cfg         *config.Config
+	awsRepo     *awsservice.AwsRepository
+	screen      screen
+	quitting    bool
+	exitMessage string
+	exitTitle   string
 
 	// Service selection
 	services []domain.Service
@@ -272,6 +277,16 @@ type Model struct {
 	contextTable       table.Model
 	ctxPrevScreen      screen
 	pendingContextName string
+	envContextName     string
+	envContextSource   string
+	envContextKnown    bool
+
+	contextSSOBase       config.ContextInfo
+	contextSSOAccounts   []awsservice.SSOAccount
+	contextSSOAccountIdx int
+	contextSSOAccount    awsservice.SSOAccount
+	contextSSORoles      []awsservice.SSORole
+	contextSSORoleIdx    int
 
 	// Context add wizard
 	addStep     int // 0=auth_type select, 1+=field input, -1=confirm
@@ -439,6 +454,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.quitting = true
 			return m, tea.Quit
 		}
+		if m.screen == screenExitNotice {
+			m.quitting = true
+			return m, tea.Quit
+		}
 		if msg.String() == "?" {
 			m.helpVisible = !m.helpVisible
 			return m, nil
@@ -560,6 +579,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateContextPicker(msg)
 		case screenContextAdd:
 			return m.updateContextAdd(msg)
+		case screenContextSSOAccountList:
+			return m.updateContextSSOAccountList(msg)
+		case screenContextSSORoleList:
+			return m.updateContextSSORoleList(msg)
 		case screenError:
 			return m.updateError(msg)
 		}
@@ -812,10 +835,16 @@ func (m Model) View() string {
 		v = m.viewContextPicker()
 	case screenContextAdd:
 		v = m.viewContextAdd()
+	case screenContextSSOAccountList:
+		v = m.viewContextSSOAccountList()
+	case screenContextSSORoleList:
+		v = m.viewContextSSORoleList()
 	case screenLoading:
 		v = m.viewLoading()
 	case screenError:
 		v = m.viewError()
+	case screenExitNotice:
+		v = m.viewExitNotice()
 	}
 
 	return m.fitToHeight(v)

--- a/internal/app/context_table.go
+++ b/internal/app/context_table.go
@@ -96,9 +96,9 @@ func contextTableHeight(terminalHeight int) int {
 		return defaultContextTableHeight
 	}
 	// Context picker layout overhead:
-	// title/filter block (3) + panel border (2) + separator/help bar (2) = 7.
+	// title/current/env/filter block (6) + panel border (2) + separator/help bar (2) = 10.
 	// The table height itself must fit inside the remaining rows.
-	return max(terminalHeight-7, 3)
+	return max(terminalHeight-10, 3)
 }
 
 func contextTableColumns(terminalWidth int) []table.Column {

--- a/internal/app/context_terminal.go
+++ b/internal/app/context_terminal.go
@@ -110,6 +110,9 @@ func (m Model) loadSSOContextRoles(base config.ContextInfo, account awsservice.S
 
 func (m Model) setupResolvedSSOContextForTerminal() tea.Cmd {
 	return func() tea.Msg {
+		if m.contextSSORoleIdx < 0 || m.contextSSORoleIdx >= len(m.contextSSORoles) {
+			return errMsg{err: fmt.Errorf("invalid role selection")}
+		}
 		finalName, err := contextResolveSSOSelectionFn(m.configPath, m.contextSSOBase, m.contextSSOAccount, m.contextSSORoles[m.contextSSORoleIdx])
 		if err != nil {
 			return errMsg{err: err}

--- a/internal/app/context_terminal.go
+++ b/internal/app/context_terminal.go
@@ -1,0 +1,321 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"unic/internal/auth"
+	"unic/internal/clipboard"
+	"unic/internal/config"
+	awsservice "unic/internal/services/aws"
+)
+
+type contextSSOAccountsLoadedMsg struct {
+	base     config.ContextInfo
+	accounts []awsservice.SSOAccount
+}
+
+type contextSSORolesLoadedMsg struct {
+	base    config.ContextInfo
+	account awsservice.SSOAccount
+	roles   []awsservice.SSORole
+}
+
+type contextTerminalActionDoneMsg struct {
+	title   string
+	message string
+}
+
+var (
+	contextBuildEnvExportsFn     = auth.BuildEnvExports
+	contextBuildEnvCleanupFn     = auth.BuildEnvCleanupCommands
+	contextSetCurrentFn          = config.SetCurrent
+	contextUnsetCurrentFn        = config.UnsetCurrent
+	contextLoadNamedContextFn    = config.LoadNamedContext
+	contextCopyClipboardFn       = clipboard.Copy
+	contextListSSOAccountsFn     = auth.ListSSOContextAccounts
+	contextListSSORolesFn        = auth.ListSSOContextRoles
+	contextResolveSSOSelectionFn = auth.ResolveSSOContextSelection
+	contextDetectEnvFn           = auth.DetectEnvContext
+)
+
+func (m Model) selectedContextInfo() (config.ContextInfo, bool) {
+	cursor := m.contextTable.Cursor()
+	if len(m.filteredCtxList) == 0 || cursor < 0 || cursor >= len(m.filteredCtxList) {
+		return config.ContextInfo{}, false
+	}
+	return m.filteredCtxList[cursor], true
+}
+
+func (m Model) beginContextSetup(selected config.ContextInfo) (tea.Model, tea.Cmd) {
+	if auth.IsBaseSSOContext(selected) {
+		details := []string{
+			renderDetailLine("Context", selected.Name),
+			renderDetailLine("Auth", "sso"),
+		}
+		return m.startLoadingWithMessage("Loading SSO accounts...", details, m.loadSSOContextAccounts(selected))
+	}
+
+	return m.startLoadingWithMessage(
+		"Preparing terminal exports...",
+		[]string{renderDetailLine("Context", selected.Name)},
+		m.setupSelectedContextForTerminal(selected.Name),
+	)
+}
+
+func (m Model) beginContextExport(selected config.ContextInfo) (tea.Model, tea.Cmd) {
+	return m.startLoadingWithMessage(
+		"Copying environment exports...",
+		[]string{renderDetailLine("Context", selected.Name)},
+		m.copySelectedContextExports(selected.Name),
+	)
+}
+
+func (m Model) beginContextUnset() (tea.Model, tea.Cmd) {
+	return m.startLoadingWithMessage(
+		"Clearing terminal context...",
+		[]string{renderDetailLine("Action", "Unset shell exports and current context")},
+		m.unsetTerminalContext(),
+	)
+}
+
+func (m Model) loadSSOContextAccounts(selected config.ContextInfo) tea.Cmd {
+	return func() tea.Msg {
+		accounts, err := contextListSSOAccountsFn(context.Background(), m.configPath, selected)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		if len(accounts) == 0 {
+			return errMsg{err: fmt.Errorf("no SSO accounts available for %q", selected.Name)}
+		}
+		return contextSSOAccountsLoadedMsg{base: selected, accounts: accounts}
+	}
+}
+
+func (m Model) loadSSOContextRoles(base config.ContextInfo, account awsservice.SSOAccount) tea.Cmd {
+	return func() tea.Msg {
+		roles, err := contextListSSORolesFn(context.Background(), m.configPath, base, account.ID)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		if len(roles) == 0 {
+			return errMsg{err: fmt.Errorf("no SSO roles available for account %s", account.ID)}
+		}
+		return contextSSORolesLoadedMsg{base: base, account: account, roles: roles}
+	}
+}
+
+func (m Model) setupResolvedSSOContextForTerminal() tea.Cmd {
+	return func() tea.Msg {
+		finalName, err := contextResolveSSOSelectionFn(m.configPath, m.contextSSOBase, m.contextSSOAccount, m.contextSSORoles[m.contextSSORoleIdx])
+		if err != nil {
+			return errMsg{err: err}
+		}
+		return m.setupSelectedContextForTerminal(finalName)()
+	}
+}
+
+func (m Model) setupSelectedContextForTerminal(name string) tea.Cmd {
+	return func() tea.Msg {
+		if err := contextSetCurrentFn(m.configPath, name); err != nil {
+			return errMsg{err: err}
+		}
+
+		cfg, err := contextLoadNamedContextFn(m.configPath, name)
+		if err != nil {
+			return errMsg{err: err}
+		}
+
+		exports, err := contextBuildEnvExportsFn(context.Background(), cfg)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		if err := contextCopyClipboardFn(exports); err != nil {
+			return errMsg{err: fmt.Errorf("failed to copy exports to clipboard: %w", err)}
+		}
+		return contextTerminalActionDoneMsg{
+			title:   "CONTEXT SET UP",
+			message: fmt.Sprintf("[%s] has been set up and copied. Goodbye!", name),
+		}
+	}
+}
+
+func (m Model) copySelectedContextExports(name string) tea.Cmd {
+	return func() tea.Msg {
+		cfg, err := contextLoadNamedContextFn(m.configPath, name)
+		if err != nil {
+			return errMsg{err: err}
+		}
+
+		exports, err := contextBuildEnvExportsFn(context.Background(), cfg)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		if err := contextCopyClipboardFn(exports); err != nil {
+			return errMsg{err: fmt.Errorf("failed to copy exports to clipboard: %w", err)}
+		}
+		return contextTerminalActionDoneMsg{
+			title:   "EXPORTS COPIED",
+			message: fmt.Sprintf("[%s] exports have been copied. Goodbye!", name),
+		}
+	}
+}
+
+func (m Model) unsetTerminalContext() tea.Cmd {
+	return func() tea.Msg {
+		if err := contextUnsetCurrentFn(m.configPath); err != nil {
+			return errMsg{err: err}
+		}
+
+		if err := contextCopyClipboardFn(contextBuildEnvCleanupFn()); err != nil {
+			return errMsg{err: fmt.Errorf("failed to copy cleanup commands to clipboard: %w", err)}
+		}
+		return contextTerminalActionDoneMsg{
+			title:   "CONTEXT CLEARED",
+			message: "Shell context has been cleared and cleanup commands copied. Goodbye!",
+		}
+	}
+}
+
+func (m Model) updateContextSSOAccountList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q":
+		m.screen = screenContextPicker
+	case "esc":
+		m.screen = screenContextPicker
+	case "up", "k":
+		if m.contextSSOAccountIdx > 0 {
+			m.contextSSOAccountIdx--
+		}
+	case "down", "j":
+		if m.contextSSOAccountIdx < len(m.contextSSOAccounts)-1 {
+			m.contextSSOAccountIdx++
+		}
+	case "enter":
+		if len(m.contextSSOAccounts) == 0 {
+			return m, nil
+		}
+		account := m.contextSSOAccounts[m.contextSSOAccountIdx]
+		details := []string{
+			renderDetailLine("Context", m.contextSSOBase.Name),
+			renderDetailLine("Account", formatSSOAccountLabel(account)),
+		}
+		return m.startLoadingWithMessage("Loading SSO roles...", details, m.loadSSOContextRoles(m.contextSSOBase, account))
+	}
+	return m, nil
+}
+
+func (m Model) updateContextSSORoleList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q":
+		m.screen = screenContextPicker
+	case "esc":
+		m.screen = screenContextSSOAccountList
+	case "up", "k":
+		if m.contextSSORoleIdx > 0 {
+			m.contextSSORoleIdx--
+		}
+	case "down", "j":
+		if m.contextSSORoleIdx < len(m.contextSSORoles)-1 {
+			m.contextSSORoleIdx++
+		}
+	case "enter":
+		if len(m.contextSSORoles) == 0 {
+			return m, nil
+		}
+		details := []string{
+			renderDetailLine("Context", m.contextSSOBase.Name),
+			renderDetailLine("Account", formatSSOAccountLabel(m.contextSSOAccount)),
+			renderDetailLine("Role", m.contextSSORoles[m.contextSSORoleIdx].Name),
+		}
+		return m.startLoadingWithMessage("Preparing terminal exports...", details, m.setupResolvedSSOContextForTerminal())
+	}
+	return m, nil
+}
+
+func (m Model) viewContextSSOAccountList() string {
+	var b strings.Builder
+	var panel strings.Builder
+
+	b.WriteString(titleStyle.Render("Select SSO Account"))
+	b.WriteString("\n")
+	b.WriteString(renderDetailLine("Context", m.contextSSOBase.Name))
+	b.WriteString("\n\n")
+
+	visibleLines := max(m.height-9, 3)
+	start := 0
+	if m.contextSSOAccountIdx >= visibleLines {
+		start = m.contextSSOAccountIdx - visibleLines + 1
+	}
+	end := min(start+visibleLines, len(m.contextSSOAccounts))
+
+	for i := start; i < end; i++ {
+		account := m.contextSSOAccounts[i]
+		cursor := "  "
+		style := normalStyle
+		if i == m.contextSSOAccountIdx {
+			cursor = "> "
+			style = selectedStyle
+		}
+		panel.WriteString(style.Render(fmt.Sprintf("%s%s", cursor, formatSSOAccountLabel(account))))
+		panel.WriteString("\n")
+	}
+
+	b.WriteString(m.renderListPanel(panel.String()))
+	b.WriteString("\n\n")
+	b.WriteString(m.renderHelpBar("↑/↓: navigate • enter: select • esc: back • q: cancel"))
+	return b.String()
+}
+
+func (m Model) viewContextSSORoleList() string {
+	var b strings.Builder
+	var panel strings.Builder
+
+	b.WriteString(titleStyle.Render("Select SSO Role"))
+	b.WriteString("\n")
+	b.WriteString(renderDetailLine("Context", m.contextSSOBase.Name))
+	b.WriteString("\n")
+	b.WriteString(renderDetailLine("Account", formatSSOAccountLabel(m.contextSSOAccount)))
+	b.WriteString("\n\n")
+
+	visibleLines := max(m.height-10, 3)
+	start := 0
+	if m.contextSSORoleIdx >= visibleLines {
+		start = m.contextSSORoleIdx - visibleLines + 1
+	}
+	end := min(start+visibleLines, len(m.contextSSORoles))
+
+	for i := start; i < end; i++ {
+		role := m.contextSSORoles[i]
+		cursor := "  "
+		style := normalStyle
+		if i == m.contextSSORoleIdx {
+			cursor = "> "
+			style = selectedStyle
+		}
+		panel.WriteString(style.Render(fmt.Sprintf("%s%s", cursor, role.Name)))
+		panel.WriteString("\n")
+	}
+
+	b.WriteString(m.renderListPanel(panel.String()))
+	b.WriteString("\n\n")
+	b.WriteString(m.renderHelpBar("↑/↓: navigate • enter: select • esc: back • q: cancel"))
+	return b.String()
+}
+
+func formatSSOAccountLabel(account awsservice.SSOAccount) string {
+	label := account.Name
+	if strings.TrimSpace(label) == "" {
+		label = account.ID
+	}
+	if account.Email != "" {
+		return fmt.Sprintf("%s <%s> (%s)", label, account.Email, account.ID)
+	}
+	if label == account.ID {
+		return label
+	}
+	return fmt.Sprintf("%s (%s)", label, account.ID)
+}

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -402,11 +402,14 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 			{"↑/↓, j/k", "Move between contexts"},
 			{"/", "Start filtering contexts"},
 			{"enter", "Switch to the selected context"},
+			{"s", "Set up the selected context for the shell and quit"},
+			{"y", "Copy shell exports for the selected context and quit"},
+			{"u", "Clear shell exports and current context, then quit"},
 			{"a", "Open the add-context wizard"},
 			{"q", "Quit unic"},
 		}
 		if m.cfg.ContextName != "" {
-			shortcuts = append(shortcuts[:4], append([]helpShortcut{{"esc", "Return to the previous screen"}}, shortcuts[4:]...)...)
+			shortcuts = append(shortcuts[:7], append([]helpShortcut{{"esc", "Return to the previous screen"}}, shortcuts[7:]...)...)
 		}
 		return shortcuts
 	case screenContextAdd:
@@ -429,6 +432,20 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 			{"enter", "Save the current field and continue"},
 			{"esc", "Go back to the previous field or auth type"},
 		}
+	case screenContextSSOAccountList:
+		return []helpShortcut{
+			{"↑/↓, j/k", "Move between AWS accounts"},
+			{"enter", "Select the highlighted account"},
+			{"esc", "Go back to the context picker"},
+			{"q", "Cancel and return to the context picker"},
+		}
+	case screenContextSSORoleList:
+		return []helpShortcut{
+			{"↑/↓, j/k", "Move between AWS roles"},
+			{"enter", "Select the highlighted role and copy exports"},
+			{"esc", "Go back to the account list"},
+			{"q", "Cancel and return to the context picker"},
+		}
 	case screenLoading:
 		return []helpShortcut{
 			{"Wait", "The current AWS request is still loading"},
@@ -437,6 +454,10 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 		return []helpShortcut{
 			{"enter / esc", "Return to the service list"},
 			{"q", "Quit unic"},
+		}
+	case screenExitNotice:
+		return []helpShortcut{
+			{"any key", "Close the exit notice and return to the terminal"},
 		}
 	default:
 		return nil
@@ -596,10 +617,16 @@ func (m Model) helpScreenTitle() string {
 		return "Context Picker"
 	case screenContextAdd:
 		return "Add Context"
+	case screenContextSSOAccountList:
+		return "Select SSO Account"
+	case screenContextSSORoleList:
+		return "Select SSO Role"
 	case screenLoading:
 		return "Loading"
 	case screenError:
 		return "Error"
+	case screenExitNotice:
+		return "Exit Notice"
 	default:
 		return "Current Screen"
 	}

--- a/internal/app/screen_context.go
+++ b/internal/app/screen_context.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -18,7 +19,17 @@ func (m Model) handleContextMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		m.ctxList = msg.contexts
 		m.filteredCtxList = msg.contexts
 		m.ctxIdx = 0
+		m.contextSSOBase = config.ContextInfo{}
+		m.contextSSOAccounts = nil
+		m.contextSSOAccountIdx = 0
+		m.contextSSOAccount = awsservice.SSOAccount{}
+		m.contextSSORoles = nil
+		m.contextSSORoleIdx = 0
 		m.resetFilter(filterContexts)
+		envContext := contextDetectEnvFn(msg.contexts, os.Getenv)
+		m.envContextName = envContext.Name
+		m.envContextSource = envContext.Source
+		m.envContextKnown = envContext.Known
 		for i, ctx := range m.filteredCtxList {
 			if ctx.Current {
 				m.ctxIdx = i
@@ -43,6 +54,27 @@ func (m Model) handleContextMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		m.awsRepo = nil
 		m.screen = m.ctxPrevScreen
 		return m, tea.ClearScreen, true
+
+	case contextSSOAccountsLoadedMsg:
+		m.contextSSOBase = msg.base
+		m.contextSSOAccounts = msg.accounts
+		m.contextSSOAccountIdx = 0
+		m.screen = screenContextSSOAccountList
+		return m, nil, true
+
+	case contextSSORolesLoadedMsg:
+		m.contextSSOBase = msg.base
+		m.contextSSOAccount = msg.account
+		m.contextSSORoles = msg.roles
+		m.contextSSORoleIdx = 0
+		m.screen = screenContextSSORoleList
+		return m, nil, true
+
+	case contextTerminalActionDoneMsg:
+		m.exitTitle = msg.title
+		m.exitMessage = msg.message
+		m.screen = screenExitNotice
+		return m, nil, true
 	}
 	return m, nil, false
 }
@@ -87,6 +119,20 @@ func (m Model) updateContextPicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.pendingContextName = selected.Name
 			return m.startLoading(m.switchContext(selected.Name))
 		}
+	case "s":
+		selected, ok := m.selectedContextInfo()
+		if !ok {
+			return m, nil
+		}
+		return m.beginContextSetup(selected)
+	case "y":
+		selected, ok := m.selectedContextInfo()
+		if !ok {
+			return m, nil
+		}
+		return m.beginContextExport(selected)
+	case "u":
+		return m.beginContextUnset()
 	case "a":
 		m.addStep = 0
 		m.addAuthIdx = 0
@@ -175,6 +221,10 @@ func (m Model) viewContextPicker() string {
 	var panel strings.Builder
 	b.WriteString(titleStyle.Render("Select Context"))
 	b.WriteString("\n")
+	b.WriteString(renderDetailLine("UNIC current", displayContextName(m.cfg.ContextName)))
+	b.WriteString("\n")
+	b.WriteString(renderDetailLine("Shell env", m.displayShellEnvContext()))
+	b.WriteString("\n\n")
 
 	b.WriteString(m.renderFilterValue(filterContexts))
 	b.WriteString("\n\n")
@@ -195,9 +245,38 @@ func (m Model) viewContextPicker() string {
 	b.WriteString(m.renderListPanel(panel.String()))
 	b.WriteString("\n\n")
 	if m.cfg.ContextName != "" {
-		b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • enter: select • a: add • esc: back • q: quit"))
+		b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • enter: switch • s: setup • y: copy env • u: unset • a: add • esc: back • q: quit"))
 	} else {
-		b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • enter: select • a: add • q: quit"))
+		b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • enter: switch • s: setup • y: copy env • u: unset • a: add • q: quit"))
 	}
 	return b.String()
+}
+
+func displayContextName(name string) string {
+	if strings.TrimSpace(name) == "" {
+		return "none"
+	}
+	return name
+}
+
+func (m Model) displayShellEnvContext() string {
+	if strings.TrimSpace(m.envContextName) == "" {
+		return "not detected"
+	}
+
+	summary := m.envContextName
+	switch m.envContextSource {
+	case auth.ContextEnvVar:
+		if !m.envContextKnown {
+			return summary + " (UNIC_CONTEXT, not in config)"
+		}
+		return summary + " (UNIC_CONTEXT)"
+	case "AWS_PROFILE":
+		if !m.envContextKnown {
+			return summary + " (best effort from AWS_PROFILE)"
+		}
+		return summary + " (AWS_PROFILE)"
+	default:
+		return summary
+	}
 }

--- a/internal/app/screen_context_test.go
+++ b/internal/app/screen_context_test.go
@@ -1,12 +1,18 @@
 package app
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"unic/internal/auth"
 	"unic/internal/config"
+	awsservice "unic/internal/services/aws"
 )
 
 func testContexts() []config.ContextInfo {
@@ -15,6 +21,16 @@ func testContexts() []config.ContextInfo {
 		{Name: "prod", Region: "us-west-2", AuthType: "sso", Current: true},
 		{Name: "staging", Region: "ap-northeast-2", AuthType: "assume_role"},
 	}
+}
+
+func writeContextConfig(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }
 
 func TestContextsLoadedSyncsContextTable(t *testing.T) {
@@ -116,5 +132,414 @@ func TestContextPickerEnterUsesSelectedTableRow(t *testing.T) {
 	}
 	if model.screen != screenLoading {
 		t.Fatalf("expected loading screen after selecting context, got %v", model.screen)
+	}
+}
+
+func TestContextPickerShowsUNICAndShellContext(t *testing.T) {
+	t.Setenv(auth.ContextEnvVar, "prod")
+
+	m := New(&config.Config{ContextName: "staging", Region: "ap-northeast-2"}, "", "dev")
+	m.width = 80
+	m.height = 20
+
+	updated, _ := m.Update(contextsLoadedMsg{contexts: testContexts()})
+	model := updated.(Model)
+	view := model.viewContextPicker()
+
+	for _, want := range []string{
+		"UNIC current",
+		"staging",
+		"Shell env",
+		"prod (UNIC_CONTEXT)",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected context picker view to contain %q, got %q", want, view)
+		}
+	}
+}
+
+func TestContextPickerSetupCopiesExportsAndQuits(t *testing.T) {
+	path := writeContextConfig(t, `
+current: prod
+defaults:
+  region: us-east-1
+contexts:
+  - name: dev
+    auth_type: credential
+    profile: dev-profile
+    region: us-east-1
+  - name: prod
+    auth_type: credential
+    profile: prod-profile
+    region: us-west-2
+`)
+
+	origBuildEnv := contextBuildEnvExportsFn
+	origCopy := contextCopyClipboardFn
+	defer func() {
+		contextBuildEnvExportsFn = origBuildEnv
+		contextCopyClipboardFn = origCopy
+	}()
+
+	var copied string
+	contextBuildEnvExportsFn = func(_ context.Context, cfg *config.Config) (string, error) {
+		return fmt.Sprintf("export %s='%s'", auth.ContextEnvVar, cfg.ContextName), nil
+	}
+	contextCopyClipboardFn = func(text string) error {
+		copied = text
+		return nil
+	}
+
+	m := New(testConfig(), path, "dev")
+	m.width = 80
+	m.height = 20
+
+	updated, _ := m.Update(contextsLoadedMsg{contexts: []config.ContextInfo{
+		{Name: "dev", Region: "us-east-1", AuthType: "credential"},
+		{Name: "prod", Region: "us-west-2", AuthType: "credential", Current: true},
+	}})
+	model := updated.(Model)
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	model = updated.(Model)
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	model = updated.(Model)
+	if model.screen != screenLoading || cmd == nil {
+		t.Fatalf("expected loading command for setup, got screen=%v cmd=%v", model.screen, cmd)
+	}
+
+	msg := model.setupSelectedContextForTerminal("dev")()
+	updated, noticeCmd := model.Update(msg)
+	model = updated.(Model)
+	if model.quitting || noticeCmd != nil {
+		t.Fatalf("expected setup success to open exit notice, got quitting=%v cmd=%v", model.quitting, noticeCmd)
+	}
+	if model.screen != screenExitNotice {
+		t.Fatalf("expected exit notice screen, got %v", model.screen)
+	}
+	if model.exitTitle != "CONTEXT SET UP" {
+		t.Fatalf("unexpected exit title: %q", model.exitTitle)
+	}
+	if model.exitMessage != "[dev] has been set up and copied. Goodbye!" {
+		t.Fatalf("unexpected exit message: %q", model.exitMessage)
+	}
+	if copied != "export UNIC_CONTEXT='dev'" {
+		t.Fatalf("unexpected clipboard exports: %q", copied)
+	}
+	if view := model.viewExitNotice(); !strings.Contains(view, "Press any key to exit unic") {
+		t.Fatalf("expected exit notice prompt, got %q", view)
+	}
+
+	updated, quitCmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	if !model.quitting || quitCmd == nil {
+		t.Fatalf("expected keypress on exit notice to quit the app")
+	}
+
+	cfg, err := config.Load(nil, nil, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ContextName != "dev" {
+		t.Fatalf("expected current context to switch to dev, got %q", cfg.ContextName)
+	}
+}
+
+func TestContextPickerCopyExportsDoesNotChangeCurrentContext(t *testing.T) {
+	path := writeContextConfig(t, `
+current: prod
+defaults:
+  region: us-east-1
+contexts:
+  - name: dev
+    auth_type: credential
+    profile: dev-profile
+    region: us-east-1
+  - name: prod
+    auth_type: credential
+    profile: prod-profile
+    region: us-west-2
+`)
+
+	origBuildEnv := contextBuildEnvExportsFn
+	origCopy := contextCopyClipboardFn
+	defer func() {
+		contextBuildEnvExportsFn = origBuildEnv
+		contextCopyClipboardFn = origCopy
+	}()
+
+	var copied string
+	contextBuildEnvExportsFn = func(_ context.Context, cfg *config.Config) (string, error) {
+		return "exports-for-" + cfg.ContextName, nil
+	}
+	contextCopyClipboardFn = func(text string) error {
+		copied = text
+		return nil
+	}
+
+	m := New(testConfig(), path, "dev")
+	m.width = 80
+	m.height = 20
+
+	updated, _ := m.Update(contextsLoadedMsg{contexts: []config.ContextInfo{
+		{Name: "dev", Region: "us-east-1", AuthType: "credential"},
+		{Name: "prod", Region: "us-west-2", AuthType: "credential", Current: true},
+	}})
+	model := updated.(Model)
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	model = updated.(Model)
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	model = updated.(Model)
+	if model.screen != screenLoading || cmd == nil {
+		t.Fatalf("expected loading command for copy env, got screen=%v cmd=%v", model.screen, cmd)
+	}
+
+	msg := model.copySelectedContextExports("dev")()
+	updated, noticeCmd := model.Update(msg)
+	model = updated.(Model)
+	if model.quitting || noticeCmd != nil {
+		t.Fatalf("expected copy exports to open exit notice, got quitting=%v cmd=%v", model.quitting, noticeCmd)
+	}
+	if model.screen != screenExitNotice {
+		t.Fatalf("expected exit notice screen, got %v", model.screen)
+	}
+	if model.exitTitle != "EXPORTS COPIED" {
+		t.Fatalf("unexpected exit title: %q", model.exitTitle)
+	}
+	if model.exitMessage != "[dev] exports have been copied. Goodbye!" {
+		t.Fatalf("unexpected exit message: %q", model.exitMessage)
+	}
+	if copied != "exports-for-dev" {
+		t.Fatalf("unexpected clipboard exports: %q", copied)
+	}
+
+	updated, quitCmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	model = updated.(Model)
+	if !model.quitting || quitCmd == nil {
+		t.Fatalf("expected any key on exit notice to quit the app")
+	}
+
+	cfg, err := config.Load(nil, nil, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ContextName != "prod" {
+		t.Fatalf("expected current context to remain prod, got %q", cfg.ContextName)
+	}
+}
+
+func TestContextPickerUnsetCopiesCleanupAndClearsCurrent(t *testing.T) {
+	path := writeContextConfig(t, `
+current: prod
+defaults:
+  region: us-east-1
+contexts:
+  - name: prod
+    auth_type: credential
+    profile: prod-profile
+    region: us-west-2
+`)
+
+	origCleanup := contextBuildEnvCleanupFn
+	origCopy := contextCopyClipboardFn
+	defer func() {
+		contextBuildEnvCleanupFn = origCleanup
+		contextCopyClipboardFn = origCopy
+	}()
+
+	var copied string
+	contextBuildEnvCleanupFn = func() string { return "unset UNIC_CONTEXT" }
+	contextCopyClipboardFn = func(text string) error {
+		copied = text
+		return nil
+	}
+
+	m := New(testConfig(), path, "dev")
+	m.width = 80
+	m.height = 20
+
+	updated, _ := m.Update(contextsLoadedMsg{contexts: []config.ContextInfo{
+		{Name: "prod", Region: "us-west-2", AuthType: "credential", Current: true},
+	}})
+	model := updated.(Model)
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+	model = updated.(Model)
+	if model.screen != screenLoading || cmd == nil {
+		t.Fatalf("expected loading command for unset, got screen=%v cmd=%v", model.screen, cmd)
+	}
+
+	msg := model.unsetTerminalContext()()
+	updated, noticeCmd := model.Update(msg)
+	model = updated.(Model)
+	if model.quitting || noticeCmd != nil {
+		t.Fatalf("expected unset to open exit notice, got quitting=%v cmd=%v", model.quitting, noticeCmd)
+	}
+	if model.screen != screenExitNotice {
+		t.Fatalf("expected exit notice screen, got %v", model.screen)
+	}
+	if model.exitTitle != "CONTEXT CLEARED" {
+		t.Fatalf("unexpected exit title: %q", model.exitTitle)
+	}
+	if model.exitMessage != "Shell context has been cleared and cleanup commands copied. Goodbye!" {
+		t.Fatalf("unexpected exit message: %q", model.exitMessage)
+	}
+	if copied != "unset UNIC_CONTEXT" {
+		t.Fatalf("unexpected cleanup commands: %q", copied)
+	}
+
+	updated, quitCmd := model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	model = updated.(Model)
+	if !model.quitting || quitCmd == nil {
+		t.Fatalf("expected exit notice dismissal to quit the app")
+	}
+
+	cfg, err := config.Load(nil, nil, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ContextName != "" {
+		t.Fatalf("expected current context to be cleared, got %q", cfg.ContextName)
+	}
+}
+
+func TestContextPickerSetupBaseSSOUsesNativeSelectionFlow(t *testing.T) {
+	path := writeContextConfig(t, `
+defaults:
+  region: ap-northeast-2
+contexts:
+  - name: base-sso
+    auth_type: sso
+    profile: sso-profile
+    region: ap-northeast-2
+    sso_start_url: https://example.awsapps.com/start
+`)
+
+	origAccounts := contextListSSOAccountsFn
+	origRoles := contextListSSORolesFn
+	origResolve := contextResolveSSOSelectionFn
+	origSetCurrent := contextSetCurrentFn
+	origLoadNamed := contextLoadNamedContextFn
+	origBuildEnv := contextBuildEnvExportsFn
+	origCopy := contextCopyClipboardFn
+	defer func() {
+		contextListSSOAccountsFn = origAccounts
+		contextListSSORolesFn = origRoles
+		contextResolveSSOSelectionFn = origResolve
+		contextSetCurrentFn = origSetCurrent
+		contextLoadNamedContextFn = origLoadNamed
+		contextBuildEnvExportsFn = origBuildEnv
+		contextCopyClipboardFn = origCopy
+	}()
+
+	contextListSSOAccountsFn = func(_ context.Context, configPath string, selected config.ContextInfo) ([]awsservice.SSOAccount, error) {
+		if configPath != path || selected.Name != "base-sso" {
+			t.Fatalf("unexpected account selection input: path=%q selected=%+v", configPath, selected)
+		}
+		return []awsservice.SSOAccount{{ID: "123456789012", Name: "dev"}}, nil
+	}
+	contextListSSORolesFn = func(_ context.Context, configPath string, selected config.ContextInfo, accountID string) ([]awsservice.SSORole, error) {
+		if configPath != path || selected.Name != "base-sso" || accountID != "123456789012" {
+			t.Fatalf("unexpected role selection input: path=%q selected=%+v account=%q", configPath, selected, accountID)
+		}
+		return []awsservice.SSORole{{Name: "AdministratorAccess"}}, nil
+	}
+	contextResolveSSOSelectionFn = func(configPath string, selected config.ContextInfo, account awsservice.SSOAccount, role awsservice.SSORole) (string, error) {
+		if configPath != path || selected.Name != "base-sso" || account.ID != "123456789012" || role.Name != "AdministratorAccess" {
+			t.Fatalf("unexpected resolve input: path=%q selected=%+v account=%+v role=%+v", configPath, selected, account, role)
+		}
+		return "resolved-sso", nil
+	}
+
+	var currentSet string
+	contextSetCurrentFn = func(_ string, name string) error {
+		currentSet = name
+		return nil
+	}
+	contextLoadNamedContextFn = func(_ string, name string) (*config.Config, error) {
+		return &config.Config{
+			ContextName:  name,
+			AuthType:     config.AuthTypeSSO,
+			Region:       "ap-northeast-2",
+			SSOStartURL:  "https://example.awsapps.com/start",
+			SSOAccountID: "123456789012",
+			SSORoleName:  "AdministratorAccess",
+		}, nil
+	}
+	contextBuildEnvExportsFn = func(_ context.Context, cfg *config.Config) (string, error) {
+		return "exports-for-" + cfg.ContextName, nil
+	}
+
+	var copied string
+	contextCopyClipboardFn = func(text string) error {
+		copied = text
+		return nil
+	}
+
+	m := New(testConfig(), path, "dev")
+	m.width = 80
+	m.height = 20
+
+	updated, _ := m.Update(contextsLoadedMsg{contexts: []config.ContextInfo{
+		{Name: "base-sso", Region: "ap-northeast-2", AuthType: "sso", SSOStartURL: "https://example.awsapps.com/start"},
+	}})
+	model := updated.(Model)
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	model = updated.(Model)
+	if model.screen != screenLoading || cmd == nil {
+		t.Fatalf("expected loading command for base SSO setup, got screen=%v cmd=%v", model.screen, cmd)
+	}
+
+	updated, _ = model.Update(model.loadSSOContextAccounts(model.filteredCtxList[0])())
+	model = updated.(Model)
+	if model.screen != screenContextSSOAccountList || len(model.contextSSOAccounts) != 1 {
+		t.Fatalf("expected SSO account selection screen, got screen=%v accounts=%d", model.screen, len(model.contextSSOAccounts))
+	}
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	if model.screen != screenLoading || cmd == nil {
+		t.Fatalf("expected loading command for role lookup, got screen=%v cmd=%v", model.screen, cmd)
+	}
+
+	updated, _ = model.Update(model.loadSSOContextRoles(model.contextSSOBase, model.contextSSOAccounts[0])())
+	model = updated.(Model)
+	if model.screen != screenContextSSORoleList || len(model.contextSSORoles) != 1 {
+		t.Fatalf("expected SSO role selection screen, got screen=%v roles=%d", model.screen, len(model.contextSSORoles))
+	}
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	if model.screen != screenLoading || cmd == nil {
+		t.Fatalf("expected loading command for final setup, got screen=%v cmd=%v", model.screen, cmd)
+	}
+
+	updated, noticeCmd := model.Update(model.setupResolvedSSOContextForTerminal()())
+	model = updated.(Model)
+	if model.quitting || noticeCmd != nil {
+		t.Fatalf("expected final setup to open exit notice, got quitting=%v cmd=%v", model.quitting, noticeCmd)
+	}
+	if model.screen != screenExitNotice {
+		t.Fatalf("expected exit notice screen, got %v", model.screen)
+	}
+	if model.exitTitle != "CONTEXT SET UP" {
+		t.Fatalf("unexpected exit title: %q", model.exitTitle)
+	}
+	if model.exitMessage != "[resolved-sso] has been set up and copied. Goodbye!" {
+		t.Fatalf("unexpected exit message: %q", model.exitMessage)
+	}
+	if currentSet != "resolved-sso" {
+		t.Fatalf("expected resolved context to be set current, got %q", currentSet)
+	}
+	if copied != "exports-for-resolved-sso" {
+		t.Fatalf("unexpected clipboard exports: %q", copied)
+	}
+
+	updated, quitCmd := model.Update(tea.KeyMsg{Type: tea.KeySpace})
+	model = updated.(Model)
+	if !model.quitting || quitCmd == nil {
+		t.Fatalf("expected exit notice dismissal to quit the app")
 	}
 }

--- a/internal/app/screen_context_test.go
+++ b/internal/app/screen_context_test.go
@@ -543,3 +543,20 @@ contexts:
 		t.Fatalf("expected exit notice dismissal to quit the app")
 	}
 }
+
+func TestContextPickerSetupResolvedSSORejectsInvalidRoleSelection(t *testing.T) {
+	m := New(testConfig(), "/tmp/config.yaml", "dev")
+	m.contextSSOBase = config.ContextInfo{Name: "base-sso", AuthType: "sso"}
+	m.contextSSOAccount = awsservice.SSOAccount{ID: "123456789012", Name: "dev"}
+	m.contextSSORoles = []awsservice.SSORole{{Name: "AdministratorAccess"}}
+	m.contextSSORoleIdx = 3
+
+	msg := m.setupResolvedSSOContextForTerminal()()
+	err, ok := msg.(errMsg)
+	if !ok {
+		t.Fatalf("expected errMsg for invalid role selection, got %T", msg)
+	}
+	if err.err == nil || err.err.Error() != "invalid role selection" {
+		t.Fatalf("unexpected error: %v", err.err)
+	}
+}

--- a/internal/app/styles.go
+++ b/internal/app/styles.go
@@ -25,6 +25,22 @@ var (
 	listPanelStyle   = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("240")).Padding(0, 1)
 	helpStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Background(lipgloss.Color("237"))
 	detailLabelStyle = dimStyle.Copy().Width(14)
+	exitPanelStyle   = lipgloss.NewStyle().
+				Border(lipgloss.DoubleBorder()).
+				BorderForeground(lipgloss.Color("39")).
+				Foreground(lipgloss.Color("252")).
+				Background(lipgloss.Color("236")).
+				Padding(1, 2)
+	exitTitleStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("39")).
+			Background(lipgloss.Color("236")).
+			Padding(0, 1)
+	exitBodyStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("252"))
+	exitPromptStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("214")).
+			Bold(true)
 )
 
 func (m Model) renderStatusBar() string {
@@ -174,4 +190,34 @@ func (m Model) viewError() string {
 	b.WriteString("\n\n")
 	b.WriteString(m.renderHelpBar("enter/esc: go back • q: quit"))
 	return b.String()
+}
+
+func (m Model) viewExitNotice() string {
+	title := strings.TrimSpace(m.exitTitle)
+	if title == "" {
+		title = "SYSTEM NOTICE"
+	}
+	message := strings.TrimSpace(m.exitMessage)
+	if message == "" {
+		message = "Operation complete."
+	}
+
+	boxWidth := 60
+	if m.width > 0 {
+		boxWidth = min(max(m.width-10, 48), 72)
+	}
+	contentWidth := max(boxWidth-6, 32)
+
+	var body strings.Builder
+	body.WriteString(exitTitleStyle.Copy().Width(contentWidth).Align(lipgloss.Center).Render(title))
+	body.WriteString("\n\n")
+	body.WriteString(exitBodyStyle.Copy().Width(contentWidth).Align(lipgloss.Center).Render(message))
+	body.WriteString("\n\n")
+	body.WriteString(exitPromptStyle.Copy().Width(contentWidth).Align(lipgloss.Center).Render("Press any key to exit unic"))
+
+	modal := exitPanelStyle.Copy().Width(boxWidth).Render(body.String())
+	if m.width <= 0 || m.height <= 0 {
+		return modal
+	}
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, modal)
 }

--- a/internal/app/styles_test.go
+++ b/internal/app/styles_test.go
@@ -94,7 +94,7 @@ func TestContextPickerUsesBorderedPanelAndHelpBar(t *testing.T) {
 	m = updated.(Model)
 
 	view := stripANSI(m.viewContextPicker())
-	for _, want := range []string{"╭", "╰", "NAME", "AUTH TYPE", "prod", "↑/↓: navigate • /: filter • enter: select • a: add • q: quit"} {
+	for _, want := range []string{"╭", "╰", "NAME", "AUTH TYPE", "prod", "↑/↓: navigate • /: filter • enter: switch • s: setup • y: copy env • u: unset •"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("expected context picker view to contain %q, got %q", want, view)
 		}

--- a/internal/auth/env.go
+++ b/internal/auth/env.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -16,48 +17,124 @@ import (
 var assumeRoleFn = assumeRoleEnv
 var resolveSSORoleFn = resolveSSORoleEnv
 
+const ContextEnvVar = "UNIC_CONTEXT"
+
+type EnvContextDetection struct {
+	Name   string
+	Source string
+	Known  bool
+}
+
 // BuildEnvExports renders shell export commands for the given context.
 func BuildEnvExports(ctx context.Context, cfg *config.Config) (string, error) {
+	var values map[string]string
+
 	switch cfg.AuthType {
 	case config.AuthTypeSSO:
 		if cfg.SSOAccountID == "" || cfg.SSORoleName == "" {
 			return "", fmt.Errorf("context %q is an SSO base context; run `unic context setup` first", cfg.ContextName)
 		}
-		values, err := resolveSSORoleFn(ctx, cfg)
+		var err error
+		values, err = resolveSSORoleFn(ctx, cfg)
 		if err != nil {
 			return "", err
 		}
 		values["AWS_REGION"] = cfg.Region
 		values["AWS_DEFAULT_REGION"] = cfg.Region
 		values["AWS_PROFILE"] = ""
-		return renderExports(values), nil
 
 	case config.AuthTypeAssumeRole:
-		values, err := assumeRoleFn(ctx, cfg)
+		var err error
+		values, err = assumeRoleFn(ctx, cfg)
 		if err != nil {
 			return "", err
 		}
 		values["AWS_REGION"] = cfg.Region
 		values["AWS_DEFAULT_REGION"] = cfg.Region
 		values["AWS_PROFILE"] = ""
-		return renderExports(values), nil
 
 	case config.AuthTypeCredential, config.AuthTypeDefault:
 		profile := cfg.Profile
 		if profile == "" {
 			profile = "default"
 		}
-		return renderExports(map[string]string{
+		values = map[string]string{
 			"AWS_PROFILE":           profile,
 			"AWS_REGION":            cfg.Region,
 			"AWS_DEFAULT_REGION":    cfg.Region,
 			"AWS_ACCESS_KEY_ID":     "",
 			"AWS_SECRET_ACCESS_KEY": "",
 			"AWS_SESSION_TOKEN":     "",
-		}), nil
+		}
 
 	default:
 		return "", fmt.Errorf("unsupported auth type %q", cfg.AuthType)
+	}
+
+	values[ContextEnvVar] = cfg.ContextName
+	return renderExports(values), nil
+}
+
+func BuildEnvCleanupCommands() string {
+	return renderExports(map[string]string{
+		"AWS_PROFILE":           "",
+		"AWS_REGION":            "",
+		"AWS_DEFAULT_REGION":    "",
+		"AWS_ACCESS_KEY_ID":     "",
+		"AWS_SECRET_ACCESS_KEY": "",
+		"AWS_SESSION_TOKEN":     "",
+		ContextEnvVar:           "",
+	})
+}
+
+func DetectEnvContext(contexts []config.ContextInfo, lookup func(string) string) EnvContextDetection {
+	if lookup == nil {
+		lookup = os.Getenv
+	}
+
+	marker := strings.TrimSpace(lookup(ContextEnvVar))
+	if marker != "" {
+		return EnvContextDetection{
+			Name:   marker,
+			Source: ContextEnvVar,
+			Known:  hasContext(contexts, marker),
+		}
+	}
+
+	profile := strings.TrimSpace(lookup("AWS_PROFILE"))
+	if profile == "" {
+		return EnvContextDetection{}
+	}
+
+	region := strings.TrimSpace(lookup("AWS_REGION"))
+	if region == "" {
+		region = strings.TrimSpace(lookup("AWS_DEFAULT_REGION"))
+	}
+
+	matches := matchContextsByProfile(contexts, profile, region)
+	if len(matches) == 1 {
+		return EnvContextDetection{
+			Name:   matches[0].Name,
+			Source: "AWS_PROFILE",
+			Known:  true,
+		}
+	}
+
+	if region == "" {
+		matches = matchContextsByProfile(contexts, profile, "")
+		if len(matches) == 1 {
+			return EnvContextDetection{
+				Name:   matches[0].Name,
+				Source: "AWS_PROFILE",
+				Known:  true,
+			}
+		}
+	}
+
+	return EnvContextDetection{
+		Name:   profile,
+		Source: "AWS_PROFILE",
+		Known:  false,
 	}
 }
 
@@ -103,6 +180,29 @@ func resolveSSORoleEnv(ctx context.Context, cfg *config.Config) (map[string]stri
 		"AWS_SECRET_ACCESS_KEY": creds.SecretAccessKey,
 		"AWS_SESSION_TOKEN":     creds.SessionToken,
 	}, nil
+}
+
+func hasContext(contexts []config.ContextInfo, name string) bool {
+	for _, ctx := range contexts {
+		if ctx.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func matchContextsByProfile(contexts []config.ContextInfo, profile, region string) []config.ContextInfo {
+	var matches []config.ContextInfo
+	for _, ctx := range contexts {
+		if ctx.Profile != profile {
+			continue
+		}
+		if region != "" && ctx.Region != region {
+			continue
+		}
+		matches = append(matches, ctx)
+	}
+	return matches
 }
 
 func renderExports(values map[string]string) string {

--- a/internal/auth/env_test.go
+++ b/internal/auth/env_test.go
@@ -25,6 +25,7 @@ func TestBuildEnvExportsCredentialContext(t *testing.T) {
 		"export AWS_PROFILE='dev-profile'",
 		"export AWS_REGION='ap-northeast-2'",
 		"export AWS_DEFAULT_REGION='ap-northeast-2'",
+		"export UNIC_CONTEXT='dev'",
 		"unset AWS_ACCESS_KEY_ID",
 		"unset AWS_SECRET_ACCESS_KEY",
 		"unset AWS_SESSION_TOKEN",
@@ -66,6 +67,9 @@ func TestBuildEnvExportsAssumeRoleContext(t *testing.T) {
 	if !strings.Contains(exports, "unset AWS_PROFILE") {
 		t.Fatalf("expected AWS_PROFILE to be unset for temp credentials, got:\n%s", exports)
 	}
+	if !strings.Contains(exports, "export UNIC_CONTEXT='prod'") {
+		t.Fatalf("expected UNIC_CONTEXT marker in exports, got:\n%s", exports)
+	}
 }
 
 func TestBuildEnvExportsRejectsIncompleteSSOContext(t *testing.T) {
@@ -79,5 +83,66 @@ func TestBuildEnvExportsRejectsIncompleteSSOContext(t *testing.T) {
 	_, err := BuildEnvExports(context.Background(), cfg)
 	if err == nil || !strings.Contains(err.Error(), "run `unic context setup` first") {
 		t.Fatalf("expected incomplete SSO error, got %v", err)
+	}
+}
+
+func TestBuildEnvCleanupCommandsIncludesUNICContext(t *testing.T) {
+	exports := BuildEnvCleanupCommands()
+	for _, expected := range []string{
+		"unset AWS_PROFILE",
+		"unset AWS_REGION",
+		"unset AWS_DEFAULT_REGION",
+		"unset AWS_ACCESS_KEY_ID",
+		"unset AWS_SECRET_ACCESS_KEY",
+		"unset AWS_SESSION_TOKEN",
+		"unset UNIC_CONTEXT",
+	} {
+		if !strings.Contains(exports, expected) {
+			t.Fatalf("expected cleanup commands to contain %q, got:\n%s", expected, exports)
+		}
+	}
+}
+
+func TestDetectEnvContextPrefersUNICContextMarker(t *testing.T) {
+	contexts := []config.ContextInfo{
+		{Name: "dev", Profile: "dev-profile", Region: "ap-northeast-2"},
+	}
+
+	detection := DetectEnvContext(contexts, func(key string) string {
+		if key == ContextEnvVar {
+			return "dev"
+		}
+		if key == "AWS_PROFILE" {
+			return "wrong"
+		}
+		return ""
+	})
+
+	if detection.Name != "dev" || detection.Source != ContextEnvVar || !detection.Known {
+		t.Fatalf("unexpected detection: %+v", detection)
+	}
+}
+
+func TestDetectEnvContextFallsBackToAWSProfile(t *testing.T) {
+	contexts := []config.ContextInfo{
+		{Name: "dev", Profile: "dev-profile", Region: "ap-northeast-2"},
+		{Name: "prod", Profile: "prod-profile", Region: "us-east-1"},
+	}
+
+	detection := DetectEnvContext(contexts, func(key string) string {
+		switch key {
+		case ContextEnvVar:
+			return ""
+		case "AWS_PROFILE":
+			return "dev-profile"
+		case "AWS_REGION":
+			return "ap-northeast-2"
+		default:
+			return ""
+		}
+	})
+
+	if detection.Name != "dev" || detection.Source != "AWS_PROFILE" || !detection.Known {
+		t.Fatalf("unexpected detection: %+v", detection)
 	}
 }

--- a/internal/auth/setup.go
+++ b/internal/auth/setup.go
@@ -54,20 +54,12 @@ func SetupContext(ctx context.Context, configPath string, in io.Reader, errOut i
 }
 
 func resolveContextSelection(ctx context.Context, configPath string, selected config.ContextInfo, in *bufio.Reader, errOut io.Writer) (string, error) {
-	if config.AuthType(selected.AuthType) != config.AuthTypeSSO || (selected.SSOAccountID != "" && selected.SSORoleName != "") {
+	if !IsBaseSSOContext(selected) {
 		return selected.Name, nil
-	}
-	if selected.SSOStartURL == "" {
-		return "", fmt.Errorf("context %q is missing sso_start_url", selected.Name)
-	}
-
-	baseCfg, err := config.LoadNamedContext(configPath, selected.Name)
-	if err != nil {
-		return "", err
 	}
 
 	fmt.Fprintf(errOut, "Listing AWS accounts for %s ...\n", selected.Name)
-	accounts, err := listSSOAccountsFn(ctx, baseCfg)
+	accounts, err := ListSSOContextAccounts(ctx, configPath, selected)
 	if err != nil {
 		return "", err
 	}
@@ -81,7 +73,7 @@ func resolveContextSelection(ctx context.Context, configPath string, selected co
 	}
 
 	fmt.Fprintf(errOut, "Listing roles for account %s ...\n", account.ID)
-	roles, err := listSSOAccountRolesFn(ctx, baseCfg, account.ID)
+	roles, err := ListSSOContextRoles(ctx, configPath, selected, account.ID)
 	if err != nil {
 		return "", err
 	}
@@ -94,6 +86,42 @@ func resolveContextSelection(ctx context.Context, configPath string, selected co
 		return "", err
 	}
 
+	return ResolveSSOContextSelection(configPath, selected, account, role)
+}
+
+func IsBaseSSOContext(selected config.ContextInfo) bool {
+	return config.AuthType(selected.AuthType) == config.AuthTypeSSO &&
+		(selected.SSOAccountID == "" || selected.SSORoleName == "")
+}
+
+func ListSSOContextAccounts(ctx context.Context, configPath string, selected config.ContextInfo) ([]awsservice.SSOAccount, error) {
+	if !IsBaseSSOContext(selected) {
+		return nil, fmt.Errorf("context %q is not an SSO base context", selected.Name)
+	}
+	if selected.SSOStartURL == "" {
+		return nil, fmt.Errorf("context %q is missing sso_start_url", selected.Name)
+	}
+
+	baseCfg, err := config.LoadNamedContext(configPath, selected.Name)
+	if err != nil {
+		return nil, err
+	}
+	return listSSOAccountsFn(ctx, baseCfg)
+}
+
+func ListSSOContextRoles(ctx context.Context, configPath string, selected config.ContextInfo, accountID string) ([]awsservice.SSORole, error) {
+	if !IsBaseSSOContext(selected) {
+		return nil, fmt.Errorf("context %q is not an SSO base context", selected.Name)
+	}
+
+	baseCfg, err := config.LoadNamedContext(configPath, selected.Name)
+	if err != nil {
+		return nil, err
+	}
+	return listSSOAccountRolesFn(ctx, baseCfg, accountID)
+}
+
+func ResolveSSOContextSelection(configPath string, selected config.ContextInfo, account awsservice.SSOAccount, role awsservice.SSORole) (string, error) {
 	entry, name, err := buildSSOContextEntry(configPath, selected, account, role)
 	if err != nil {
 		return "", err

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -17,6 +16,7 @@ var (
 	ensureConfigExistsFn = config.EnsureConfigExists
 	setupContextFn       = auth.SetupContext
 	buildEnvFn           = auth.BuildEnvExports
+	buildCleanupEnvFn    = auth.BuildEnvCleanupCommands
 	loadNamedContextFn   = config.LoadNamedContext
 	loadConfigFn         = config.Load
 	unsetCurrentFn       = config.UnsetCurrent
@@ -79,14 +79,7 @@ func newContextUnsetCmd() *cobra.Command {
 				return err
 			}
 
-			exports := strings.Join([]string{
-				"unset AWS_PROFILE",
-				"unset AWS_REGION",
-				"unset AWS_DEFAULT_REGION",
-				"unset AWS_ACCESS_KEY_ID",
-				"unset AWS_SECRET_ACCESS_KEY",
-				"unset AWS_SESSION_TOKEN",
-			}, "\n")
+			exports := buildCleanupEnvFn()
 
 			if err := copyClipboardFn(exports); err != nil {
 				fmt.Fprintf(cmd.ErrOrStderr(), "Clipboard unavailable: %v\n", err)

--- a/internal/cli/context_test.go
+++ b/internal/cli/context_test.go
@@ -105,11 +105,13 @@ func TestContextUnsetClearsCurrentAndCopiesCleanupCommands(t *testing.T) {
 	origEnsure := ensureConfigExistsFn
 	origUnset := unsetCurrentFn
 	origClipboard := copyClipboardFn
+	origCleanup := buildCleanupEnvFn
 	defer func() {
 		defaultPathFn = origDefaultPath
 		ensureConfigExistsFn = origEnsure
 		unsetCurrentFn = origUnset
 		copyClipboardFn = origClipboard
+		buildCleanupEnvFn = origCleanup
 	}()
 
 	defaultPathFn = func() (string, error) { return "/tmp/config.yaml", nil }
@@ -120,12 +122,22 @@ func TestContextUnsetClearsCurrentAndCopiesCleanupCommands(t *testing.T) {
 		}
 		return nil
 	}
+	buildCleanupEnvFn = func() string {
+		return strings.Join([]string{
+			"unset AWS_PROFILE",
+			"unset AWS_SESSION_TOKEN",
+			"unset UNIC_CONTEXT",
+		}, "\n")
+	}
 	copyClipboardFn = func(text string) error {
 		if !strings.Contains(text, "unset AWS_PROFILE") {
 			t.Fatalf("expected cleanup commands, got %q", text)
 		}
 		if !strings.Contains(text, "unset AWS_SESSION_TOKEN") {
 			t.Fatalf("expected session token cleanup, got %q", text)
+		}
+		if !strings.Contains(text, "unset UNIC_CONTEXT") {
+			t.Fatalf("expected UNIC_CONTEXT cleanup, got %q", text)
 		}
 		return nil
 	}


### PR DESCRIPTION
### Summary

Add terminal-oriented context actions to the TUI context picker.

- add `s`, `y`, and `u` actions for setup, export copy, and unset
- show both UNIC current context and detected shell context in the picker
- add TUI-native SSO account / role selection plus a dedicated exit notice modal
- add `UNIC_CONTEXT` to export and cleanup helpers shared by the TUI and CLI flows

### Related Issues

Closes #116

### Validation

- `GOCACHE=/tmp/unic-go-build make test`
- `GOCACHE=/tmp/unic-go-build make build`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed
- [x] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented (none)
