### PR TITLE
feat: improve context setup filtering and ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ eval "$(unic env prod-admin)"
 # Interactively choose/setup a context and copy exports to clipboard
 unic context setup
 
+# Set a display order for a context
+unic context order prod-admin 10
+
+# Or open reorder mode, then move the selected context with arrow keys and save
+unic context order
+
 # Clear current context and copy cleanup commands to clipboard
 unic context unset
 ```
@@ -103,6 +109,8 @@ unic context unset
 `unic env` prints shell commands to `stdout` so it can be used with `eval`.
 Both flows now include a `UNIC_CONTEXT` marker in the generated exports so the TUI can show which shell context is currently active.
 Contexts can be prioritized in the setup picker with an `order` field in config.
+In the CLI `unic context setup` flow, the picker now filters contexts, SSO accounts, and SSO roles as you type, with arrow-key navigation and Enter to confirm.
+Use `unic context order` to open reorder mode, choose a context with `↑/↓` or `j/k`, press `Enter` to start moving it, then press `Enter` again to save. `unic context order <name> <number>` still works for direct updates.
 
 ## Configuration
 
@@ -176,6 +184,12 @@ Resolution priority:
 ```text
 CLI flags > selected context > config defaults > hardcoded default (us-east-1)
 ```
+
+Context ordering:
+
+- Lower `order` values appear first
+- Contexts without `order` appear after ordered contexts
+- Contexts with the same `order` keep their file order
 
 ## Current Features
 

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -39,6 +39,8 @@ Owns non-TUI commands:
 - `unic update`
 - `unic env [context]`
 - `unic context setup`
+  - live incremental filtering for large context/account/role lists
+  - interactive context ordering via `unic context order`
 - `unic context unset`
 
 ### `internal/config/`

--- a/docs/architecture.ko.md
+++ b/docs/architecture.ko.md
@@ -39,6 +39,8 @@ cmd/unic/main.go
 - `unic update`
 - `unic env [context]`
 - `unic context setup`
+  - 많은 context/account/role 목록에서 live incremental filtering 지원
+  - `unic context order`를 통한 interactive context ordering 지원
 - `unic context unset`
 
 ### `internal/config/`

--- a/internal/auth/setup.go
+++ b/internal/auth/setup.go
@@ -18,6 +18,19 @@ var (
 	buildEnvExportsFn     = BuildEnvExports
 )
 
+// SelectContext interactively selects a context without changing current state.
+func SelectContext(configPath string, in io.Reader, errOut io.Writer) (config.ContextInfo, error) {
+	reader := bufio.NewReader(in)
+	contexts, err := config.Contexts(configPath)
+	if err != nil {
+		return config.ContextInfo{}, err
+	}
+	if len(contexts) == 0 {
+		return config.ContextInfo{}, fmt.Errorf("no contexts found in %s", configPath)
+	}
+	return chooseContext(in, reader, errOut, contexts)
+}
+
 // SetupContext interactively selects a context, resolves any required SSO account/role,
 // sets it as current, and returns shell exports for eval.
 func SetupContext(ctx context.Context, configPath string, in io.Reader, errOut io.Writer) (string, error) {
@@ -30,12 +43,12 @@ func SetupContext(ctx context.Context, configPath string, in io.Reader, errOut i
 		return "", fmt.Errorf("no contexts found in %s", configPath)
 	}
 
-	selected, err := chooseContext(reader, errOut, contexts)
+	selected, err := chooseContext(in, reader, errOut, contexts)
 	if err != nil {
 		return "", err
 	}
 
-	finalName, err := resolveContextSelection(ctx, configPath, selected, reader, errOut)
+	finalName, err := resolveContextSelection(ctx, configPath, selected, in, reader, errOut)
 	if err != nil {
 		return "", err
 	}
@@ -53,7 +66,7 @@ func SetupContext(ctx context.Context, configPath string, in io.Reader, errOut i
 	return buildEnvExportsFn(ctx, finalCfg)
 }
 
-func resolveContextSelection(ctx context.Context, configPath string, selected config.ContextInfo, in *bufio.Reader, errOut io.Writer) (string, error) {
+func resolveContextSelection(ctx context.Context, configPath string, selected config.ContextInfo, rawIn io.Reader, in *bufio.Reader, errOut io.Writer) (string, error) {
 	if !IsBaseSSOContext(selected) {
 		return selected.Name, nil
 	}
@@ -67,7 +80,7 @@ func resolveContextSelection(ctx context.Context, configPath string, selected co
 		return "", fmt.Errorf("no SSO accounts available for %q", selected.Name)
 	}
 
-	account, err := chooseSSOAccount(in, errOut, accounts)
+	account, err := chooseSSOAccount(rawIn, in, errOut, accounts)
 	if err != nil {
 		return "", err
 	}
@@ -81,7 +94,7 @@ func resolveContextSelection(ctx context.Context, configPath string, selected co
 		return "", fmt.Errorf("no SSO roles available for account %s", account.ID)
 	}
 
-	role, err := chooseSSORole(in, errOut, roles)
+	role, err := chooseSSORole(rawIn, in, errOut, roles)
 	if err != nil {
 		return "", err
 	}
@@ -132,50 +145,34 @@ func ResolveSSOContextSelection(configPath string, selected config.ContextInfo, 
 	return name, nil
 }
 
-func chooseContext(in *bufio.Reader, errOut io.Writer, contexts []config.ContextInfo) (config.ContextInfo, error) {
-	fmt.Fprintln(errOut, "Available contexts:")
-	for i, ctx := range contexts {
-		current := ""
-		if ctx.Current {
-			current = " (current)"
-		}
-		fmt.Fprintf(errOut, "  %d) %s [%s]%s\n", i+1, ctx.Name, displayAuthType(ctx.AuthType), current)
-	}
-
-	index, err := chooseIndex(in, errOut, "Select context", len(contexts))
+func chooseContext(rawIn io.Reader, in *bufio.Reader, errOut io.Writer, contexts []config.ContextInfo) (config.ContextInfo, error) {
+	index, err := chooseFilteredIndex(rawIn, in, errOut, "contexts", contexts, renderContextChoice, func(ctx config.ContextInfo, query string) bool {
+		return strings.Contains(strings.ToLower(ctx.FilterText()), strings.ToLower(strings.TrimSpace(query)))
+	})
 	if err != nil {
 		return config.ContextInfo{}, err
 	}
 	return contexts[index], nil
 }
 
-func chooseSSOAccount(in *bufio.Reader, errOut io.Writer, accounts []awsservice.SSOAccount) (awsservice.SSOAccount, error) {
-	fmt.Fprintln(errOut, "Available AWS accounts:")
-	for i, account := range accounts {
+func chooseSSOAccount(rawIn io.Reader, in *bufio.Reader, errOut io.Writer, accounts []awsservice.SSOAccount) (awsservice.SSOAccount, error) {
+	index, err := chooseFilteredIndex(rawIn, in, errOut, "AWS accounts", accounts, renderAccountChoice, func(account awsservice.SSOAccount, query string) bool {
 		label := account.Name
 		if label == "" {
 			label = account.ID
 		}
-		if account.Email != "" {
-			label = fmt.Sprintf("%s <%s>", label, account.Email)
-		}
-		fmt.Fprintf(errOut, "  %d) %s (%s)\n", i+1, label, account.ID)
-	}
-
-	index, err := chooseIndex(in, errOut, "Select account", len(accounts))
+		return containsFold(label, query) || containsFold(account.ID, query) || containsFold(account.Email, query)
+	})
 	if err != nil {
 		return awsservice.SSOAccount{}, err
 	}
 	return accounts[index], nil
 }
 
-func chooseSSORole(in *bufio.Reader, errOut io.Writer, roles []awsservice.SSORole) (awsservice.SSORole, error) {
-	fmt.Fprintln(errOut, "Available AWS roles:")
-	for i, role := range roles {
-		fmt.Fprintf(errOut, "  %d) %s\n", i+1, role.Name)
-	}
-
-	index, err := chooseIndex(in, errOut, "Select role", len(roles))
+func chooseSSORole(rawIn io.Reader, in *bufio.Reader, errOut io.Writer, roles []awsservice.SSORole) (awsservice.SSORole, error) {
+	index, err := chooseFilteredIndex(rawIn, in, errOut, "AWS roles", roles, renderRoleChoice, func(role awsservice.SSORole, query string) bool {
+		return containsFold(role.Name, query)
+	})
 	if err != nil {
 		return awsservice.SSORole{}, err
 	}
@@ -197,6 +194,110 @@ func chooseIndex(in *bufio.Reader, errOut io.Writer, label string, count int) (i
 		}
 		return index - 1, nil
 	}
+}
+
+func chooseFilteredIndex[T any](
+	rawIn io.Reader,
+	in *bufio.Reader,
+	errOut io.Writer,
+	label string,
+	items []T,
+	render func(T) string,
+	matches func(T, string) bool,
+) (int, error) {
+	if ttyIn, ttyOut, ok := interactiveChoiceIO(rawIn, errOut); ok {
+		return chooseInteractiveIndex(ttyIn, ttyOut, label, items, render, matches)
+	}
+	return chooseLineFilteredIndex(in, errOut, label, items, render, matches)
+}
+
+func chooseLineFilteredIndex[T any](
+	in *bufio.Reader,
+	errOut io.Writer,
+	label string,
+	items []T,
+	render func(T) string,
+	matches func(T, string) bool,
+) (int, error) {
+	filtered := make([]int, len(items))
+	for i := range items {
+		filtered[i] = i
+	}
+	query := ""
+
+	for {
+		fmt.Fprintf(errOut, "Available %s", label)
+		if query != "" {
+			fmt.Fprintf(errOut, " (filtered by %q)", query)
+		}
+		fmt.Fprintln(errOut, ":")
+		for i, originalIdx := range filtered {
+			fmt.Fprintf(errOut, "  %d) %s\n", i+1, render(items[originalIdx]))
+		}
+
+		fmt.Fprintf(errOut, "Select %s [1-%d, search text, / to reset]: ", strings.TrimSuffix(label, "s"), len(filtered))
+		raw, err := in.ReadString('\n')
+		if err != nil {
+			return 0, err
+		}
+		raw = strings.TrimSpace(raw)
+		if raw == "/" {
+			filtered = filtered[:0]
+			for i := range items {
+				filtered = append(filtered, i)
+			}
+			query = ""
+			continue
+		}
+
+		index := 0
+		if _, err := fmt.Sscanf(raw, "%d", &index); err == nil && index >= 1 && index <= len(filtered) {
+			return filtered[index-1], nil
+		}
+
+		query = raw
+		filtered = filtered[:0]
+		for i, item := range items {
+			if matches(item, query) {
+				filtered = append(filtered, i)
+			}
+		}
+		if len(filtered) == 0 {
+			fmt.Fprintf(errOut, "No %s match %q\n", label, query)
+			filtered = make([]int, len(items))
+			for i := range items {
+				filtered[i] = i
+			}
+			query = ""
+		}
+	}
+}
+
+func renderContextChoice(ctx config.ContextInfo) string {
+	current := ""
+	if ctx.Current {
+		current = " (current)"
+	}
+	return fmt.Sprintf("%s [%s]%s", ctx.Name, displayAuthType(ctx.AuthType), current)
+}
+
+func renderAccountChoice(account awsservice.SSOAccount) string {
+	label := account.Name
+	if label == "" {
+		label = account.ID
+	}
+	if account.Email != "" {
+		label = fmt.Sprintf("%s <%s>", label, account.Email)
+	}
+	return fmt.Sprintf("%s (%s)", label, account.ID)
+}
+
+func renderRoleChoice(role awsservice.SSORole) string {
+	return role.Name
+}
+
+func containsFold(value, query string) bool {
+	return strings.Contains(strings.ToLower(value), strings.ToLower(strings.TrimSpace(query)))
 }
 
 func buildSSOContextEntry(configPath string, base config.ContextInfo, account awsservice.SSOAccount, role awsservice.SSORole) (config.ContextEntry, string, error) {

--- a/internal/auth/setup_picker.go
+++ b/internal/auth/setup_picker.go
@@ -1,0 +1,233 @@
+package auth
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/x/term"
+)
+
+type pickerState struct {
+	query    string
+	filtered []int
+	cursor   int
+}
+
+func interactiveChoiceIO(in io.Reader, errOut io.Writer) (*os.File, *os.File, bool) {
+	file, ok := in.(*os.File)
+	if !ok {
+		return nil, nil, false
+	}
+
+	outFile, ok := errOut.(*os.File)
+	if !ok {
+		return nil, nil, false
+	}
+
+	if !term.IsTerminal(file.Fd()) || !term.IsTerminal(outFile.Fd()) {
+		return nil, nil, false
+	}
+
+	return file, outFile, true
+}
+
+func chooseInteractiveIndex[T any](
+	in *os.File,
+	errOut *os.File,
+	label string,
+	items []T,
+	render func(T) string,
+	matches func(T, string) bool,
+) (int, error) {
+	oldState, err := term.MakeRaw(in.Fd())
+	if err != nil {
+		return 0, err
+	}
+	defer term.Restore(in.Fd(), oldState)
+	defer fmt.Fprint(errOut, "\x1b[2J\x1b[H\x1b[?25h")
+
+	reader := bufio.NewReader(in)
+	state := newPickerState(len(items))
+	renderInteractivePicker(errOut, label, items, render, state)
+	fmt.Fprint(errOut, "\x1b[?25l")
+
+	for {
+		r, _, err := reader.ReadRune()
+		if err != nil {
+			return 0, err
+		}
+
+		switch r {
+		case '\r', '\n':
+			if len(state.filtered) == 0 {
+				continue
+			}
+			return state.filtered[state.cursor], nil
+		case 3:
+			return 0, io.EOF
+		case 8, 127:
+			deleteLastPickerRune(&state, items, matches)
+		case 21:
+			clearPickerQuery(&state, items, matches)
+		case 27:
+			next, _, err := reader.ReadRune()
+			if err != nil {
+				return 0, err
+			}
+			if next != '[' {
+				continue
+			}
+			arrow, _, err := reader.ReadRune()
+			if err != nil {
+				return 0, err
+			}
+			switch arrow {
+			case 'A':
+				state.moveUp()
+			case 'B':
+				state.moveDown()
+			}
+		default:
+			if unicode.IsControl(r) {
+				continue
+			}
+			appendPickerRune(&state, items, matches, r)
+		}
+
+		renderInteractivePicker(errOut, label, items, render, state)
+	}
+}
+
+func newPickerState(count int) pickerState {
+	filtered := make([]int, count)
+	for i := 0; i < count; i++ {
+		filtered[i] = i
+	}
+	return pickerState{filtered: filtered}
+}
+
+func (s *pickerState) moveUp() {
+	if len(s.filtered) == 0 || s.cursor == 0 {
+		return
+	}
+	s.cursor--
+}
+
+func (s *pickerState) moveDown() {
+	if len(s.filtered) == 0 || s.cursor >= len(s.filtered)-1 {
+		return
+	}
+	s.cursor++
+}
+
+func clearPickerQuery[T any](s *pickerState, items []T, matches func(T, string) bool) {
+	s.query = ""
+	applyPickerFilter(s, items, matches)
+}
+
+func appendPickerRune[T any](s *pickerState, items []T, matches func(T, string) bool, r rune) {
+	s.query += string(r)
+	applyPickerFilter(s, items, matches)
+}
+
+func deleteLastPickerRune[T any](s *pickerState, items []T, matches func(T, string) bool) {
+	if s.query == "" {
+		return
+	}
+	_, size := utf8.DecodeLastRuneInString(s.query)
+	s.query = s.query[:len(s.query)-size]
+	applyPickerFilter(s, items, matches)
+}
+
+func applyPickerFilter[T any](s *pickerState, items []T, matches func(T, string) bool) {
+	s.filtered = s.filtered[:0]
+	query := strings.TrimSpace(s.query)
+	for i, item := range items {
+		if query == "" || matches(item, query) {
+			s.filtered = append(s.filtered, i)
+		}
+	}
+
+	if len(s.filtered) == 0 {
+		s.cursor = 0
+		return
+	}
+	if s.cursor >= len(s.filtered) {
+		s.cursor = len(s.filtered) - 1
+	}
+}
+
+func renderInteractivePicker[T any](out io.Writer, label string, items []T, render func(T) string, state pickerState) {
+	fmt.Fprint(out, "\x1b[2J\x1b[H")
+	height := 24
+	if file, ok := out.(*os.File); ok {
+		if _, h, err := term.GetSize(file.Fd()); err == nil && h > 0 {
+			height = h
+		}
+	}
+	if height <= 0 {
+		height = 24
+	}
+
+	fmt.Fprintf(out, "Select %s\r\n", strings.TrimSuffix(label, "s"))
+	if state.query == "" {
+		fmt.Fprint(out, "Filter: type to filter\r\n")
+	} else {
+		fmt.Fprintf(out, "Filter: %s\r\n", state.query)
+	}
+	fmt.Fprint(out, "Keys: type to filter, ↑/↓ move, Enter select, Backspace delete, Ctrl+U clear\r\n")
+	fmt.Fprint(out, "\r\n")
+
+	if len(state.filtered) == 0 {
+		fmt.Fprintf(out, "  No %s match %q\r\n", label, state.query)
+		return
+	}
+
+	indexWidth := len(strconv.Itoa(len(state.filtered)))
+	headerLines := 4
+	footerLines := 2
+	visibleRows := height - headerLines - footerLines
+	if visibleRows < 5 {
+		visibleRows = 5
+	}
+	start, end := pickerWindow(len(state.filtered), state.cursor, visibleRows)
+
+	for i := start; i < end; i++ {
+		originalIdx := state.filtered[i]
+		marker := " "
+		if i == state.cursor {
+			marker = ">"
+		}
+		fmt.Fprintf(out, "%s %*d) %s\r\n", marker, indexWidth, i+1, render(items[originalIdx]))
+	}
+
+	if len(state.filtered) > visibleRows {
+		fmt.Fprint(out, "\r\n")
+		fmt.Fprintf(out, "Showing %d-%d of %d\r\n", start+1, end, len(state.filtered))
+	}
+}
+
+func pickerWindow(total, cursor, visibleRows int) (int, int) {
+	if total <= visibleRows {
+		return 0, total
+	}
+
+	start := cursor - visibleRows/2
+	if start < 0 {
+		start = 0
+	}
+
+	end := start + visibleRows
+	if end > total {
+		end = total
+		start = end - visibleRows
+	}
+
+	return start, end
+}

--- a/internal/auth/setup_picker_test.go
+++ b/internal/auth/setup_picker_test.go
@@ -1,0 +1,101 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPickerStateFiltersAsYouType(t *testing.T) {
+	items := []string{"dev", "prod-admin", "staging"}
+	matches := func(item, query string) bool {
+		return containsFold(item, query)
+	}
+
+	state := newPickerState(len(items))
+	appendPickerRune(&state, items, matches, 'p')
+	if len(state.filtered) != 1 || state.filtered[0] != 1 {
+		t.Fatalf("expected only prod-admin after first rune, got %#v", state.filtered)
+	}
+
+	appendPickerRune(&state, items, matches, 'r')
+	if len(state.filtered) != 1 || state.filtered[0] != 1 {
+		t.Fatalf("expected prod-admin to stay selected after second rune, got %#v", state.filtered)
+	}
+}
+
+func TestPickerStateBackspaceRestoresMatches(t *testing.T) {
+	items := []string{"dev", "prod-admin", "prod-readonly"}
+	matches := func(item, query string) bool {
+		return containsFold(item, query)
+	}
+
+	state := newPickerState(len(items))
+	appendPickerRune(&state, items, matches, 'p')
+	appendPickerRune(&state, items, matches, 'r')
+	appendPickerRune(&state, items, matches, 'o')
+	if len(state.filtered) != 2 {
+		t.Fatalf("expected 2 filtered matches, got %d", len(state.filtered))
+	}
+
+	deleteLastPickerRune(&state, items, matches)
+	if state.query != "pr" {
+		t.Fatalf("expected query to shrink to pr, got %q", state.query)
+	}
+	if len(state.filtered) != 2 {
+		t.Fatalf("expected filtered matches after backspace, got %d", len(state.filtered))
+	}
+}
+
+func TestPickerStateClearResetsFilter(t *testing.T) {
+	items := []string{"dev", "prod", "staging"}
+	matches := func(item, query string) bool {
+		return containsFold(item, query)
+	}
+
+	state := newPickerState(len(items))
+	appendPickerRune(&state, items, matches, 's')
+	if len(state.filtered) != 1 {
+		t.Fatalf("expected 1 filtered item, got %d", len(state.filtered))
+	}
+
+	clearPickerQuery(&state, items, matches)
+	if state.query != "" {
+		t.Fatalf("expected query to clear, got %q", state.query)
+	}
+	if len(state.filtered) != len(items) {
+		t.Fatalf("expected all items after clear, got %d", len(state.filtered))
+	}
+}
+
+func TestRenderInteractivePickerAlignsNumberedRows(t *testing.T) {
+	items := []string{"dev", "prod", "staging"}
+	state := pickerState{filtered: []int{0, 1, 2}, cursor: 1}
+
+	var out strings.Builder
+	renderInteractivePicker(&out, "contexts", items, func(item string) string { return item }, state)
+
+	rendered := out.String()
+	if !strings.Contains(rendered, "  1) dev") {
+		t.Fatalf("expected first row to be numbered and aligned, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "> 2) prod") {
+		t.Fatalf("expected selected row marker and numbering, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "  3) staging") {
+		t.Fatalf("expected third row to be numbered and aligned, got %q", rendered)
+	}
+}
+
+func TestPickerWindowStartsAtTopForInitialCursor(t *testing.T) {
+	start, end := pickerWindow(40, 0, 10)
+	if start != 0 || end != 10 {
+		t.Fatalf("expected top window 0-10, got %d-%d", start, end)
+	}
+}
+
+func TestPickerWindowCentersAroundCursorWhenPossible(t *testing.T) {
+	start, end := pickerWindow(40, 20, 10)
+	if start != 15 || end != 25 {
+		t.Fatalf("expected centered window 15-25, got %d-%d", start, end)
+	}
+}

--- a/internal/auth/setup_test.go
+++ b/internal/auth/setup_test.go
@@ -109,3 +109,113 @@ contexts:
 		t.Fatalf("expected entry name %q, got %q", name, entry.Name)
 	}
 }
+
+func TestSetupContextSupportsSearchBeforeSelectingContext(t *testing.T) {
+	origBuild := buildEnvExportsFn
+	defer func() {
+		buildEnvExportsFn = origBuild
+	}()
+
+	buildEnvExportsFn = func(ctx context.Context, cfg *config.Config) (string, error) {
+		return "export UNIC_CONTEXT='" + cfg.ContextName + "'", nil
+	}
+
+	dir := t.TempDir()
+	path := writeConfig(t, dir, `
+current: prod
+defaults:
+  region: ap-northeast-2
+contexts:
+  - name: dev
+    auth_type: credential
+    profile: dev
+    region: ap-northeast-2
+  - name: prod
+    auth_type: credential
+    profile: prod
+    region: us-east-1
+  - name: staging
+    auth_type: credential
+    profile: staging
+    region: ap-southeast-1
+`)
+
+	var stderr strings.Builder
+	exports, err := SetupContext(context.Background(), path, strings.NewReader("stag\n1\n"), &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exports != "export UNIC_CONTEXT='staging'" {
+		t.Fatalf("unexpected exports: %q", exports)
+	}
+
+	cfg, err := config.Load(nil, nil, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ContextName != "staging" {
+		t.Fatalf("expected current context staging, got %q", cfg.ContextName)
+	}
+	if !strings.Contains(stderr.String(), `Available contexts (filtered by "stag")`) {
+		t.Fatalf("expected filtered context list in stderr, got %q", stderr.String())
+	}
+}
+
+func TestSetupContextSupportsSearchBeforeSelectingSSOAccountAndRole(t *testing.T) {
+	origAccounts := listSSOAccountsFn
+	origRoles := listSSOAccountRolesFn
+	origBuild := buildEnvExportsFn
+	defer func() {
+		listSSOAccountsFn = origAccounts
+		listSSOAccountRolesFn = origRoles
+		buildEnvExportsFn = origBuild
+	}()
+
+	listSSOAccountsFn = func(ctx context.Context, cfg *config.Config) ([]awsservice.SSOAccount, error) {
+		return []awsservice.SSOAccount{
+			{ID: "111111111111", Name: "sandbox"},
+			{ID: "222222222222", Name: "production"},
+		}, nil
+	}
+	listSSOAccountRolesFn = func(ctx context.Context, cfg *config.Config, accountID string) ([]awsservice.SSORole, error) {
+		return []awsservice.SSORole{
+			{Name: "ReadOnly"},
+			{Name: "AdministratorAccess"},
+		}, nil
+	}
+	buildEnvExportsFn = func(ctx context.Context, cfg *config.Config) (string, error) {
+		return "export AWS_REGION='ap-northeast-2'", nil
+	}
+
+	dir := t.TempDir()
+	path := writeConfig(t, dir, `
+defaults:
+  region: ap-northeast-2
+contexts:
+  - name: base-sso
+    auth_type: sso
+    sso_start_url: https://example.awsapps.com/start
+    region: ap-northeast-2
+`)
+
+	var stderr strings.Builder
+	_, err := SetupContext(context.Background(), path, strings.NewReader("1\nprod\n1\nadmin\n1\n"), &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.Load(nil, nil, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ContextName != "base-sso-222222222222-administratoraccess" {
+		t.Fatalf("expected resolved SSO context, got %q", cfg.ContextName)
+	}
+	output := stderr.String()
+	if !strings.Contains(output, `Available AWS accounts (filtered by "prod")`) {
+		t.Fatalf("expected filtered account list, got %q", output)
+	}
+	if !strings.Contains(output, `Available AWS roles (filtered by "admin")`) {
+		t.Fatalf("expected filtered role list, got %q", output)
+	}
+}

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -95,7 +95,11 @@ func parseContextOrder(raw string) (int, error) {
 	if _, err := fmt.Sscanf(raw, "%d", &order); err != nil {
 		return 0, fmt.Errorf("invalid order %q", raw)
 	}
+	if order < 1 {
+		return 0, fmt.Errorf("order must be a positive integer, got %d", order)
+	}
 	return order, nil
+}
 }
 
 func newContextSetupCmd() *cobra.Command {

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"context"
 	"fmt"
+	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -20,6 +22,9 @@ var (
 	loadNamedContextFn   = config.LoadNamedContext
 	loadConfigFn         = config.Load
 	unsetCurrentFn       = config.UnsetCurrent
+	setContextOrderFn    = config.SetContextOrder
+	setContextOrdersFn   = config.SetContextOrders
+	reorderContextsFn    = reorderContexts
 	copyClipboardFn      = clipboard.Copy
 )
 
@@ -30,8 +35,67 @@ func newContextCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newContextSetupCmd())
+	cmd.AddCommand(newContextOrderCmd())
 	cmd.AddCommand(newContextUnsetCmd())
 	return cmd
+}
+
+func newContextOrderCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "order [context-name] [number]",
+		Short: "Set the display order for a context",
+		Args:  cobra.MaximumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configPath, err := defaultPathFn()
+			if err != nil {
+				return err
+			}
+			if err := ensureConfigExistsFn(configPath); err != nil {
+				return err
+			}
+
+			message, err := applyContextOrder(configPath, cmd.InOrStdin(), cmd.ErrOrStderr(), args)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.ErrOrStderr(), message)
+			return nil
+		},
+	}
+}
+
+func applyContextOrder(configPath string, in io.Reader, errOut io.Writer, args []string) (string, error) {
+	switch len(args) {
+	case 2:
+		order, err := parseContextOrder(args[1])
+		if err != nil {
+			return "", err
+		}
+		if err := setContextOrderFn(configPath, args[0], order); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Updated context %s to order %d.", args[0], order), nil
+	case 0:
+		names, err := reorderContextsFn(configPath, in, errOut)
+		if err != nil {
+			return "", err
+		}
+		if err := setContextOrdersFn(configPath, names); err != nil {
+			return "", err
+		}
+		return "Updated context order.", nil
+	default:
+		return "", fmt.Errorf("expected either no arguments or <context-name> <number>")
+	}
+}
+
+func parseContextOrder(raw string) (int, error) {
+	raw = strings.TrimSpace(raw)
+	order := 0
+	if _, err := fmt.Sscanf(raw, "%d", &order); err != nil {
+		return 0, fmt.Errorf("invalid order %q", raw)
+	}
+	return order, nil
 }
 
 func newContextSetupCmd() *cobra.Command {

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -100,7 +100,6 @@ func parseContextOrder(raw string) (int, error) {
 	}
 	return order, nil
 }
-}
 
 func newContextSetupCmd() *cobra.Command {
 	return &cobra.Command{

--- a/internal/cli/context_reorder.go
+++ b/internal/cli/context_reorder.go
@@ -243,11 +243,18 @@ func reorderContextInfos(contexts []config.ContextInfo, from, to int) []config.C
 	updated := append([]config.ContextInfo(nil), contexts[:from]...)
 	updated = append(updated, contexts[from+1:]...)
 
+	// Adjust 'to' if it comes after 'from' since we removed an element
+	adjustedTo := to
+	if to > from {
+		adjustedTo = to - 1
+	}
+
 	result := make([]config.ContextInfo, 0, len(contexts))
-	result = append(result, updated[:to]...)
+	result = append(result, updated[:adjustedTo]...)
 	result = append(result, item)
-	result = append(result, updated[to:]...)
+	result = append(result, updated[adjustedTo:]...)
 	return result
+}
 }
 
 func contextNames(contexts []config.ContextInfo) []string {

--- a/internal/cli/context_reorder.go
+++ b/internal/cli/context_reorder.go
@@ -1,0 +1,259 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/x/term"
+
+	"unic/internal/config"
+)
+
+func reorderContexts(configPath string, in io.Reader, errOut io.Writer) ([]string, error) {
+	contexts, err := config.Contexts(configPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(contexts) == 0 {
+		return nil, fmt.Errorf("no contexts found in %s", configPath)
+	}
+
+	inFile, okIn := in.(*os.File)
+	outFile, okOut := errOut.(*os.File)
+	if okIn && okOut && term.IsTerminal(inFile.Fd()) && term.IsTerminal(outFile.Fd()) {
+		return reorderContextsInteractive(inFile, outFile, contexts)
+	}
+	return reorderContextsLineMode(bufio.NewReader(in), errOut, contexts)
+}
+
+func reorderContextsLineMode(in *bufio.Reader, errOut io.Writer, contexts []config.ContextInfo) ([]string, error) {
+	for i, ctx := range contexts {
+		fmt.Fprintf(errOut, "%2d) %s\n", i+1, ctx.Name)
+	}
+
+	selected := 0
+	for {
+		fmt.Fprintf(errOut, "Select context to move [1-%d]: ", len(contexts))
+		raw, err := in.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		if _, err := fmt.Sscanf(raw, "%d", &selected); err == nil && selected >= 1 && selected <= len(contexts) {
+			break
+		}
+		fmt.Fprintf(errOut, "Invalid selection %q\n", raw)
+	}
+
+	target := 0
+	for {
+		fmt.Fprintf(errOut, "Enter new position for %s [1-%d]: ", contexts[selected-1].Name, len(contexts))
+		raw, err := in.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		if _, err := fmt.Sscanf(raw, "%d", &target); err == nil && target >= 1 && target <= len(contexts) {
+			break
+		}
+		fmt.Fprintf(errOut, "Invalid position %q\n", raw)
+	}
+
+	ordered := reorderContextInfos(contexts, selected-1, target-1)
+	return contextNames(ordered), nil
+}
+
+func reorderContextsInteractive(in *os.File, errOut *os.File, contexts []config.ContextInfo) ([]string, error) {
+	oldState, err := term.MakeRaw(in.Fd())
+	if err != nil {
+		return nil, err
+	}
+	defer term.Restore(in.Fd(), oldState)
+	defer fmt.Fprint(errOut, "\x1b[2J\x1b[H\x1b[?25h")
+
+	reader := bufio.NewReader(in)
+	cursor := 0
+	moving := false
+	renderContextReorderPicker(errOut, contexts, cursor, moving)
+	fmt.Fprint(errOut, "\x1b[?25l")
+
+	for {
+		r, _, err := reader.ReadRune()
+		if err != nil {
+			return nil, err
+		}
+
+		switch r {
+		case '\r', '\n':
+			if moving {
+				return contextNames(contexts), nil
+			}
+			moving = true
+		case 3:
+			return nil, io.EOF
+		case 'k':
+			if moving {
+				contexts, cursor = moveContext(contexts, cursor, -1)
+			} else {
+				cursor = moveReorderCursor(len(contexts), cursor, -1)
+			}
+		case 'j':
+			if moving {
+				contexts, cursor = moveContext(contexts, cursor, 1)
+			} else {
+				cursor = moveReorderCursor(len(contexts), cursor, 1)
+			}
+		case 27:
+			next, _, err := reader.ReadRune()
+			if err != nil {
+				if moving {
+					moving = false
+					renderContextReorderPicker(errOut, contexts, cursor, moving)
+					continue
+				}
+				return nil, err
+			}
+			if next != '[' {
+				if moving {
+					moving = false
+				}
+				continue
+			}
+			arrow, _, err := reader.ReadRune()
+			if err != nil {
+				return nil, err
+			}
+			switch arrow {
+			case 'A':
+				if moving {
+					contexts, cursor = moveContext(contexts, cursor, -1)
+				} else {
+					cursor = moveReorderCursor(len(contexts), cursor, -1)
+				}
+			case 'B':
+				if moving {
+					contexts, cursor = moveContext(contexts, cursor, 1)
+				} else {
+					cursor = moveReorderCursor(len(contexts), cursor, 1)
+				}
+			}
+		}
+
+		renderContextReorderPicker(errOut, contexts, cursor, moving)
+	}
+}
+
+func renderContextReorderPicker(out io.Writer, contexts []config.ContextInfo, cursor int, moving bool) {
+	fmt.Fprint(out, "\x1b[2J\x1b[H")
+	height := 24
+	if file, ok := out.(*os.File); ok {
+		if _, h, err := term.GetSize(file.Fd()); err == nil && h > 0 {
+			height = h
+		}
+	}
+
+	fmt.Fprint(out, "Reorder contexts\r\n")
+	if moving {
+		fmt.Fprint(out, "Move mode: ↑/↓ or j/k move this context, Enter save, Esc stop moving, Ctrl+C cancel\r\n\r\n")
+	} else {
+		fmt.Fprint(out, "Select mode: ↑/↓ or j/k choose a context, Enter start moving, Ctrl+C cancel\r\n\r\n")
+	}
+
+	indexWidth := len(strconv.Itoa(len(contexts)))
+	visibleRows := height - 6
+	if visibleRows < 5 {
+		visibleRows = 5
+	}
+	start, end := reorderWindow(len(contexts), cursor, visibleRows)
+
+	for i := start; i < end; i++ {
+		marker := " "
+		if i == cursor {
+			if moving {
+				marker = "↕"
+			} else {
+				marker = ">"
+			}
+		}
+		fmt.Fprintf(out, "%s %*d) %s\r\n", marker, indexWidth, i+1, renderReorderContextChoice(contexts[i]))
+	}
+
+	if len(contexts) > visibleRows {
+		fmt.Fprint(out, "\r\n")
+		fmt.Fprintf(out, "Showing %d-%d of %d\r\n", start+1, end, len(contexts))
+	}
+}
+
+func moveReorderCursor(total, cursor, delta int) int {
+	next := cursor + delta
+	if next < 0 {
+		return 0
+	}
+	if next >= total {
+		return total - 1
+	}
+	return next
+}
+
+func reorderWindow(total, cursor, visibleRows int) (int, int) {
+	if total <= visibleRows {
+		return 0, total
+	}
+	start := cursor - visibleRows/2
+	if start < 0 {
+		start = 0
+	}
+	end := start + visibleRows
+	if end > total {
+		end = total
+		start = end - visibleRows
+	}
+	return start, end
+}
+
+func renderReorderContextChoice(ctx config.ContextInfo) string {
+	current := ""
+	if ctx.Current {
+		current = " (current)"
+	}
+	authType := ctx.AuthType
+	if authType == "" {
+		authType = "default"
+	}
+	return fmt.Sprintf("%s [%s]%s", ctx.Name, strings.ToLower(authType), current)
+}
+
+func moveContext(contexts []config.ContextInfo, cursor, delta int) ([]config.ContextInfo, int) {
+	next := cursor + delta
+	if next < 0 || next >= len(contexts) {
+		return contexts, cursor
+	}
+	contexts[cursor], contexts[next] = contexts[next], contexts[cursor]
+	return contexts, next
+}
+
+func reorderContextInfos(contexts []config.ContextInfo, from, to int) []config.ContextInfo {
+	if from < 0 || from >= len(contexts) || to < 0 || to >= len(contexts) || from == to {
+		return append([]config.ContextInfo(nil), contexts...)
+	}
+
+	item := contexts[from]
+	updated := append([]config.ContextInfo(nil), contexts[:from]...)
+	updated = append(updated, contexts[from+1:]...)
+
+	result := make([]config.ContextInfo, 0, len(contexts))
+	result = append(result, updated[:to]...)
+	result = append(result, item)
+	result = append(result, updated[to:]...)
+	return result
+}
+
+func contextNames(contexts []config.ContextInfo) []string {
+	names := make([]string, 0, len(contexts))
+	for _, ctx := range contexts {
+		names = append(names, ctx.Name)
+	}
+	return names
+}

--- a/internal/cli/context_reorder.go
+++ b/internal/cli/context_reorder.go
@@ -255,7 +255,6 @@ func reorderContextInfos(contexts []config.ContextInfo, from, to int) []config.C
 	result = append(result, updated[adjustedTo:]...)
 	return result
 }
-}
 
 func contextNames(contexts []config.ContextInfo) []string {
 	names := make([]string, 0, len(contexts))

--- a/internal/cli/context_reorder_test.go
+++ b/internal/cli/context_reorder_test.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"testing"
+
+	"unic/internal/config"
+)
+
+func TestMoveContextSwapsWithPrevious(t *testing.T) {
+	contexts := []config.ContextInfo{
+		{Name: "one"},
+		{Name: "two"},
+		{Name: "three"},
+	}
+
+	updated, cursor := moveContext(contexts, 1, -1)
+	if cursor != 0 {
+		t.Fatalf("expected cursor 0, got %d", cursor)
+	}
+	if updated[0].Name != "two" || updated[1].Name != "one" {
+		t.Fatalf("unexpected order after move up: %#v", updated)
+	}
+}
+
+func TestMoveContextStaysWithinBounds(t *testing.T) {
+	contexts := []config.ContextInfo{
+		{Name: "one"},
+		{Name: "two"},
+	}
+
+	updated, cursor := moveContext(contexts, 0, -1)
+	if cursor != 0 {
+		t.Fatalf("expected cursor to stay at 0, got %d", cursor)
+	}
+	if updated[0].Name != "one" || updated[1].Name != "two" {
+		t.Fatalf("unexpected order when moving out of bounds: %#v", updated)
+	}
+}
+
+func TestContextNamesReturnsCurrentOrder(t *testing.T) {
+	contexts := []config.ContextInfo{
+		{Name: "alpha"},
+		{Name: "beta"},
+		{Name: "gamma"},
+	}
+
+	names := contextNames(contexts)
+	if len(names) != 3 || names[0] != "alpha" || names[1] != "beta" || names[2] != "gamma" {
+		t.Fatalf("unexpected names: %#v", names)
+	}
+}
+
+func TestMoveReorderCursorClampsWithinBounds(t *testing.T) {
+	if got := moveReorderCursor(3, 0, -1); got != 0 {
+		t.Fatalf("expected top clamp to 0, got %d", got)
+	}
+	if got := moveReorderCursor(3, 2, 1); got != 2 {
+		t.Fatalf("expected bottom clamp to 2, got %d", got)
+	}
+	if got := moveReorderCursor(3, 1, 1); got != 2 {
+		t.Fatalf("expected move to 2, got %d", got)
+	}
+}

--- a/internal/cli/context_test.go
+++ b/internal/cli/context_test.go
@@ -15,11 +15,112 @@ func TestRootIncludesContextAndEnvCommands(t *testing.T) {
 	if _, _, err := cmd.Find([]string{"context", "setup"}); err != nil {
 		t.Fatalf("expected context setup command: %v", err)
 	}
+	if _, _, err := cmd.Find([]string{"context", "order"}); err != nil {
+		t.Fatalf("expected context order command: %v", err)
+	}
 	if _, _, err := cmd.Find([]string{"context", "unset"}); err != nil {
 		t.Fatalf("expected context unset command: %v", err)
 	}
 	if _, _, err := cmd.Find([]string{"env"}); err != nil {
 		t.Fatalf("expected env command: %v", err)
+	}
+}
+
+func TestContextOrderUpdatesConfiguredOrder(t *testing.T) {
+	origDefaultPath := defaultPathFn
+	origEnsure := ensureConfigExistsFn
+	origSetOrder := setContextOrderFn
+	origSetOrders := setContextOrdersFn
+	origReorder := reorderContextsFn
+	defer func() {
+		defaultPathFn = origDefaultPath
+		ensureConfigExistsFn = origEnsure
+		setContextOrderFn = origSetOrder
+		setContextOrdersFn = origSetOrders
+		reorderContextsFn = origReorder
+	}()
+
+	defaultPathFn = func() (string, error) { return "/tmp/config.yaml", nil }
+	ensureConfigExistsFn = func(string) error { return nil }
+	setContextOrderFn = func(path, name string, order int) error {
+		if path != "/tmp/config.yaml" {
+			t.Fatalf("unexpected path: %q", path)
+		}
+		if name != "prod-admin" {
+			t.Fatalf("unexpected context name: %q", name)
+		}
+		if order != 10 {
+			t.Fatalf("unexpected order: %d", order)
+		}
+		return nil
+	}
+
+	cmd := NewRootCmd()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"context", "order", "prod-admin", "10"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Fatalf("expected no stdout output, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "Updated context prod-admin to order 10.") {
+		t.Fatalf("expected confirmation message, got %q", stderr.String())
+	}
+}
+
+func TestContextOrderInteractiveSelectionAndPrompt(t *testing.T) {
+	origDefaultPath := defaultPathFn
+	origEnsure := ensureConfigExistsFn
+	origSetOrder := setContextOrderFn
+	origSetOrders := setContextOrdersFn
+	origReorder := reorderContextsFn
+	defer func() {
+		defaultPathFn = origDefaultPath
+		ensureConfigExistsFn = origEnsure
+		setContextOrderFn = origSetOrder
+		setContextOrdersFn = origSetOrders
+		reorderContextsFn = origReorder
+	}()
+
+	defaultPathFn = func() (string, error) { return "/tmp/config.yaml", nil }
+	ensureConfigExistsFn = func(string) error { return nil }
+	reorderContextsFn = func(path string, in io.Reader, errOut io.Writer) ([]string, error) {
+		if path != "/tmp/config.yaml" {
+			t.Fatalf("unexpected path: %q", path)
+		}
+		return []string{"lgi-prod", "prod-admin"}, nil
+	}
+	setContextOrdersFn = func(path string, names []string) error {
+		if path != "/tmp/config.yaml" {
+			t.Fatalf("unexpected path: %q", path)
+		}
+		if len(names) != 2 || names[0] != "lgi-prod" || names[1] != "prod-admin" {
+			t.Fatalf("unexpected context order: %#v", names)
+		}
+		return nil
+	}
+
+	cmd := NewRootCmd()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetIn(strings.NewReader(""))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"context", "order"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Fatalf("expected no stdout output, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "Updated context order.") {
+		t.Fatalf("expected update message, got %q", stderr.String())
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -480,6 +480,79 @@ func UpsertContext(configPath string, entry ContextEntry) error {
 	return nil
 }
 
+// SetContextOrder updates the display order for a named context.
+func SetContextOrder(configPath, name string, order int) error {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to read config: %w", err)
+	}
+
+	var fc fileConfig
+	if err := yaml.Unmarshal(data, &fc); err != nil {
+		return fmt.Errorf("failed to parse %s: %w", configPath, err)
+	}
+
+	found := false
+	for i := range fc.Contexts {
+		if fc.Contexts[i].Name == name {
+			fc.Contexts[i].Order = order
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("context %q not found in config", name)
+	}
+
+	out, err := yaml.Marshal(&fc)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+	if err := os.WriteFile(configPath, out, 0644); err != nil {
+		return fmt.Errorf("failed to write config: %w", err)
+	}
+	return nil
+}
+
+// SetContextOrders rewrites all context orders based on the provided name order.
+func SetContextOrders(configPath string, names []string) error {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to read config: %w", err)
+	}
+
+	var fc fileConfig
+	if err := yaml.Unmarshal(data, &fc); err != nil {
+		return fmt.Errorf("failed to parse %s: %w", configPath, err)
+	}
+
+	if len(names) != len(fc.Contexts) {
+		return fmt.Errorf("expected %d context names, got %d", len(fc.Contexts), len(names))
+	}
+
+	orderMap := make(map[string]int, len(names))
+	for i, name := range names {
+		orderMap[name] = i + 1
+	}
+
+	for i := range fc.Contexts {
+		order, ok := orderMap[fc.Contexts[i].Name]
+		if !ok {
+			return fmt.Errorf("context %q missing from order list", fc.Contexts[i].Name)
+		}
+		fc.Contexts[i].Order = order
+	}
+
+	out, err := yaml.Marshal(&fc)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+	if err := os.WriteFile(configPath, out, 0644); err != nil {
+		return fmt.Errorf("failed to write config: %w", err)
+	}
+	return nil
+}
+
 // DefaultPath returns the default config file path following XDG Base Directory spec.
 func DefaultPath() (string, error) {
 	dir := os.Getenv("XDG_CONFIG_HOME")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -287,6 +287,32 @@ contexts:
 	}
 }
 
+func TestSetContextOrder(t *testing.T) {
+	dir := t.TempDir()
+	path := writeUnicConfig(t, dir, `
+contexts:
+  - name: dev
+    profile: dev-profile
+  - name: prod
+    profile: prod-profile
+`)
+
+	if err := SetContextOrder(path, "prod", 5); err != nil {
+		t.Fatal(err)
+	}
+
+	infos, err := Contexts(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if infos[0].Name != "prod" {
+		t.Fatalf("expected prod to move first after ordering, got %q", infos[0].Name)
+	}
+	if infos[0].Order != 5 {
+		t.Fatalf("expected prod order 5, got %#v", infos[0].Order)
+	}
+}
+
 func TestSetCurrent(t *testing.T) {
 	dir := t.TempDir()
 	path := writeUnicConfig(t, dir, `


### PR DESCRIPTION
### Summary

- add live incremental filtering to the CLI `unic context setup` picker for large context, account, and role lists
- add interactive `unic context order` reordering so a chosen context can be moved up or down before saving
- keep direct `unic context order <name> <number>` updates for scripted/manual usage
- update README and architecture docs for the shipped context workflow changes

### Related Issues

Closes #118
Closes #119

### Validation

- `make test`
- `make build`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed
- [x] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented
