### PR TITLE
feat: allow custom ordering for context setup choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ unic context unset
 `unic context setup` writes its prompts to `stderr` and copies the generated shell commands to the clipboard.
 `unic env` prints shell commands to `stdout` so it can be used with `eval`.
 Both flows now include a `UNIC_CONTEXT` marker in the generated exports so the TUI can show which shell context is currently active.
+Contexts can be prioritized in the setup picker with an `order` field in config.
 
 ## Configuration
 
@@ -128,6 +129,7 @@ defaults:
 
 contexts:
   - name: dev-sso
+    order: 10
     profile: my-sso-profile
     region: ap-northeast-2
     auth_type: sso
@@ -142,6 +144,7 @@ contexts:
     sso_role_name: DeveloperRole
 
   - name: prod-admin
+    order: 20
     profile: base-profile
     region: us-east-1
     auth_type: assume_role
@@ -161,6 +164,12 @@ contexts:
 | `credential` | Use shared AWS profile credentials | `profile` |
 | `assume_role` | Assume a role from a base profile | `profile`, `role_arn` |
 | `sso` | Use AWS IAM Identity Center / SSO | `profile`, `sso_start_url`, and for concrete contexts `sso_account_id`, `sso_role_name` |
+
+Optional context fields:
+
+| Field | Meaning |
+|---|---|
+| `order` | Lower values appear first in the context setup picker. Contexts without `order` fall back after ordered entries in their existing file order. |
 
 Resolution priority:
 
@@ -218,7 +227,7 @@ The Inspector feature ships built-in rule packs for Security Group exposure, RDS
 | CloudWatch Logs | log groups/streams load 10 at a time, `n` load more, `1`-`6` time presets, `t` live tail, `f` filter pattern, `w` wrap toggle, `h/l` horizontal scroll |
 | ECS Exec | `r` refresh, `Enter` drill down / exec |
 | Inspector | `r` run/rescan, `1`-`5` severity filter, `Enter` finding detail |
-| Context Picker | `a` add context, `/` filter, `s` setup selected context and quit, `y` copy selected exports and quit, `u` clear shell context and quit with a final confirmation message |
+| Context Picker | `a` add context, type or `/` filter, `s` setup selected context and quit, `y` copy selected exports and quit, `u` clear shell context and quit with a final confirmation message |
 
 Filtering is currently available on EC2 instances, IAM users, VPCs/subnets, RDS instances, Route53 zones/records, CloudWatch log groups/streams, Secrets Manager resources, ECS clusters/services, S3 buckets/objects, and the context picker.
 

--- a/internal/app/context_add.go
+++ b/internal/app/context_add.go
@@ -20,6 +20,7 @@ var authTypes = []string{"sso", "credential", "assume_role"}
 var fieldsByAuthType = map[string][]fieldDef{
 	"sso": {
 		{key: "name", label: "Name", required: true},
+		{key: "order", label: "Display Order (optional, lower first)", required: false},
 		{key: "region", label: "Region", required: true},
 		{key: "sso_start_url", label: "SSO Start URL", required: true},
 		{key: "sso_account_id", label: "SSO Account ID", required: true},
@@ -27,11 +28,13 @@ var fieldsByAuthType = map[string][]fieldDef{
 	},
 	"credential": {
 		{key: "name", label: "Name", required: true},
+		{key: "order", label: "Display Order (optional, lower first)", required: false},
 		{key: "region", label: "Region", required: true},
 		{key: "profile", label: "Profile", required: true},
 	},
 	"assume_role": {
 		{key: "name", label: "Name", required: true},
+		{key: "order", label: "Display Order (optional, lower first)", required: false},
 		{key: "region", label: "Region", required: true},
 		{key: "profile", label: "Profile", required: true},
 		{key: "role_arn", label: "Role ARN", required: true},
@@ -117,8 +120,13 @@ func (m Model) updateContextAdd(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m Model) saveContext() tea.Cmd {
 	return func() tea.Msg {
+		order, err := parseOptionalContextOrder(m.addValues["order"])
+		if err != nil {
+			return errMsg{err: err}
+		}
 		entry := config.ContextEntry{
 			Name:         m.addValues["name"],
+			Order:        order,
 			AuthType:     m.addValues["auth_type"],
 			Region:       m.addValues["region"],
 			Profile:      m.addValues["profile"],
@@ -135,6 +143,18 @@ func (m Model) saveContext() tea.Cmd {
 		contexts, _ := config.Contexts(m.configPath)
 		return contextsLoadedMsg{contexts: contexts}
 	}
+}
+
+func parseOptionalContextOrder(raw string) (int, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return 0, nil
+	}
+	var order int
+	if _, err := fmt.Sscanf(value, "%d", &order); err != nil || order < 0 {
+		return 0, fmt.Errorf("display order must be a non-negative integer")
+	}
+	return order, nil
 }
 
 func (m Model) viewContextAdd() string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -44,6 +45,7 @@ const (
 // ContextEntry represents a single context definition in config.yaml.
 type ContextEntry struct {
 	Name         string `yaml:"name"`
+	Order        int    `yaml:"order,omitempty"`
 	Profile      string `yaml:"profile,omitempty"`
 	Region       string `yaml:"region"`
 	AuthType     string `yaml:"auth_type"`
@@ -87,6 +89,7 @@ func normalizeAuthType(value string) AuthType {
 // ContextInfo holds summary information about a context for listing.
 type ContextInfo struct {
 	Name         string
+	Order        int
 	Profile      string
 	Region       string
 	AuthType     string
@@ -245,6 +248,7 @@ func Contexts(configPath string) ([]ContextInfo, error) {
 	for _, ctx := range fc.Contexts {
 		infos = append(infos, ContextInfo{
 			Name:         ctx.Name,
+			Order:        ctx.Order,
 			Profile:      ctx.Profile,
 			Region:       ctx.Region,
 			AuthType:     ctx.AuthType,
@@ -256,6 +260,20 @@ func Contexts(configPath string) ([]ContextInfo, error) {
 			Current:      ctx.Name == fc.Current,
 		})
 	}
+	sort.SliceStable(infos, func(i, j int) bool {
+		left, right := infos[i], infos[j]
+		switch {
+		case left.Order > 0 && right.Order > 0:
+			if left.Order != right.Order {
+				return left.Order < right.Order
+			}
+		case left.Order > 0:
+			return true
+		case right.Order > 0:
+			return false
+		}
+		return false
+	})
 	return infos, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -264,9 +264,7 @@ func Contexts(configPath string) ([]ContextInfo, error) {
 		left, right := infos[i], infos[j]
 		switch {
 		case left.Order > 0 && right.Order > 0:
-			if left.Order != right.Order {
-				return left.Order < right.Order
-			}
+			return left.Order < right.Order
 		case left.Order > 0:
 			return true
 		case right.Order > 0:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -257,6 +257,36 @@ contexts:
 	}
 }
 
+func TestContextsRespectsExplicitOrderBeforeFallbackOrder(t *testing.T) {
+	dir := t.TempDir()
+	path := writeUnicConfig(t, dir, `
+current: dev
+contexts:
+  - name: prod
+    profile: prod-profile
+  - name: staging
+    profile: staging-profile
+    order: 20
+  - name: dev
+    profile: dev-profile
+    order: 10
+`)
+
+	infos, err := Contexts(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(infos) != 3 {
+		t.Fatalf("expected 3 contexts, got %d", len(infos))
+	}
+	if infos[0].Name != "dev" || infos[1].Name != "staging" || infos[2].Name != "prod" {
+		t.Fatalf("unexpected ordered contexts: %#v", infos)
+	}
+	if infos[0].Order != 10 || infos[1].Order != 20 || infos[2].Order != 0 {
+		t.Fatalf("unexpected order values: %#v", infos)
+	}
+}
+
 func TestSetCurrent(t *testing.T) {
 	dir := t.TempDir()
 	path := writeUnicConfig(t, dir, `
@@ -496,6 +526,7 @@ contexts:
 
 	err := UpsertContext(path, ContextEntry{
 		Name:     "prod",
+		Order:    5,
 		Profile:  "prod-profile",
 		Region:   "ap-northeast-2",
 		AuthType: "credential",
@@ -511,8 +542,8 @@ contexts:
 	if len(infos) != 2 {
 		t.Fatalf("expected 2 contexts, got %d", len(infos))
 	}
-	if infos[1].Name != "prod" {
-		t.Fatalf("expected appended context prod, got %q", infos[1].Name)
+	if infos[0].Name != "prod" {
+		t.Fatalf("expected ordered context prod to sort first, got %q", infos[0].Name)
 	}
 }
 


### PR DESCRIPTION
### Summary

- add an optional `order` field to contexts in `config.yaml`
- sort ordered contexts ahead of fallback entries in the setup picker
- allow entering display order in the add-context flow
- document the ordering behavior and cover it with tests

### Related Issues

Closes #119

### Validation

- `make test`
- `make build`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed
- [x] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented
