### PR TITLE
feat: add incremental filtering to context setup picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ unic context unset
 `unic context setup` writes its prompts to `stderr` and copies the generated shell commands to the clipboard.
 `unic env` prints shell commands to `stdout` so it can be used with `eval`.
 Both flows now include a `UNIC_CONTEXT` marker in the generated exports so the TUI can show which shell context is currently active.
+In the TUI context picker, typing starts an incremental filter immediately.
 
 ## Configuration
 
@@ -218,7 +219,7 @@ The Inspector feature ships built-in rule packs for Security Group exposure, RDS
 | CloudWatch Logs | log groups/streams load 10 at a time, `n` load more, `1`-`6` time presets, `t` live tail, `f` filter pattern, `w` wrap toggle, `h/l` horizontal scroll |
 | ECS Exec | `r` refresh, `Enter` drill down / exec |
 | Inspector | `r` run/rescan, `1`-`5` severity filter, `Enter` finding detail |
-| Context Picker | `a` add context, `/` filter, `s` setup selected context and quit, `y` copy selected exports and quit, `u` clear shell context and quit with a final confirmation message |
+| Context Picker | `a` add context, type or `/` filter, `s` setup selected context and quit, `y` copy selected exports and quit, `u` clear shell context and quit with a final confirmation message |
 
 Filtering is currently available on EC2 instances, IAM users, VPCs/subnets, RDS instances, Route53 zones/records, CloudWatch log groups/streams, Secrets Manager resources, ECS clusters/services, S3 buckets/objects, and the context picker.
 

--- a/internal/app/screen_context.go
+++ b/internal/app/screen_context.go
@@ -92,8 +92,23 @@ func (m Model) loadContexts() tea.Cmd {
 func (m Model) updateContextPicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
+	if m.isFiltering(filterContexts) && key == "esc" {
+		if strings.TrimSpace(m.filterValue(filterContexts)) != "" {
+			m.resetFilter(filterContexts)
+			m.syncContextTable()
+			return m, nil
+		}
+		m.deactivateFilter()
+		return m, nil
+	}
+
 	if cmd, handled := m.updateSharedFilter(msg, filterContexts); handled {
+		m.syncContextTable()
 		return m, cmd
+	}
+
+	if shouldStartContextIncrementalFilter(msg) {
+		return m.startContextIncrementalFilter(msg)
 	}
 
 	switch key {
@@ -245,11 +260,35 @@ func (m Model) viewContextPicker() string {
 	b.WriteString(m.renderListPanel(panel.String()))
 	b.WriteString("\n\n")
 	if m.cfg.ContextName != "" {
-		b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • enter: switch • s: setup • y: copy env • u: unset • a: add • esc: back • q: quit"))
+		b.WriteString(m.renderHelpBar("↑/↓: navigate • type: filter • /: filter • enter: switch • s: setup • y: copy env • u: unset • a: add • esc: clear/back • q: quit"))
 	} else {
-		b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • enter: switch • s: setup • y: copy env • u: unset • a: add • q: quit"))
+		b.WriteString(m.renderHelpBar("↑/↓: navigate • type: filter • /: filter • enter: switch • s: setup • y: copy env • u: unset • a: add • q: quit"))
 	}
 	return b.String()
+}
+
+func shouldStartContextIncrementalFilter(msg tea.KeyMsg) bool {
+	if len(msg.Runes) != 1 {
+		return false
+	}
+	switch msg.String() {
+	case "/", "q", "s", "y", "u", "a", "j", "k":
+		return false
+	}
+	r := msg.Runes[0]
+	return r >= 32 && r != 127
+}
+
+func (m Model) startContextIncrementalFilter(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	value := string(msg.Runes)
+	m.activeFilter = filterContexts
+	m.filterTI.SetValue(value)
+	m.filterTI.CursorEnd()
+	m.syncFilterInputWidth()
+	m.storeFilterValue(filterContexts, value)
+	m.applyFilterTarget(filterContexts)
+	m.syncContextTable()
+	return m, m.filterTI.Focus()
 }
 
 func displayContextName(name string) string {

--- a/internal/app/screen_context_test.go
+++ b/internal/app/screen_context_test.go
@@ -111,6 +111,57 @@ func TestContextPickerFilterUpdatesTableRows(t *testing.T) {
 	}
 }
 
+func TestContextPickerIncrementalFilterStartsOnTyping(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.width = 80
+	m.height = 20
+
+	updated, _ := m.Update(contextsLoadedMsg{contexts: testContexts()})
+	model := updated.(Model)
+
+	for _, ch := range []rune("prod") {
+		updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{ch}})
+		model = updated.(Model)
+	}
+
+	if !model.isFiltering(filterContexts) {
+		t.Fatal("expected incremental typing to activate context filter")
+	}
+	if got := model.filterValue(filterContexts); got != "prod" {
+		t.Fatalf("expected filter value 'prod', got %q", got)
+	}
+	if got := len(model.filteredCtxList); got != 1 {
+		t.Fatalf("expected 1 filtered context, got %d", got)
+	}
+	if selected := model.contextTable.SelectedRow(); len(selected) == 0 || selected[0] != "prod" {
+		t.Fatalf("expected filtered context prod, got %#v", selected)
+	}
+}
+
+func TestContextPickerEscClearsFilterBeforeBackingOut(t *testing.T) {
+	m := New(&config.Config{ContextName: "prod"}, "", "dev")
+	m.width = 80
+	m.height = 20
+
+	updated, _ := m.Update(contextsLoadedMsg{contexts: testContexts()})
+	model := updated.(Model)
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
+	model = updated.(Model)
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	model = updated.(Model)
+
+	if model.screen != screenContextPicker {
+		t.Fatalf("expected to remain on context picker after clearing filter, got %v", model.screen)
+	}
+	if got := model.filterValue(filterContexts); got != "" {
+		t.Fatalf("expected filter to be cleared, got %q", got)
+	}
+	if got := len(model.filteredCtxList); got != len(testContexts()) {
+		t.Fatalf("expected full context list after clear, got %d", got)
+	}
+}
+
 func TestContextPickerEnterUsesSelectedTableRow(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.width = 80

--- a/internal/app/styles_test.go
+++ b/internal/app/styles_test.go
@@ -94,7 +94,7 @@ func TestContextPickerUsesBorderedPanelAndHelpBar(t *testing.T) {
 	m = updated.(Model)
 
 	view := stripANSI(m.viewContextPicker())
-	for _, want := range []string{"╭", "╰", "NAME", "AUTH TYPE", "prod", "↑/↓: navigate • /: filter • enter: switch • s: setup • y: copy env • u: unset •"} {
+	for _, want := range []string{"╭", "╰", "NAME", "AUTH TYPE", "prod", "↑/↓: navigate • type: filter • /: filter • enter: switch • s: setup • y: copy"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("expected context picker view to contain %q, got %q", want, view)
 		}


### PR DESCRIPTION
### Summary

- start filtering context setup choices as soon as the user types
- keep `/` as an explicit filter entry path for shortcut-key queries
- clear the active context filter with `esc` before leaving the picker
- update README and tests for the new picker behavior

### Related Issues

Closes #118

### Validation

- `make test`
- `make build`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed
- [x] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented
