### PR TITLE
feat: add incremental filtering to context setup picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ The Inspector feature ships built-in rule packs for Security Group exposure, RDS
 | `j` / `k`, `↑` / `↓` | Move selection |
 | `Enter` | Select / drill down |
 | `Esc` | Go back |
-| `q` | Quit from top-level screens |
+| `q` | Quit from top-level screens outside the context picker |
 | `H` | Jump to service list |
 | `C` | Open context picker |
 | `/` | Toggle filter mode on supported screens |
@@ -218,9 +218,11 @@ The Inspector feature ships built-in rule packs for Security Group exposure, RDS
 | CloudWatch Logs | log groups/streams load 10 at a time, `n` load more, `1`-`6` time presets, `t` live tail, `f` filter pattern, `w` wrap toggle, `h/l` horizontal scroll |
 | ECS Exec | `r` refresh, `Enter` drill down / exec |
 | Inspector | `r` run/rescan, `1`-`5` severity filter, `Enter` finding detail |
-| Context Picker | `a` add context, `/` filter, `s` setup selected context and quit, `y` copy selected exports and quit, `u` clear shell context and quit with a final confirmation message |
+| Context Picker | `type` incremental filter, `Backspace` trim filter, `Esc` clear filter before back/quit, `/` edit filter directly, `S` setup selected context and quit, `Y` copy selected exports and quit, `U` clear shell context and quit with a final confirmation message, `A` add context |
 
 Filtering is currently available on EC2 instances, IAM users, VPCs/subnets, RDS instances, Route53 zones/records, CloudWatch log groups/streams, Secrets Manager resources, ECS clusters/services, S3 buckets/objects, and the context picker.
+
+The context picker now supports immediate type-to-filter matching against context name, profile, and region. `/` is still available when you want to edit the full query explicitly, including navigation shortcut letters such as `j` and `k`.
 
 Reachability Analyzer starts with a region selection step, defaults to the current context region, and now surfaces the AWS-documented source and destination resource types that unic supports: EC2 instances, Internet gateways, Network interfaces, Transit gateways, Transit gateway attachments, Virtual private gateways, VPC endpoint services, VPC endpoints, VPC peering connections, plus IP addresses as destinations. The source and destination pickers support type tabs, keyword filtering, IPv4 destination validation, and automatic cleanup of temporary Network Insights resources after each analysis. During analysis, the loading screen shows a vertical source-to-destination flow and intent summary, and the result view renders path hops and findings in a more readable layout.
 

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -160,7 +160,7 @@ Current screen families include:
 - ECS cluster/service/task/container flows
 - S3 bucket/object/detail flows
 - Inspector home/scanning/results/detail flows
-- context picker, context add, and TUI-native context setup/export/unset flows
+- context picker, including incremental type-to-filter, explicit filter editing, context add, and TUI-native context setup/export/unset flows
 - SSO account / role selection and exit notice flows
 - loading and error screens
 

--- a/docs/architecture.ko.md
+++ b/docs/architecture.ko.md
@@ -160,7 +160,7 @@ UNIC은 현재 세 가지 인증 모드를 지원한다.
 - ECS cluster/service/task/container
 - S3 bucket/object/detail
 - Inspector home/scanning/results/detail
-- context picker, context add, TUI-native context setup/export/unset
+- context picker(즉시 type-to-filter, 명시적 filter 편집 포함), context add, TUI-native context setup/export/unset
 - SSO account / role selection, exit notice
 - loading, error
 

--- a/internal/app/filter.go
+++ b/internal/app/filter.go
@@ -65,13 +65,21 @@ func handleFilterKey(key, current string) (next string, deactivate bool, changed
 		if len(current) == 0 {
 			return current, false, false
 		}
-		return current[:len(current)-1], false, true
+		return trimLastRune(current), false, true
 	}
 
 	if len(key) == 1 {
 		return current + key, false, true
 	}
 	return current, false, false
+}
+
+func trimLastRune(value string) string {
+	runes := []rune(value)
+	if len(runes) == 0 {
+		return value
+	}
+	return string(runes[:len(runes)-1])
 }
 
 func (m *Model) syncFilterInputWidth() {
@@ -132,7 +140,14 @@ func (m *Model) updateSharedFilter(msg tea.KeyMsg, target filterTarget) (tea.Cmd
 	}
 
 	switch msg.String() {
-	case "esc", "enter":
+	case "esc":
+		if target == filterContexts && m.filterTI.Value() != "" {
+			m.resetFilter(target)
+			return nil, true
+		}
+		m.deactivateFilter()
+		return nil, true
+	case "enter":
 		m.deactivateFilter()
 		return nil, true
 	}

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -103,6 +103,12 @@ func (m Model) helpModeShortcuts() []helpShortcut {
 			{"backspace", "Delete the previous character"},
 			{"enter / esc", "Close target filter mode"},
 		}
+	case m.screen == screenContextPicker && m.filterValue(filterContexts) != "":
+		return []helpShortcut{
+			{"type", "Update the context filter"},
+			{"backspace", "Delete the previous character"},
+			{"esc", "Clear the active filter"},
+		}
 	}
 	return nil
 }
@@ -400,16 +406,22 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 	case screenContextPicker:
 		shortcuts := []helpShortcut{
 			{"↑/↓, j/k", "Move between contexts"},
-			{"/", "Start filtering contexts"},
+			{"type", "Filter contexts incrementally"},
+			{"backspace", "Delete the previous filter character"},
+			{"/", "Edit the context filter directly"},
 			{"enter", "Switch to the selected context"},
-			{"s", "Set up the selected context for the shell and quit"},
-			{"y", "Copy shell exports for the selected context and quit"},
-			{"u", "Clear shell exports and current context, then quit"},
-			{"a", "Open the add-context wizard"},
-			{"q", "Quit unic"},
+			{"S", "Set up the selected context for the shell and quit"},
+			{"Y", "Copy shell exports for the selected context and quit"},
+			{"U", "Clear shell exports and current context, then quit"},
+			{"A", "Open the add-context wizard"},
+			{"Q", "Quit unic"},
 		}
-		if m.cfg.ContextName != "" {
-			shortcuts = append(shortcuts[:7], append([]helpShortcut{{"esc", "Return to the previous screen"}}, shortcuts[7:]...)...)
+		if m.filterValue(filterContexts) != "" {
+			shortcuts = append(shortcuts[:4], append([]helpShortcut{{"esc", "Clear the active filter"}}, shortcuts[4:]...)...)
+		} else if m.cfg.ContextName != "" {
+			shortcuts = append(shortcuts[:4], append([]helpShortcut{{"esc", "Return to the previous screen"}}, shortcuts[4:]...)...)
+		} else {
+			shortcuts = append(shortcuts[:4], append([]helpShortcut{{"esc", "Quit unic"}}, shortcuts[4:]...)...)
 		}
 		return shortcuts
 	case screenContextAdd:

--- a/internal/app/screen_context.go
+++ b/internal/app/screen_context.go
@@ -96,8 +96,12 @@ func (m Model) updateContextPicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	}
 
+	if handled := m.updateIncrementalContextFilter(msg); handled {
+		return m, nil
+	}
+
 	switch key {
-	case "q":
+	case "Q":
 		m.quitting = true
 		return m, tea.Quit
 	case "esc":
@@ -119,21 +123,21 @@ func (m Model) updateContextPicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.pendingContextName = selected.Name
 			return m.startLoading(m.switchContext(selected.Name))
 		}
-	case "s":
+	case "S":
 		selected, ok := m.selectedContextInfo()
 		if !ok {
 			return m, nil
 		}
 		return m.beginContextSetup(selected)
-	case "y":
+	case "Y":
 		selected, ok := m.selectedContextInfo()
 		if !ok {
 			return m, nil
 		}
 		return m.beginContextExport(selected)
-	case "u":
+	case "U":
 		return m.beginContextUnset()
-	case "a":
+	case "A":
 		m.addStep = 0
 		m.addAuthIdx = 0
 		m.addFields = nil
@@ -153,6 +157,47 @@ func (m Model) updateContextPicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	}
 	return m, nil
+}
+
+func (m *Model) updateIncrementalContextFilter(msg tea.KeyMsg) bool {
+	query := m.filterValue(filterContexts)
+
+	switch msg.String() {
+	case "backspace":
+		if query == "" {
+			return false
+		}
+		m.storeFilterValue(filterContexts, trimLastRune(query))
+		m.applyFilterTarget(filterContexts)
+		return true
+	case "esc":
+		if query == "" {
+			return false
+		}
+		m.resetFilter(filterContexts)
+		return true
+	}
+
+	if !shouldTypeFilterContext(msg) {
+		return false
+	}
+
+	m.storeFilterValue(filterContexts, query+string(msg.Runes))
+	m.applyFilterTarget(filterContexts)
+	return true
+}
+
+func shouldTypeFilterContext(msg tea.KeyMsg) bool {
+	if len(msg.Runes) == 0 {
+		return false
+	}
+
+	switch msg.String() {
+	case "/", "A", "Q", "S", "U", "Y", "j", "k":
+		return false
+	default:
+		return true
+	}
 }
 
 func (m Model) switchContext(name string) tea.Cmd {
@@ -245,9 +290,9 @@ func (m Model) viewContextPicker() string {
 	b.WriteString(m.renderListPanel(panel.String()))
 	b.WriteString("\n\n")
 	if m.cfg.ContextName != "" {
-		b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • enter: switch • s: setup • y: copy env • u: unset • a: add • esc: back • q: quit"))
+		b.WriteString(m.renderHelpBar("↑/↓: navigate • type: filter • /: edit filter • enter: switch • S: setup • Y: copy env • U: unset • A: add • esc: clear/back • Q: quit"))
 	} else {
-		b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • enter: switch • s: setup • y: copy env • u: unset • a: add • q: quit"))
+		b.WriteString(m.renderHelpBar("↑/↓: navigate • type: filter • /: edit filter • enter: switch • S: setup • Y: copy env • U: unset • A: add • esc: clear/quit • Q: quit"))
 	}
 	return b.String()
 }

--- a/internal/app/screen_context_test.go
+++ b/internal/app/screen_context_test.go
@@ -85,7 +85,114 @@ func TestContextPickerNavigationUsesTableModel(t *testing.T) {
 	}
 }
 
-func TestContextPickerFilterUpdatesTableRows(t *testing.T) {
+func TestContextPickerTypingFiltersTableRows(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.width = 80
+	m.height = 20
+
+	updated, _ := m.Update(contextsLoadedMsg{contexts: testContexts()})
+	model := updated.(Model)
+
+	for _, ch := range []rune("prod") {
+		updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{ch}})
+		model = updated.(Model)
+	}
+
+	if got := len(model.filteredCtxList); got != 1 {
+		t.Fatalf("expected 1 filtered context, got %d", got)
+	}
+	if got := len(model.contextTable.Rows()); got != 1 {
+		t.Fatalf("expected table to show 1 filtered row, got %d", got)
+	}
+	if selected := model.contextTable.SelectedRow(); len(selected) == 0 || selected[0] != "prod" {
+		t.Fatalf("expected filtered table row for prod, got %#v", selected)
+	}
+}
+
+func TestContextPickerFilterMatchesProfileAndRegionCaseInsensitive(t *testing.T) {
+	contexts := []config.ContextInfo{
+		{Name: "dev", Profile: "Dev-Profile", Region: "us-east-1", AuthType: "credential"},
+		{Name: "ops", Profile: "Ops-Admin", Region: "us-West-2", AuthType: "credential"},
+	}
+
+	m := New(testConfig(), "", "dev")
+	m.width = 80
+	m.height = 20
+
+	updated, _ := m.Update(contextsLoadedMsg{contexts: contexts})
+	model := updated.(Model)
+
+	for _, ch := range []rune("ops") {
+		updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{ch}})
+		model = updated.(Model)
+	}
+
+	if got := len(model.filteredCtxList); got != 1 {
+		t.Fatalf("expected 1 context after profile filter, got %d", got)
+	}
+	if model.filteredCtxList[0].Name != "ops" {
+		t.Fatalf("expected ops context after profile filter, got %q", model.filteredCtxList[0].Name)
+	}
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	model = updated.(Model)
+	if got := len(model.filteredCtxList); got != 2 {
+		t.Fatalf("expected esc to restore all contexts, got %d", got)
+	}
+
+	for _, ch := range []rune("west-2") {
+		updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{ch}})
+		model = updated.(Model)
+	}
+
+	if got := len(model.filteredCtxList); got != 1 {
+		t.Fatalf("expected 1 context after region filter, got %d", got)
+	}
+	if model.filteredCtxList[0].Name != "ops" {
+		t.Fatalf("expected ops context after region filter, got %q", model.filteredCtxList[0].Name)
+	}
+}
+
+func TestContextPickerBackspaceAndEscManageIncrementalFilter(t *testing.T) {
+	m := New(&config.Config{ContextName: "prod", Region: "us-east-1"}, "", "dev")
+	m.width = 80
+	m.height = 20
+
+	updated, _ := m.Update(contextsLoadedMsg{contexts: testContexts()})
+	model := updated.(Model)
+
+	for _, ch := range []rune("prod") {
+		updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{ch}})
+		model = updated.(Model)
+	}
+
+	if got := model.filterValue(filterContexts); got != "prod" {
+		t.Fatalf("expected filter query prod, got %q", got)
+	}
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	model = updated.(Model)
+	if got := model.filterValue(filterContexts); got != "pro" {
+		t.Fatalf("expected backspace to trim filter to pro, got %q", got)
+	}
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	model = updated.(Model)
+	if got := model.filterValue(filterContexts); got != "" {
+		t.Fatalf("expected esc to clear the filter, got %q", got)
+	}
+	if model.screen != screenContextPicker {
+		t.Fatalf("expected esc with active filter to stay on context picker, got %v", model.screen)
+	}
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	model = updated.(Model)
+	if model.screen != screenServiceList {
+		t.Fatalf("expected second esc with empty filter to return to previous screen, got %v", model.screen)
+	}
+}
+
+func TestContextPickerEscClearsSlashFilterQuery(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.width = 80
 	m.height = 20
@@ -100,14 +207,48 @@ func TestContextPickerFilterUpdatesTableRows(t *testing.T) {
 		model = updated.(Model)
 	}
 
-	if got := len(model.filteredCtxList); got != 1 {
-		t.Fatalf("expected 1 filtered context, got %d", got)
+	if !model.isFiltering(filterContexts) {
+		t.Fatal("expected slash filter mode to be active")
 	}
-	if got := len(model.contextTable.Rows()); got != 1 {
-		t.Fatalf("expected table to show 1 filtered row, got %d", got)
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	model = updated.(Model)
+
+	if model.isFiltering(filterContexts) {
+		t.Fatal("expected esc to exit slash filter mode")
 	}
-	if selected := model.contextTable.SelectedRow(); len(selected) == 0 || selected[0] != "prod" {
-		t.Fatalf("expected filtered table row for prod, got %#v", selected)
+	if got := model.filterValue(filterContexts); got != "" {
+		t.Fatalf("expected esc to clear slash filter query, got %q", got)
+	}
+	if got := len(model.filteredCtxList); got != len(testContexts()) {
+		t.Fatalf("expected esc to restore all contexts, got %d", got)
+	}
+}
+
+func TestContextPickerTypingFilterResetsSelectionSafely(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.width = 80
+	m.height = 20
+
+	updated, _ := m.Update(contextsLoadedMsg{contexts: testContexts()})
+	model := updated.(Model)
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	model = updated.(Model)
+
+	for _, ch := range []rune("staging") {
+		updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{ch}})
+		model = updated.(Model)
+	}
+
+	if model.ctxIdx != 0 {
+		t.Fatalf("expected filtered cursor to reset to 0, got %d", model.ctxIdx)
+	}
+	if model.contextTable.Cursor() != 0 {
+		t.Fatalf("expected filtered table cursor to reset to 0, got %d", model.contextTable.Cursor())
+	}
+	if selected := model.contextTable.SelectedRow(); len(selected) == 0 || selected[0] != "staging" {
+		t.Fatalf("expected filtered selection for staging, got %#v", selected)
 	}
 }
 
@@ -202,7 +343,7 @@ contexts:
 
 	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
 	model = updated.(Model)
-	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'S'}})
 	model = updated.(Model)
 	if model.screen != screenLoading || cmd == nil {
 		t.Fatalf("expected loading command for setup, got screen=%v cmd=%v", model.screen, cmd)
@@ -289,7 +430,7 @@ contexts:
 
 	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
 	model = updated.(Model)
-	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'Y'}})
 	model = updated.(Model)
 	if model.screen != screenLoading || cmd == nil {
 		t.Fatalf("expected loading command for copy env, got screen=%v cmd=%v", model.screen, cmd)
@@ -364,7 +505,7 @@ contexts:
 	}})
 	model := updated.(Model)
 
-	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'U'}})
 	model = updated.(Model)
 	if model.screen != screenLoading || cmd == nil {
 		t.Fatalf("expected loading command for unset, got screen=%v cmd=%v", model.screen, cmd)
@@ -486,7 +627,7 @@ contexts:
 	}})
 	model := updated.(Model)
 
-	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'S'}})
 	model = updated.(Model)
 	if model.screen != screenLoading || cmd == nil {
 		t.Fatalf("expected loading command for base SSO setup, got screen=%v cmd=%v", model.screen, cmd)

--- a/internal/app/styles_test.go
+++ b/internal/app/styles_test.go
@@ -94,7 +94,7 @@ func TestContextPickerUsesBorderedPanelAndHelpBar(t *testing.T) {
 	m = updated.(Model)
 
 	view := stripANSI(m.viewContextPicker())
-	for _, want := range []string{"╭", "╰", "NAME", "AUTH TYPE", "prod", "↑/↓: navigate • /: filter • enter: switch • s: setup • y: copy env • u: unset •"} {
+	for _, want := range []string{"╭", "╰", "NAME", "AUTH TYPE", "prod", "type: filter", "S: setup", "copy env", "Q: quit"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("expected context picker view to contain %q, got %q", want, view)
 		}
@@ -137,7 +137,7 @@ func TestContextPickerPanelDoesNotOverflowHelpBar(t *testing.T) {
 		if strings.Contains(line, "╰") {
 			borderLine = i
 		}
-		if strings.Contains(line, "q: quit") {
+		if strings.Contains(line, "Q: quit") {
 			helpLine = i
 		}
 	}


### PR DESCRIPTION
### Summary

- Add immediate type-to-filter support in the context picker for context names, profiles, and regions
- Clear active context filters before backing out while keeping slash-based filter editing available
- Update tests, README, and architecture docs for the revised context picker flow and shortcuts

### Related Issues

Closes #118

### Validation

- `make test`
- `make build`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed
- [x] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented: none