### PR TITLE
feat: expand security inspector coverage

### DIFF
--- a/.agents/skills/unic-implement-feature/SKILL.md
+++ b/.agents/skills/unic-implement-feature/SKILL.md
@@ -16,9 +16,19 @@ Treat the prompt as one of:
 ## Workflow
 
 1. Resolve scope first.
+- Before implementing anything, inspect open pull requests with
+  `gh pr list --state open --limit 50`.
+- If the target issue or feature already has an open PR in progress, stop and
+  tell the user instead of implementing duplicate scope. Only continue if the
+  user explicitly asks to work on that existing PR or to intentionally create a
+  follow-up.
 - If the user gave an issue number, read it with `gh issue view <number>`.
+- When an issue number is known, also search open PRs for that issue first
+  (title, body, or branch naming) before starting implementation.
 - If the user gave a description, search open issues first with
   `gh issue list --state open --search '<terms>' --limit 20`.
+- For description-based requests, also search open PRs with the same terms
+  before choosing the feature to implement.
 - If the user did not name a concrete feature, inspect the current backlog with
   `gh issue list --state open --limit 50` and prefer an open issue over
   inventing new scope from `PLAN.md`.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It combines a Bubble Tea application, Cobra-based CLI commands, and AWS SDK v2 c
 - Open a context-aware keyboard shortcut help screen with `?`
 - Show animated loading indicators while async AWS data is being fetched
 - Perform operational workflows such as SSM sessions, RDS control, Route53 record changes, ECS exec, and IAM access key rotation
-- Open the Security Inspector workflow and review built-in findings for Security Groups, RDS, IAM keys, Secrets Manager, and S3 buckets
+- Open the Security Inspector workflow and review built-in findings for network exposure, RDS, IAM, Secrets Manager, S3, snapshot sharing, CloudTrail, GuardDuty, AWS Config, and ElastiCache for Valkey
 
 ## Documentation Map
 
@@ -187,7 +187,7 @@ CLI flags > selected context > config defaults > hardcoded default (us-east-1)
 | IAM | RotateAccessKey |
 | Inspector | Security Scan |
 
-The Inspector feature ships built-in rule packs for Security Group exposure, RDS encryption/public access/backups, IAM access key age, Secrets Manager rotation age, and S3 public access/versioning checks.
+The Inspector feature ships built-in rule packs for Security Group exposure, RDS encryption/public access/backups and public snapshot sharing, IAM access key age/root-account hardening/wildcard policies, Secrets Manager rotation age, S3 public access/Block Public Access/versioning, CloudTrail baseline coverage, GuardDuty and AWS Config baseline controls, and ElastiCache for Valkey encryption/backup/access-control checks.
 
 ## TUI Navigation
 

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
+	github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.9 // indirect
+	github.com/aws/aws-sdk-go-v2/service/configservice v1.62.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/guardduty v1.75.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
 github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=
@@ -16,12 +18,20 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6/go.mod h1:O3h0IK87yXci+kg6flUKzJnWeziQUKciKrLjcatSNcY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 h1:rWyie/PxDRIdhNf4DzRk0lvjVOqFJuNnO8WwaIRVxzQ=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22/go.mod h1:zd/JsJ4P7oGfUhXn1VyLqaRZwPmZwg44Jf2dS84Dm3Y=
+github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.9 h1:ndjU1c3H1BYJy7fG0Y6Nh/sgD2M/KN+PZaqyCK/Fdfs=
+github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.9/go.mod h1:aH6yXmBYSr1k8uycfqxH5pv4T5N3x2cfFPvrlhyWjAU=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.68.0 h1:+/lmB/+i2oqkzbmlQxsW0kr/+wmJgmyiEF9VDJicX34=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.68.0/go.mod h1:PobeppEnIjw4pcgjFryNDZCTH7AiqZw0yb5r98Gvf9c=
+github.com/aws/aws-sdk-go-v2/service/configservice v1.62.1 h1:0kqK/rGcsuDGDyLLBjLSH95zC3k8lIkW0nksCYEU72g=
+github.com/aws/aws-sdk-go-v2/service/configservice v1.62.1/go.mod h1:9dXB7G3BUakIT/aCgH8si8fCl//iWvR8wpkWuVKY22A=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.296.0 h1:98Miqj16un1WLNyM1RjVDhXYumhqZrQfAeG8i4jPG6o=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.296.0/go.mod h1:T6ndRfdhnXLIY5oKBHjYZDVj706los2zGdpThppquvA=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.76.0 h1:a5G/TgJNrpuCjZBTf8/PTN0C2B0do/ylaYVynxPSbUQ=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.76.0/go.mod h1:QkWmubOYmjj3cHn7A4CoUU7BKJhVeo39Gp6NH7IyhZw=
+github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.0 h1:inluxH5ArTlQNGrFxP7RN5o5DEfP8bRbkPC/408Esgs=
+github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.0/go.mod h1:DxywiXnEB21757xcql9xCqgt8vyTxSB7tVEIOdfKIY8=
+github.com/aws/aws-sdk-go-v2/service/guardduty v1.75.0 h1:sZA3jpOkwrinRL0B5aZY6npTjDmmBCJRY51dee1Oh7Q=
+github.com/aws/aws-sdk-go-v2/service/guardduty v1.75.0/go.mod h1:lv/r48VXsENinEcSlNRYIERuliYk9dyc919tS+NWqW0=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.7 h1:n9YLiWtX3+6pTLZWvRJmtq5JIB9NA/KFelyCg5fOlTU=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.7/go.mod h1:sP46Vo6MeJcM4s0ZXcG2PFmfiSyixhIuC/74W52yKuk=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 h1:5EniKhLZe4xzL7a+fU3C2tfUN4nWIqlLesfrjkuPFTY=
@@ -52,8 +62,6 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.41.9 h1:Cng+OOwCHmFljXIxpEVXAGMnBia8
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.9/go.mod h1:LrlIndBDdjA/EeXeyNBle+gyCwTlizzW5ycgWnvIxkk=
 github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
 github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
-github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
-github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=

--- a/internal/services/aws/iam_test.go
+++ b/internal/services/aws/iam_test.go
@@ -16,6 +16,8 @@ import (
 type mockIAMClient struct {
 	listUsersFunc            func(ctx context.Context, params *iam.ListUsersInput, optFns ...func(*iam.Options)) (*iam.ListUsersOutput, error)
 	getUserFunc              func(ctx context.Context, params *iam.GetUserInput, optFns ...func(*iam.Options)) (*iam.GetUserOutput, error)
+	getAccountSummaryFunc    func(ctx context.Context, params *iam.GetAccountSummaryInput, optFns ...func(*iam.Options)) (*iam.GetAccountSummaryOutput, error)
+	getAuthzDetailsFunc      func(ctx context.Context, params *iam.GetAccountAuthorizationDetailsInput, optFns ...func(*iam.Options)) (*iam.GetAccountAuthorizationDetailsOutput, error)
 	listGroupsForUserFunc    func(ctx context.Context, params *iam.ListGroupsForUserInput, optFns ...func(*iam.Options)) (*iam.ListGroupsForUserOutput, error)
 	listAttachedPoliciesFunc func(ctx context.Context, params *iam.ListAttachedUserPoliciesInput, optFns ...func(*iam.Options)) (*iam.ListAttachedUserPoliciesOutput, error)
 	listMFADevicesFunc       func(ctx context.Context, params *iam.ListMFADevicesInput, optFns ...func(*iam.Options)) (*iam.ListMFADevicesOutput, error)
@@ -38,6 +40,20 @@ func (m *mockIAMClient) GetUser(ctx context.Context, params *iam.GetUserInput, o
 		return m.getUserFunc(ctx, params, optFns...)
 	}
 	return &iam.GetUserOutput{}, nil
+}
+
+func (m *mockIAMClient) GetAccountSummary(ctx context.Context, params *iam.GetAccountSummaryInput, optFns ...func(*iam.Options)) (*iam.GetAccountSummaryOutput, error) {
+	if m.getAccountSummaryFunc != nil {
+		return m.getAccountSummaryFunc(ctx, params, optFns...)
+	}
+	return &iam.GetAccountSummaryOutput{}, nil
+}
+
+func (m *mockIAMClient) GetAccountAuthorizationDetails(ctx context.Context, params *iam.GetAccountAuthorizationDetailsInput, optFns ...func(*iam.Options)) (*iam.GetAccountAuthorizationDetailsOutput, error) {
+	if m.getAuthzDetailsFunc != nil {
+		return m.getAuthzDetailsFunc(ctx, params, optFns...)
+	}
+	return &iam.GetAccountAuthorizationDetailsOutput{}, nil
 }
 
 func (m *mockIAMClient) ListGroupsForUser(ctx context.Context, params *iam.ListGroupsForUserInput, optFns ...func(*iam.Options)) (*iam.ListGroupsForUserOutput, error) {

--- a/internal/services/aws/inspector_rules_baselines.go
+++ b/internal/services/aws/inspector_rules_baselines.go
@@ -1,0 +1,317 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudtrail"
+	cloudtrailtypes "github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
+	"github.com/aws/aws-sdk-go-v2/service/configservice"
+	configtypes "github.com/aws/aws-sdk-go-v2/service/configservice/types"
+	"github.com/aws/aws-sdk-go-v2/service/guardduty"
+	guarddutytypes "github.com/aws/aws-sdk-go-v2/service/guardduty/types"
+)
+
+const (
+	inspectorScannerCloudTrailBaselineName      = "cloudtrail-baseline"
+	inspectorScannerGuardDutyConfigBaselineName = "guardduty-config-baseline"
+
+	inspectorRuleIDCloudTrailMissingMultiRegion = "cloudtrail-multi-region-missing"
+	inspectorRuleIDCloudTrailLoggingDisabled    = "cloudtrail-logging-disabled"
+	inspectorRuleIDCloudTrailValidationDisabled = "cloudtrail-log-file-validation-disabled"
+	inspectorRuleIDGuardDutyDisabled            = "guardduty-disabled"
+	inspectorRuleIDConfigMissing                = "config-recorder-missing"
+	inspectorRuleIDConfigBaselineGap            = "config-recorder-baseline-gap"
+)
+
+func init() {
+	registerSecurityInspectorScanner(InspectorScanner{
+		Name: inspectorScannerCloudTrailBaselineName,
+		Run:  runCloudTrailBaselineScan,
+	})
+	registerSecurityInspectorScanner(InspectorScanner{
+		Name: inspectorScannerGuardDutyConfigBaselineName,
+		Run:  runGuardDutyConfigBaselineScan,
+	})
+}
+
+func runCloudTrailBaselineScan(ctx context.Context, repo *AwsRepository) ([]SecurityFinding, error) {
+	output, err := repo.CloudTrailClient.DescribeTrails(ctx, &cloudtrail.DescribeTrailsInput{
+		IncludeShadowTrails: awssdk.Bool(true),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect CloudTrail trails: %w", err)
+	}
+
+	trails := uniqueMultiRegionTrails(output.TrailList)
+	if len(trails) == 0 {
+		return []SecurityFinding{
+			{
+				RuleID:         inspectorRuleIDCloudTrailMissingMultiRegion,
+				RuleName:       "CloudTrail multi-Region trail missing",
+				Severity:       RuleSeverityCritical,
+				ResourceType:   "CloudTrail",
+				ResourceID:     "cloudtrail",
+				Summary:        "No multi-Region CloudTrail trail is configured for the active account and region.",
+				Recommendation: "Create at least one multi-Region trail so management events are recorded consistently across regions.",
+			},
+		}, nil
+	}
+
+	var findings []SecurityFinding
+	for _, trail := range trails {
+		trailID := cloudTrailResourceID(trail)
+		trailName := cloudTrailDisplayName(trail)
+		status, err := repo.CloudTrailClient.GetTrailStatus(ctx, &cloudtrail.GetTrailStatusInput{
+			Name: awssdk.String(trailID),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to inspect CloudTrail status for %s: %w", trailID, err)
+		}
+
+		if !awssdk.ToBool(status.IsLogging) {
+			findings = append(findings, SecurityFinding{
+				RuleID:         inspectorRuleIDCloudTrailLoggingDisabled,
+				RuleName:       "CloudTrail trail not logging",
+				Severity:       RuleSeverityHigh,
+				ResourceType:   "CloudTrail",
+				ResourceID:     trailID,
+				Summary:        fmt.Sprintf("Multi-Region trail %s is not actively logging.", trailName),
+				Recommendation: "Start logging on the trail and confirm the trail can deliver events to its configured destination.",
+			})
+		}
+		if !awssdk.ToBool(trail.LogFileValidationEnabled) {
+			findings = append(findings, SecurityFinding{
+				RuleID:         inspectorRuleIDCloudTrailValidationDisabled,
+				RuleName:       "CloudTrail log file validation disabled",
+				Severity:       RuleSeverityMedium,
+				ResourceType:   "CloudTrail",
+				ResourceID:     trailID,
+				Summary:        fmt.Sprintf("Multi-Region trail %s does not have log file validation enabled.", trailName),
+				Recommendation: "Enable CloudTrail log file validation so delivered log files include digest validation for tamper detection.",
+			})
+		}
+	}
+
+	sort.Slice(findings, func(i, j int) bool {
+		left := normalizedSortKey(findings[i].ResourceID, findings[i].RuleID, findings[i].RuleName)
+		right := normalizedSortKey(findings[j].ResourceID, findings[j].RuleID, findings[j].RuleName)
+		if left == right {
+			return findings[i].Severity.Rank() < findings[j].Severity.Rank()
+		}
+		return left < right
+	})
+
+	return findings, nil
+}
+
+func runGuardDutyConfigBaselineScan(ctx context.Context, repo *AwsRepository) ([]SecurityFinding, error) {
+	guardDutyFindings, err := inspectGuardDutyBaseline(ctx, repo.GuardDutyClient)
+	if err != nil {
+		return nil, err
+	}
+
+	configFindings, err := inspectConfigBaseline(ctx, repo.ConfigServiceClient)
+	if err != nil {
+		return nil, err
+	}
+
+	findings := append(guardDutyFindings, configFindings...)
+	sort.Slice(findings, func(i, j int) bool {
+		left := normalizedSortKey(findings[i].ResourceID, findings[i].RuleID, findings[i].RuleName)
+		right := normalizedSortKey(findings[j].ResourceID, findings[j].RuleID, findings[j].RuleName)
+		if left == right {
+			return findings[i].Severity.Rank() < findings[j].Severity.Rank()
+		}
+		return left < right
+	})
+
+	return findings, nil
+}
+
+func inspectGuardDutyBaseline(ctx context.Context, client GuardDutyClientAPI) ([]SecurityFinding, error) {
+	var detectorIDs []string
+	nextToken := ""
+
+	for {
+		input := &guardduty.ListDetectorsInput{
+			MaxResults: awssdk.Int32(50),
+		}
+		if nextToken != "" {
+			input.NextToken = awssdk.String(nextToken)
+		}
+
+		page, err := client.ListDetectors(ctx, input)
+		if err != nil {
+			return nil, fmt.Errorf("failed to inspect GuardDuty detectors: %w", err)
+		}
+
+		detectorIDs = append(detectorIDs, page.DetectorIds...)
+		if awssdk.ToString(page.NextToken) == "" {
+			break
+		}
+		nextToken = awssdk.ToString(page.NextToken)
+	}
+
+	if len(detectorIDs) == 0 {
+		return []SecurityFinding{
+			{
+				RuleID:         inspectorRuleIDGuardDutyDisabled,
+				RuleName:       "GuardDuty detector missing",
+				Severity:       RuleSeverityHigh,
+				ResourceType:   "GuardDuty",
+				ResourceID:     "guardduty",
+				Summary:        "GuardDuty is not enabled in the active account and region.",
+				Recommendation: "Enable GuardDuty so foundational threat-detection coverage is active in this region.",
+			},
+		}, nil
+	}
+
+	findings := make([]SecurityFinding, 0, len(detectorIDs))
+	for _, detectorID := range detectorIDs {
+		detector, err := client.GetDetector(ctx, &guardduty.GetDetectorInput{
+			DetectorId: awssdk.String(detectorID),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to inspect GuardDuty detector %s: %w", detectorID, err)
+		}
+		if detector.Status == guarddutytypes.DetectorStatusEnabled {
+			continue
+		}
+
+		findings = append(findings, SecurityFinding{
+			RuleID:         inspectorRuleIDGuardDutyDisabled,
+			RuleName:       "GuardDuty detector disabled",
+			Severity:       RuleSeverityHigh,
+			ResourceType:   "GuardDutyDetector",
+			ResourceID:     detectorID,
+			Summary:        fmt.Sprintf("GuardDuty detector %s is not enabled.", detectorID),
+			Recommendation: "Enable the detector so GuardDuty can monitor the account and region for suspicious activity.",
+		})
+	}
+
+	return findings, nil
+}
+
+func inspectConfigBaseline(ctx context.Context, client ConfigServiceClientAPI) ([]SecurityFinding, error) {
+	recordersOutput, err := client.DescribeConfigurationRecorders(ctx, &configservice.DescribeConfigurationRecordersInput{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect AWS Config recorders: %w", err)
+	}
+
+	if len(recordersOutput.ConfigurationRecorders) == 0 {
+		return []SecurityFinding{
+			{
+				RuleID:         inspectorRuleIDConfigMissing,
+				RuleName:       "AWS Config recorder missing",
+				Severity:       RuleSeverityHigh,
+				ResourceType:   "ConfigRecorder",
+				ResourceID:     "aws-config",
+				Summary:        "AWS Config does not have a baseline configuration recorder in the active account and region.",
+				Recommendation: "Create and start a configuration recorder that captures all supported resource types.",
+			},
+		}, nil
+	}
+
+	statusOutput, err := client.DescribeConfigurationRecorderStatus(ctx, &configservice.DescribeConfigurationRecorderStatusInput{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect AWS Config recorder status: %w", err)
+	}
+
+	statusByName := make(map[string]configtypes.ConfigurationRecorderStatus, len(statusOutput.ConfigurationRecordersStatus))
+	for _, status := range statusOutput.ConfigurationRecordersStatus {
+		statusByName[awssdk.ToString(status.Name)] = status
+	}
+
+	recorders := relevantConfigRecorders(recordersOutput.ConfigurationRecorders)
+	var findings []SecurityFinding
+
+	for _, recorder := range recorders {
+		recorderName := awssdk.ToString(recorder.Name)
+		status, hasStatus := statusByName[recorderName]
+		var gaps []string
+
+		if recorder.RecordingGroup == nil || !recorder.RecordingGroup.AllSupported {
+			gaps = append(gaps, "it is not set to record all supported resource types")
+		}
+		if !hasStatus || !status.Recording {
+			gaps = append(gaps, "recording is disabled")
+		}
+		if len(gaps) == 0 {
+			continue
+		}
+
+		findings = append(findings, SecurityFinding{
+			RuleID:       inspectorRuleIDConfigBaselineGap,
+			RuleName:     "AWS Config baseline gap",
+			Severity:     RuleSeverityHigh,
+			ResourceType: "ConfigRecorder",
+			ResourceID:   recorderName,
+			Summary: fmt.Sprintf(
+				"AWS Config recorder %s has a baseline gap because %s.",
+				recorderName,
+				strings.Join(gaps, " and "),
+			),
+			Recommendation: "Configure a baseline recorder for all supported resource types and ensure recording is actively enabled.",
+		})
+	}
+
+	return findings, nil
+}
+
+func uniqueMultiRegionTrails(trails []cloudtrailtypes.Trail) []cloudtrailtypes.Trail {
+	seen := make(map[string]struct{}, len(trails))
+	filtered := make([]cloudtrailtypes.Trail, 0, len(trails))
+
+	for _, trail := range trails {
+		if !awssdk.ToBool(trail.IsMultiRegionTrail) {
+			continue
+		}
+
+		key := cloudTrailResourceID(trail)
+		if key == "" {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		filtered = append(filtered, trail)
+	}
+
+	sort.Slice(filtered, func(i, j int) bool {
+		return normalizedSortKey(cloudTrailResourceID(filtered[i])) < normalizedSortKey(cloudTrailResourceID(filtered[j]))
+	})
+
+	return filtered
+}
+
+func cloudTrailResourceID(trail cloudtrailtypes.Trail) string {
+	if arn := awssdk.ToString(trail.TrailARN); arn != "" {
+		return arn
+	}
+	return awssdk.ToString(trail.Name)
+}
+
+func cloudTrailDisplayName(trail cloudtrailtypes.Trail) string {
+	if name := awssdk.ToString(trail.Name); name != "" {
+		return name
+	}
+	return cloudTrailResourceID(trail)
+}
+
+func relevantConfigRecorders(recorders []configtypes.ConfigurationRecorder) []configtypes.ConfigurationRecorder {
+	customerManaged := make([]configtypes.ConfigurationRecorder, 0, len(recorders))
+	for _, recorder := range recorders {
+		if awssdk.ToString(recorder.ServicePrincipal) == "" {
+			customerManaged = append(customerManaged, recorder)
+		}
+	}
+	if len(customerManaged) > 0 {
+		return customerManaged
+	}
+	return recorders
+}

--- a/internal/services/aws/inspector_rules_baselines_test.go
+++ b/internal/services/aws/inspector_rules_baselines_test.go
@@ -1,0 +1,212 @@
+package aws
+
+import (
+	"context"
+	"testing"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudtrail"
+	cloudtrailtypes "github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
+	"github.com/aws/aws-sdk-go-v2/service/configservice"
+	configtypes "github.com/aws/aws-sdk-go-v2/service/configservice/types"
+	"github.com/aws/aws-sdk-go-v2/service/guardduty"
+	guarddutytypes "github.com/aws/aws-sdk-go-v2/service/guardduty/types"
+)
+
+type mockCloudTrailClient struct {
+	describeTrailsFunc func(ctx context.Context, params *cloudtrail.DescribeTrailsInput, optFns ...func(*cloudtrail.Options)) (*cloudtrail.DescribeTrailsOutput, error)
+	getTrailStatusFunc func(ctx context.Context, params *cloudtrail.GetTrailStatusInput, optFns ...func(*cloudtrail.Options)) (*cloudtrail.GetTrailStatusOutput, error)
+}
+
+func (m *mockCloudTrailClient) DescribeTrails(ctx context.Context, params *cloudtrail.DescribeTrailsInput, optFns ...func(*cloudtrail.Options)) (*cloudtrail.DescribeTrailsOutput, error) {
+	if m.describeTrailsFunc != nil {
+		return m.describeTrailsFunc(ctx, params, optFns...)
+	}
+	return &cloudtrail.DescribeTrailsOutput{}, nil
+}
+
+func (m *mockCloudTrailClient) GetTrailStatus(ctx context.Context, params *cloudtrail.GetTrailStatusInput, optFns ...func(*cloudtrail.Options)) (*cloudtrail.GetTrailStatusOutput, error) {
+	if m.getTrailStatusFunc != nil {
+		return m.getTrailStatusFunc(ctx, params, optFns...)
+	}
+	return &cloudtrail.GetTrailStatusOutput{}, nil
+}
+
+type mockGuardDutyClient struct {
+	listDetectorsFunc func(ctx context.Context, params *guardduty.ListDetectorsInput, optFns ...func(*guardduty.Options)) (*guardduty.ListDetectorsOutput, error)
+	getDetectorFunc   func(ctx context.Context, params *guardduty.GetDetectorInput, optFns ...func(*guardduty.Options)) (*guardduty.GetDetectorOutput, error)
+}
+
+func (m *mockGuardDutyClient) ListDetectors(ctx context.Context, params *guardduty.ListDetectorsInput, optFns ...func(*guardduty.Options)) (*guardduty.ListDetectorsOutput, error) {
+	if m.listDetectorsFunc != nil {
+		return m.listDetectorsFunc(ctx, params, optFns...)
+	}
+	return &guardduty.ListDetectorsOutput{}, nil
+}
+
+func (m *mockGuardDutyClient) GetDetector(ctx context.Context, params *guardduty.GetDetectorInput, optFns ...func(*guardduty.Options)) (*guardduty.GetDetectorOutput, error) {
+	if m.getDetectorFunc != nil {
+		return m.getDetectorFunc(ctx, params, optFns...)
+	}
+	return &guardduty.GetDetectorOutput{}, nil
+}
+
+type mockConfigServiceClient struct {
+	describeRecordersFunc func(ctx context.Context, params *configservice.DescribeConfigurationRecordersInput, optFns ...func(*configservice.Options)) (*configservice.DescribeConfigurationRecordersOutput, error)
+	describeStatusFunc    func(ctx context.Context, params *configservice.DescribeConfigurationRecorderStatusInput, optFns ...func(*configservice.Options)) (*configservice.DescribeConfigurationRecorderStatusOutput, error)
+}
+
+func (m *mockConfigServiceClient) DescribeConfigurationRecorders(ctx context.Context, params *configservice.DescribeConfigurationRecordersInput, optFns ...func(*configservice.Options)) (*configservice.DescribeConfigurationRecordersOutput, error) {
+	if m.describeRecordersFunc != nil {
+		return m.describeRecordersFunc(ctx, params, optFns...)
+	}
+	return &configservice.DescribeConfigurationRecordersOutput{}, nil
+}
+
+func (m *mockConfigServiceClient) DescribeConfigurationRecorderStatus(ctx context.Context, params *configservice.DescribeConfigurationRecorderStatusInput, optFns ...func(*configservice.Options)) (*configservice.DescribeConfigurationRecorderStatusOutput, error) {
+	if m.describeStatusFunc != nil {
+		return m.describeStatusFunc(ctx, params, optFns...)
+	}
+	return &configservice.DescribeConfigurationRecorderStatusOutput{}, nil
+}
+
+func TestRunCloudTrailBaselineScan_FindsMissingMultiRegionTrail(t *testing.T) {
+	mock := &mockCloudTrailClient{
+		describeTrailsFunc: func(context.Context, *cloudtrail.DescribeTrailsInput, ...func(*cloudtrail.Options)) (*cloudtrail.DescribeTrailsOutput, error) {
+			return &cloudtrail.DescribeTrailsOutput{
+				TrailList: []cloudtrailtypes.Trail{
+					{Name: awssdk.String("single-region"), IsMultiRegionTrail: awssdk.Bool(false)},
+				},
+			}, nil
+		},
+	}
+
+	findings, err := runCloudTrailBaselineScan(context.Background(), &AwsRepository{CloudTrailClient: mock})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 CloudTrail baseline finding, got %d", len(findings))
+	}
+	if findings[0].RuleID != inspectorRuleIDCloudTrailMissingMultiRegion || findings[0].Severity != RuleSeverityCritical {
+		t.Fatalf("unexpected missing-trail finding: %+v", findings[0])
+	}
+}
+
+func TestRunCloudTrailBaselineScan_FlagsDisabledLoggingAndValidation(t *testing.T) {
+	mock := &mockCloudTrailClient{
+		describeTrailsFunc: func(context.Context, *cloudtrail.DescribeTrailsInput, ...func(*cloudtrail.Options)) (*cloudtrail.DescribeTrailsOutput, error) {
+			return &cloudtrail.DescribeTrailsOutput{
+				TrailList: []cloudtrailtypes.Trail{
+					{
+						Name:                     awssdk.String("org-trail"),
+						TrailARN:                 awssdk.String("arn:aws:cloudtrail:us-east-1:123456789012:trail/org-trail"),
+						IsMultiRegionTrail:       awssdk.Bool(true),
+						LogFileValidationEnabled: awssdk.Bool(false),
+					},
+				},
+			}, nil
+		},
+		getTrailStatusFunc: func(_ context.Context, params *cloudtrail.GetTrailStatusInput, _ ...func(*cloudtrail.Options)) (*cloudtrail.GetTrailStatusOutput, error) {
+			if awssdk.ToString(params.Name) != "arn:aws:cloudtrail:us-east-1:123456789012:trail/org-trail" {
+				t.Fatalf("unexpected trail status lookup %q", awssdk.ToString(params.Name))
+			}
+			return &cloudtrail.GetTrailStatusOutput{IsLogging: awssdk.Bool(false)}, nil
+		},
+	}
+
+	findings, err := runCloudTrailBaselineScan(context.Background(), &AwsRepository{CloudTrailClient: mock})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 CloudTrail findings, got %d", len(findings))
+	}
+	if findings[0].RuleID != inspectorRuleIDCloudTrailLoggingDisabled {
+		t.Fatalf("expected logging-disabled finding first, got %+v", findings[0])
+	}
+	if findings[1].RuleID != inspectorRuleIDCloudTrailValidationDisabled {
+		t.Fatalf("expected validation-disabled finding second, got %+v", findings[1])
+	}
+}
+
+func TestRunGuardDutyConfigBaselineScan_FindsBaselineGaps(t *testing.T) {
+	mockGuardDuty := &mockGuardDutyClient{
+		listDetectorsFunc: func(context.Context, *guardduty.ListDetectorsInput, ...func(*guardduty.Options)) (*guardduty.ListDetectorsOutput, error) {
+			return &guardduty.ListDetectorsOutput{}, nil
+		},
+	}
+	mockConfig := &mockConfigServiceClient{
+		describeRecordersFunc: func(context.Context, *configservice.DescribeConfigurationRecordersInput, ...func(*configservice.Options)) (*configservice.DescribeConfigurationRecordersOutput, error) {
+			return &configservice.DescribeConfigurationRecordersOutput{}, nil
+		},
+	}
+
+	findings, err := runGuardDutyConfigBaselineScan(context.Background(), &AwsRepository{
+		GuardDutyClient:     mockGuardDuty,
+		ConfigServiceClient: mockConfig,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 baseline findings, got %d", len(findings))
+	}
+
+	ruleIDs := map[string]bool{}
+	for _, finding := range findings {
+		ruleIDs[finding.RuleID] = true
+	}
+	if !ruleIDs[inspectorRuleIDGuardDutyDisabled] || !ruleIDs[inspectorRuleIDConfigMissing] {
+		t.Fatalf("missing GuardDuty/Config baseline findings: %+v", findings)
+	}
+}
+
+func TestRunGuardDutyConfigBaselineScan_IgnoresHealthyBaseline(t *testing.T) {
+	mockGuardDuty := &mockGuardDutyClient{
+		listDetectorsFunc: func(context.Context, *guardduty.ListDetectorsInput, ...func(*guardduty.Options)) (*guardduty.ListDetectorsOutput, error) {
+			return &guardduty.ListDetectorsOutput{DetectorIds: []string{"detector-1"}}, nil
+		},
+		getDetectorFunc: func(_ context.Context, params *guardduty.GetDetectorInput, _ ...func(*guardduty.Options)) (*guardduty.GetDetectorOutput, error) {
+			if awssdk.ToString(params.DetectorId) != "detector-1" {
+				t.Fatalf("unexpected detector id %q", awssdk.ToString(params.DetectorId))
+			}
+			return &guardduty.GetDetectorOutput{Status: guarddutytypes.DetectorStatusEnabled}, nil
+		},
+	}
+	mockConfig := &mockConfigServiceClient{
+		describeRecordersFunc: func(context.Context, *configservice.DescribeConfigurationRecordersInput, ...func(*configservice.Options)) (*configservice.DescribeConfigurationRecordersOutput, error) {
+			return &configservice.DescribeConfigurationRecordersOutput{
+				ConfigurationRecorders: []configtypes.ConfigurationRecorder{
+					{
+						Name: awssdk.String("default"),
+						RecordingGroup: &configtypes.RecordingGroup{
+							AllSupported: true,
+						},
+					},
+				},
+			}, nil
+		},
+		describeStatusFunc: func(context.Context, *configservice.DescribeConfigurationRecorderStatusInput, ...func(*configservice.Options)) (*configservice.DescribeConfigurationRecorderStatusOutput, error) {
+			return &configservice.DescribeConfigurationRecorderStatusOutput{
+				ConfigurationRecordersStatus: []configtypes.ConfigurationRecorderStatus{
+					{
+						Name:      awssdk.String("default"),
+						Recording: true,
+					},
+				},
+			}, nil
+		},
+	}
+
+	findings, err := runGuardDutyConfigBaselineScan(context.Background(), &AwsRepository{
+		GuardDutyClient:     mockGuardDuty,
+		ConfigServiceClient: mockConfig,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings for healthy GuardDuty/Config baseline, got %+v", findings)
+	}
+}

--- a/internal/services/aws/inspector_rules_elasticache.go
+++ b/internal/services/aws/inspector_rules_elasticache.go
@@ -1,0 +1,150 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+	elasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+)
+
+const (
+	inspectorScannerElastiCacheValkeyName = "elasticache-valkey-security"
+
+	inspectorRuleIDValkeyTransitEncryptionDisabled = "elasticache-valkey-transit-encryption-disabled"
+	inspectorRuleIDValkeyAtRestEncryptionDisabled  = "elasticache-valkey-at-rest-encryption-disabled"
+	inspectorRuleIDValkeyBackupsDisabled           = "elasticache-valkey-backups-disabled"
+	inspectorRuleIDValkeyBackupRetentionLow        = "elasticache-valkey-backup-retention-low"
+	inspectorRuleIDValkeyWeakAccessControl         = "elasticache-valkey-weak-access-control"
+
+	inspectorValkeyMinSnapshotRetentionDays = 7
+)
+
+func init() {
+	registerSecurityInspectorScanner(InspectorScanner{
+		Name: inspectorScannerElastiCacheValkeyName,
+		Run:  runElastiCacheValkeySecurityScan,
+	})
+}
+
+func runElastiCacheValkeySecurityScan(ctx context.Context, repo *AwsRepository) ([]SecurityFinding, error) {
+	var findings []SecurityFinding
+	marker := ""
+
+	for {
+		input := &elasticache.DescribeReplicationGroupsInput{
+			MaxRecords: awssdk.Int32(100),
+		}
+		if marker != "" {
+			input.Marker = awssdk.String(marker)
+		}
+
+		page, err := repo.ElastiCacheClient.DescribeReplicationGroups(ctx, input)
+		if err != nil {
+			return nil, fmt.Errorf("failed to inspect ElastiCache replication groups: %w", err)
+		}
+
+		for _, group := range page.ReplicationGroups {
+			if !strings.EqualFold(awssdk.ToString(group.Engine), "valkey") {
+				continue
+			}
+			findings = append(findings, inspectValkeyReplicationGroup(group)...)
+		}
+
+		if awssdk.ToString(page.Marker) == "" {
+			break
+		}
+		marker = awssdk.ToString(page.Marker)
+	}
+
+	sort.Slice(findings, func(i, j int) bool {
+		left := normalizedSortKey(findings[i].ResourceID, findings[i].RuleID, findings[i].RuleName)
+		right := normalizedSortKey(findings[j].ResourceID, findings[j].RuleID, findings[j].RuleName)
+		if left == right {
+			return findings[i].Severity.Rank() < findings[j].Severity.Rank()
+		}
+		return left < right
+	})
+
+	return findings, nil
+}
+
+func inspectValkeyReplicationGroup(group elasticachetypes.ReplicationGroup) []SecurityFinding {
+	groupID := awssdk.ToString(group.ReplicationGroupId)
+	if groupID == "" {
+		groupID = awssdk.ToString(group.ARN)
+	}
+	var findings []SecurityFinding
+
+	if !awssdk.ToBool(group.TransitEncryptionEnabled) {
+		findings = append(findings, SecurityFinding{
+			RuleID:         inspectorRuleIDValkeyTransitEncryptionDisabled,
+			RuleName:       "Valkey in-transit encryption disabled",
+			Severity:       RuleSeverityHigh,
+			ResourceType:   "ElastiCacheReplicationGroup",
+			ResourceID:     groupID,
+			Summary:        fmt.Sprintf("Valkey replication group %s does not have in-transit encryption enabled.", groupID),
+			Recommendation: "Enable TLS in transit for Valkey replication groups so client and node traffic is encrypted.",
+		})
+	}
+
+	if !awssdk.ToBool(group.AtRestEncryptionEnabled) {
+		findings = append(findings, SecurityFinding{
+			RuleID:         inspectorRuleIDValkeyAtRestEncryptionDisabled,
+			RuleName:       "Valkey at-rest encryption disabled",
+			Severity:       RuleSeverityHigh,
+			ResourceType:   "ElastiCacheReplicationGroup",
+			ResourceID:     groupID,
+			Summary:        fmt.Sprintf("Valkey replication group %s does not have at-rest encryption enabled.", groupID),
+			Recommendation: "Enable at-rest encryption for Valkey replication groups so snapshot and disk-backed data is protected.",
+		})
+	}
+
+	snapshotRetention := awssdk.ToInt32(group.SnapshotRetentionLimit)
+	switch {
+	case snapshotRetention <= 0:
+		findings = append(findings, SecurityFinding{
+			RuleID:         inspectorRuleIDValkeyBackupsDisabled,
+			RuleName:       "Valkey automatic backups disabled",
+			Severity:       RuleSeverityHigh,
+			ResourceType:   "ElastiCacheReplicationGroup",
+			ResourceID:     groupID,
+			Summary:        fmt.Sprintf("Valkey replication group %s has automatic backups disabled.", groupID),
+			Recommendation: "Enable automatic backups and retain snapshots long enough to support recovery expectations.",
+		})
+	case snapshotRetention < inspectorValkeyMinSnapshotRetentionDays:
+		findings = append(findings, SecurityFinding{
+			RuleID:         inspectorRuleIDValkeyBackupRetentionLow,
+			RuleName:       "Valkey backup retention too low",
+			Severity:       RuleSeverityMedium,
+			ResourceType:   "ElastiCacheReplicationGroup",
+			ResourceID:     groupID,
+			Summary:        fmt.Sprintf("Valkey replication group %s retains automatic backups for only %d days.", groupID, snapshotRetention),
+			Recommendation: fmt.Sprintf("Increase snapshot retention to at least %d days unless a shorter retention period is explicitly justified.", inspectorValkeyMinSnapshotRetentionDays),
+		})
+	}
+
+	if len(group.UserGroupIds) == 0 {
+		severity := RuleSeverityLow
+		summary := fmt.Sprintf("Valkey replication group %s does not use RBAC user groups.", groupID)
+		if awssdk.ToBool(group.AuthTokenEnabled) {
+			severity = RuleSeverityMedium
+			summary = fmt.Sprintf("Valkey replication group %s relies on shared AUTH tokens without RBAC user groups.", groupID)
+		}
+
+		findings = append(findings, SecurityFinding{
+			RuleID:         inspectorRuleIDValkeyWeakAccessControl,
+			RuleName:       "Valkey access control posture is weak",
+			Severity:       severity,
+			ResourceType:   "ElastiCacheReplicationGroup",
+			ResourceID:     groupID,
+			Summary:        summary,
+			Recommendation: "Prefer RBAC user groups and IAM authentication where supported instead of long-lived shared AUTH credentials.",
+		})
+	}
+
+	return findings
+}

--- a/internal/services/aws/inspector_rules_elasticache_test.go
+++ b/internal/services/aws/inspector_rules_elasticache_test.go
@@ -1,0 +1,99 @@
+package aws
+
+import (
+	"context"
+	"testing"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+	elasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+)
+
+type mockElastiCacheClient struct {
+	describeReplicationGroupsFunc func(ctx context.Context, params *elasticache.DescribeReplicationGroupsInput, optFns ...func(*elasticache.Options)) (*elasticache.DescribeReplicationGroupsOutput, error)
+}
+
+func (m *mockElastiCacheClient) DescribeReplicationGroups(ctx context.Context, params *elasticache.DescribeReplicationGroupsInput, optFns ...func(*elasticache.Options)) (*elasticache.DescribeReplicationGroupsOutput, error) {
+	if m.describeReplicationGroupsFunc != nil {
+		return m.describeReplicationGroupsFunc(ctx, params, optFns...)
+	}
+	return &elasticache.DescribeReplicationGroupsOutput{}, nil
+}
+
+func TestRunElastiCacheValkeySecurityScan_FindsSecurityGaps(t *testing.T) {
+	mock := &mockElastiCacheClient{
+		describeReplicationGroupsFunc: func(context.Context, *elasticache.DescribeReplicationGroupsInput, ...func(*elasticache.Options)) (*elasticache.DescribeReplicationGroupsOutput, error) {
+			return &elasticache.DescribeReplicationGroupsOutput{
+				ReplicationGroups: []elasticachetypes.ReplicationGroup{
+					{
+						ReplicationGroupId:       awssdk.String("valkey-prod"),
+						Engine:                   awssdk.String("valkey"),
+						TransitEncryptionEnabled: awssdk.Bool(false),
+						AtRestEncryptionEnabled:  awssdk.Bool(false),
+						SnapshotRetentionLimit:   awssdk.Int32(0),
+						AuthTokenEnabled:         awssdk.Bool(true),
+						UserGroupIds:             nil,
+					},
+					{
+						ReplicationGroupId:       awssdk.String("redis-legacy"),
+						Engine:                   awssdk.String("redis"),
+						TransitEncryptionEnabled: awssdk.Bool(false),
+					},
+				},
+			}, nil
+		},
+	}
+
+	findings, err := runElastiCacheValkeySecurityScan(context.Background(), &AwsRepository{
+		ElastiCacheClient: mock,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 4 {
+		t.Fatalf("expected 4 Valkey findings, got %d", len(findings))
+	}
+
+	ruleIDs := map[string]bool{}
+	for _, finding := range findings {
+		ruleIDs[finding.RuleID] = true
+		if finding.ResourceID != "valkey-prod" {
+			t.Fatalf("expected only Valkey replication-group findings, got %+v", finding)
+		}
+	}
+	if !ruleIDs[inspectorRuleIDValkeyTransitEncryptionDisabled] ||
+		!ruleIDs[inspectorRuleIDValkeyAtRestEncryptionDisabled] ||
+		!ruleIDs[inspectorRuleIDValkeyBackupsDisabled] ||
+		!ruleIDs[inspectorRuleIDValkeyWeakAccessControl] {
+		t.Fatalf("missing expected Valkey findings: %+v", findings)
+	}
+}
+
+func TestRunElastiCacheValkeySecurityScan_IgnoresCompliantReplicationGroups(t *testing.T) {
+	mock := &mockElastiCacheClient{
+		describeReplicationGroupsFunc: func(context.Context, *elasticache.DescribeReplicationGroupsInput, ...func(*elasticache.Options)) (*elasticache.DescribeReplicationGroupsOutput, error) {
+			return &elasticache.DescribeReplicationGroupsOutput{
+				ReplicationGroups: []elasticachetypes.ReplicationGroup{
+					{
+						ReplicationGroupId:       awssdk.String("valkey-secure"),
+						Engine:                   awssdk.String("valkey"),
+						TransitEncryptionEnabled: awssdk.Bool(true),
+						AtRestEncryptionEnabled:  awssdk.Bool(true),
+						SnapshotRetentionLimit:   awssdk.Int32(inspectorValkeyMinSnapshotRetentionDays),
+						UserGroupIds:             []string{"rg-123"},
+					},
+				},
+			}, nil
+		},
+	}
+
+	findings, err := runElastiCacheValkeySecurityScan(context.Background(), &AwsRepository{
+		ElastiCacheClient: mock,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings for compliant Valkey replication group, got %+v", findings)
+	}
+}

--- a/internal/services/aws/inspector_rules_iam_account.go
+++ b/internal/services/aws/inspector_rules_iam_account.go
@@ -1,0 +1,418 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+const (
+	inspectorScannerIAMRootName     = "iam-root-account"
+	inspectorScannerIAMWildcardName = "iam-wildcard-policies"
+
+	inspectorRuleIDRootMFADisabled       = "iam-root-mfa-disabled"
+	inspectorRuleIDRootAccessKeysPresent = "iam-root-access-keys-present"
+	inspectorRuleIDIAMPolicyBroadAccess  = "iam-policy-broad-access"
+)
+
+type iamPolicyDocument struct {
+	Statement json.RawMessage `json:"Statement"`
+}
+
+type iamPolicyStatement struct {
+	Effect    string `json:"Effect"`
+	Action    any    `json:"Action"`
+	NotAction any    `json:"NotAction"`
+	Resource  any    `json:"Resource"`
+}
+
+type iamPolicyAssessment struct {
+	Severity RuleSeverity
+	Reasons  []string
+}
+
+func init() {
+	registerSecurityInspectorScanner(InspectorScanner{
+		Name: inspectorScannerIAMRootName,
+		Run:  runIAMRootAccountScan,
+	})
+	registerSecurityInspectorScanner(InspectorScanner{
+		Name: inspectorScannerIAMWildcardName,
+		Run:  runIAMWildcardPolicyScan,
+	})
+}
+
+func runIAMRootAccountScan(ctx context.Context, repo *AwsRepository) ([]SecurityFinding, error) {
+	summary, err := repo.IAMClient.GetAccountSummary(ctx, &iam.GetAccountSummaryInput{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect IAM account summary: %w", err)
+	}
+
+	var findings []SecurityFinding
+	if summary.SummaryMap["AccountMFAEnabled"] == 0 {
+		findings = append(findings, SecurityFinding{
+			RuleID:         inspectorRuleIDRootMFADisabled,
+			RuleName:       "Root account MFA disabled",
+			Severity:       RuleSeverityCritical,
+			ResourceType:   "AWSAccount",
+			ResourceID:     "root-account",
+			Summary:        "The AWS account root user does not have MFA enabled.",
+			Recommendation: "Enable MFA on the root user and reserve root access for break-glass administration only.",
+		})
+	}
+	if summary.SummaryMap["AccountAccessKeysPresent"] > 0 {
+		findings = append(findings, SecurityFinding{
+			RuleID:         inspectorRuleIDRootAccessKeysPresent,
+			RuleName:       "Root account access keys present",
+			Severity:       RuleSeverityCritical,
+			ResourceType:   "AWSAccount",
+			ResourceID:     "root-account",
+			Summary:        "The AWS account root user still has active access keys present.",
+			Recommendation: "Delete root access keys and use IAM roles or short-lived credentials for programmatic access.",
+		})
+	}
+
+	return findings, nil
+}
+
+func runIAMWildcardPolicyScan(ctx context.Context, repo *AwsRepository) ([]SecurityFinding, error) {
+	accountDetails, err := loadAccountAuthorizationDetails(ctx, repo.IAMClient)
+	if err != nil {
+		return nil, err
+	}
+
+	managedPolicyDocs := buildManagedPolicyDocumentIndex(accountDetails.Policies)
+	findings := collectIAMPolicyFindings(accountDetails.UserDetailList, accountDetails.GroupDetailList, accountDetails.RoleDetailList, managedPolicyDocs)
+
+	sort.Slice(findings, func(i, j int) bool {
+		left := normalizedSortKey(findings[i].ResourceID, findings[i].RuleID, findings[i].RuleName)
+		right := normalizedSortKey(findings[j].ResourceID, findings[j].RuleID, findings[j].RuleName)
+		if left == right {
+			return findings[i].Severity.Rank() < findings[j].Severity.Rank()
+		}
+		return left < right
+	})
+
+	return findings, nil
+}
+
+func loadAccountAuthorizationDetails(ctx context.Context, client IAMClientAPI) (*iam.GetAccountAuthorizationDetailsOutput, error) {
+	result := &iam.GetAccountAuthorizationDetailsOutput{}
+	marker := ""
+
+	for {
+		input := &iam.GetAccountAuthorizationDetailsInput{
+			MaxItems: awssdk.Int32(1000),
+		}
+		if marker != "" {
+			input.Marker = awssdk.String(marker)
+		}
+
+		page, err := client.GetAccountAuthorizationDetails(ctx, input)
+		if err != nil {
+			return nil, fmt.Errorf("failed to inspect IAM policy attachments: %w", err)
+		}
+
+		result.UserDetailList = append(result.UserDetailList, page.UserDetailList...)
+		result.GroupDetailList = append(result.GroupDetailList, page.GroupDetailList...)
+		result.RoleDetailList = append(result.RoleDetailList, page.RoleDetailList...)
+		result.Policies = append(result.Policies, page.Policies...)
+
+		if !page.IsTruncated || awssdk.ToString(page.Marker) == "" {
+			break
+		}
+		marker = awssdk.ToString(page.Marker)
+	}
+
+	return result, nil
+}
+
+func buildManagedPolicyDocumentIndex(policies []iamtypes.ManagedPolicyDetail) map[string]string {
+	index := make(map[string]string, len(policies))
+	for _, policy := range policies {
+		arn := awssdk.ToString(policy.Arn)
+		if arn == "" {
+			continue
+		}
+		for _, version := range policy.PolicyVersionList {
+			if version.IsDefaultVersion && version.Document != nil {
+				index[arn] = awssdk.ToString(version.Document)
+				break
+			}
+		}
+	}
+	return index
+}
+
+func collectIAMPolicyFindings(
+	users []iamtypes.UserDetail,
+	groups []iamtypes.GroupDetail,
+	roles []iamtypes.RoleDetail,
+	managedPolicyDocs map[string]string,
+) []SecurityFinding {
+	var findings []SecurityFinding
+
+	for _, user := range users {
+		principal := fmt.Sprintf("user/%s", awssdk.ToString(user.UserName))
+		findings = append(findings, collectPrincipalPolicyFindings(principal, user.UserPolicyList, user.AttachedManagedPolicies, managedPolicyDocs)...)
+	}
+	for _, group := range groups {
+		principal := fmt.Sprintf("group/%s", awssdk.ToString(group.GroupName))
+		findings = append(findings, collectPrincipalPolicyFindings(principal, group.GroupPolicyList, group.AttachedManagedPolicies, managedPolicyDocs)...)
+	}
+	for _, role := range roles {
+		principal := fmt.Sprintf("role/%s", awssdk.ToString(role.RoleName))
+		findings = append(findings, collectPrincipalPolicyFindings(principal, role.RolePolicyList, role.AttachedManagedPolicies, managedPolicyDocs)...)
+	}
+
+	return findings
+}
+
+func collectPrincipalPolicyFindings(
+	principal string,
+	inlinePolicies []iamtypes.PolicyDetail,
+	attachedPolicies []iamtypes.AttachedPolicy,
+	managedPolicyDocs map[string]string,
+) []SecurityFinding {
+	var findings []SecurityFinding
+
+	for _, policy := range inlinePolicies {
+		policyName := awssdk.ToString(policy.PolicyName)
+		assessment, err := assessIAMPolicyDocument(awssdk.ToString(policy.PolicyDocument))
+		if err != nil || len(assessment.Reasons) == 0 {
+			continue
+		}
+		findings = append(findings, buildIAMPolicyFinding(principal, "inline", policyName, assessment))
+	}
+
+	for _, policy := range attachedPolicies {
+		policyName := awssdk.ToString(policy.PolicyName)
+		document := managedPolicyDocs[awssdk.ToString(policy.PolicyArn)]
+		if document == "" {
+			continue
+		}
+
+		assessment, err := assessIAMPolicyDocument(document)
+		if err != nil || len(assessment.Reasons) == 0 {
+			continue
+		}
+		findings = append(findings, buildIAMPolicyFinding(principal, "managed", policyName, assessment))
+	}
+
+	return findings
+}
+
+func buildIAMPolicyFinding(principal, policyKind, policyName string, assessment iamPolicyAssessment) SecurityFinding {
+	resourceID := fmt.Sprintf("%s:%s/%s", principal, policyKind, policyName)
+	return SecurityFinding{
+		RuleID:       inspectorRuleIDIAMPolicyBroadAccess,
+		RuleName:     "Overly permissive IAM policy attachment",
+		Severity:     assessment.Severity,
+		ResourceType: "IAMPolicyAttachment",
+		ResourceID:   resourceID,
+		Summary: fmt.Sprintf(
+			"%s attaches %s policy %s with %s.",
+			principal,
+			policyKind,
+			policyName,
+			strings.Join(assessment.Reasons, ", "),
+		),
+		Recommendation: "Narrow the policy to the minimum required actions and resources, and avoid wildcard administrative access where possible.",
+	}
+}
+
+func assessIAMPolicyDocument(document string) (iamPolicyAssessment, error) {
+	decoded, err := decodeIAMPolicyDocument(document)
+	if err != nil {
+		return iamPolicyAssessment{}, err
+	}
+
+	statements, err := parseIAMPolicyStatements(decoded)
+	if err != nil {
+		return iamPolicyAssessment{}, err
+	}
+
+	reasons := make(map[string]struct{})
+	severity := RuleSeverity("")
+
+	for _, statement := range statements {
+		if !strings.EqualFold(statement.Effect, "allow") {
+			continue
+		}
+
+		actions := normalizeIAMPolicyValues(statement.Action)
+		notActions := normalizeIAMPolicyValues(statement.NotAction)
+		resources := normalizeIAMPolicyValues(statement.Resource)
+
+		switch {
+		case len(notActions) > 0 && hasGlobalWildcardResource(resources):
+			reasons["an allow statement uses NotAction with Resource *"] = struct{}{}
+			severity = strongerSeverity(severity, RuleSeverityCritical)
+		case hasBroadWildcardAction(actions) && hasGlobalWildcardResource(resources):
+			reasons["wildcard actions on all resources"] = struct{}{}
+			severity = strongerSeverity(severity, RuleSeverityCritical)
+		default:
+			if hasBroadWildcardAction(actions) {
+				reasons["wildcard actions"] = struct{}{}
+				severity = strongerSeverity(severity, RuleSeverityHigh)
+			}
+			if hasGlobalWildcardResource(resources) && hasWriteScopeAction(actions) {
+				reasons["write access on Resource *"] = struct{}{}
+				severity = strongerSeverity(severity, RuleSeverityHigh)
+			}
+		}
+	}
+
+	if len(reasons) == 0 {
+		return iamPolicyAssessment{}, nil
+	}
+
+	ordered := make([]string, 0, len(reasons))
+	for reason := range reasons {
+		ordered = append(ordered, reason)
+	}
+	sort.Strings(ordered)
+
+	return iamPolicyAssessment{
+		Severity: severity,
+		Reasons:  ordered,
+	}, nil
+}
+
+func decodeIAMPolicyDocument(document string) ([]byte, error) {
+	if document == "" {
+		return nil, fmt.Errorf("empty IAM policy document")
+	}
+
+	decoded, err := url.QueryUnescape(document)
+	if err != nil {
+		decoded = document
+	}
+	return []byte(decoded), nil
+}
+
+func parseIAMPolicyStatements(document []byte) ([]iamPolicyStatement, error) {
+	var policy iamPolicyDocument
+	if err := json.Unmarshal(document, &policy); err != nil {
+		return nil, err
+	}
+
+	if len(policy.Statement) == 0 {
+		return nil, nil
+	}
+
+	if policy.Statement[0] == '[' {
+		var statements []iamPolicyStatement
+		if err := json.Unmarshal(policy.Statement, &statements); err != nil {
+			return nil, err
+		}
+		return statements, nil
+	}
+
+	var statement iamPolicyStatement
+	if err := json.Unmarshal(policy.Statement, &statement); err != nil {
+		return nil, err
+	}
+	return []iamPolicyStatement{statement}, nil
+}
+
+func normalizeIAMPolicyValues(value any) []string {
+	switch typed := value.(type) {
+	case nil:
+		return nil
+	case string:
+		return []string{typed}
+	case []any:
+		values := make([]string, 0, len(typed))
+		for _, entry := range typed {
+			if text, ok := entry.(string); ok {
+				values = append(values, text)
+			}
+		}
+		return values
+	default:
+		return nil
+	}
+}
+
+func hasGlobalWildcardResource(resources []string) bool {
+	for _, resource := range resources {
+		if strings.TrimSpace(resource) == "*" {
+			return true
+		}
+	}
+	return false
+}
+
+func hasBroadWildcardAction(actions []string) bool {
+	for _, action := range actions {
+		parts := strings.SplitN(strings.TrimSpace(action), ":", 2)
+		if len(parts) == 1 {
+			if parts[0] == "*" {
+				return true
+			}
+			continue
+		}
+		if parts[1] == "*" {
+			return true
+		}
+	}
+	return false
+}
+
+func hasWriteScopeAction(actions []string) bool {
+	for _, action := range actions {
+		if action == "" {
+			continue
+		}
+		if hasBroadWildcardAction([]string{action}) {
+			return true
+		}
+
+		parts := strings.SplitN(action, ":", 2)
+		verb := action
+		if len(parts) == 2 {
+			verb = parts[1]
+		}
+		if !isReadOnlyIAMVerb(verb) {
+			return true
+		}
+	}
+	return false
+}
+
+func isReadOnlyIAMVerb(verb string) bool {
+	readPrefixes := []string{
+		"Get",
+		"List",
+		"Describe",
+		"View",
+		"Lookup",
+		"Read",
+		"Search",
+		"BatchGet",
+		"Head",
+		"Query",
+	}
+
+	for _, prefix := range readPrefixes {
+		if strings.HasPrefix(verb, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func strongerSeverity(current, candidate RuleSeverity) RuleSeverity {
+	if current == "" || candidate.Rank() < current.Rank() {
+		return candidate
+	}
+	return current
+}

--- a/internal/services/aws/inspector_rules_iam_account_test.go
+++ b/internal/services/aws/inspector_rules_iam_account_test.go
@@ -1,0 +1,151 @@
+package aws
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+func TestRunIAMRootAccountScan_FindsHardeningGaps(t *testing.T) {
+	mock := &inspectorIAMMockClient{
+		getAccountSummaryFunc: func(context.Context, *iam.GetAccountSummaryInput, ...func(*iam.Options)) (*iam.GetAccountSummaryOutput, error) {
+			return &iam.GetAccountSummaryOutput{
+				SummaryMap: map[string]int32{
+					"AccountMFAEnabled":        0,
+					"AccountAccessKeysPresent": 1,
+				},
+			}, nil
+		},
+	}
+
+	findings, err := runIAMRootAccountScan(context.Background(), &AwsRepository{IAMClient: mock})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 root-account findings, got %d", len(findings))
+	}
+	if findings[0].RuleID != inspectorRuleIDRootMFADisabled {
+		t.Fatalf("expected root MFA finding first, got %+v", findings[0])
+	}
+	if findings[1].RuleID != inspectorRuleIDRootAccessKeysPresent {
+		t.Fatalf("expected root access-key finding second, got %+v", findings[1])
+	}
+	for _, finding := range findings {
+		if finding.Severity != RuleSeverityCritical {
+			t.Fatalf("expected critical severity for root hardening gaps, got %+v", finding)
+		}
+	}
+}
+
+func TestRunIAMWildcardPolicyScan_FlagsBroadAttachmentsAndIgnoresReadOnlyPolicies(t *testing.T) {
+	mock := &inspectorIAMMockClient{
+		getAuthzDetailsFunc: func(context.Context, *iam.GetAccountAuthorizationDetailsInput, ...func(*iam.Options)) (*iam.GetAccountAuthorizationDetailsOutput, error) {
+			return &iam.GetAccountAuthorizationDetailsOutput{
+				UserDetailList: []iamtypes.UserDetail{
+					{
+						UserName: awssdk.String("alice"),
+						UserPolicyList: []iamtypes.PolicyDetail{
+							{
+								PolicyName:     awssdk.String("FullAccess"),
+								PolicyDocument: awssdk.String(encodedIAMPolicy(`{"Statement":{"Effect":"Allow","Action":"*","Resource":"*"}}`)),
+							},
+						},
+					},
+				},
+				GroupDetailList: []iamtypes.GroupDetail{
+					{
+						GroupName: awssdk.String("devops"),
+						GroupPolicyList: []iamtypes.PolicyDetail{
+							{
+								PolicyName:     awssdk.String("NotActionTrap"),
+								PolicyDocument: awssdk.String(encodedIAMPolicy(`{"Statement":{"Effect":"Allow","NotAction":"iam:*","Resource":"*"}}`)),
+							},
+						},
+					},
+					{
+						GroupName: awssdk.String("readers"),
+						GroupPolicyList: []iamtypes.PolicyDetail{
+							{
+								PolicyName:     awssdk.String("ReadOnly"),
+								PolicyDocument: awssdk.String(encodedIAMPolicy(`{"Statement":{"Effect":"Allow","Action":["ec2:DescribeInstances","ec2:DescribeTags"],"Resource":"*"}}`)),
+							},
+						},
+					},
+				},
+				RoleDetailList: []iamtypes.RoleDetail{
+					{
+						RoleName: awssdk.String("release"),
+						AttachedManagedPolicies: []iamtypes.AttachedPolicy{
+							{
+								PolicyArn:  awssdk.String("arn:aws:iam::123456789012:policy/PassRoleEverywhere"),
+								PolicyName: awssdk.String("PassRoleEverywhere"),
+							},
+						},
+					},
+				},
+				Policies: []iamtypes.ManagedPolicyDetail{
+					{
+						Arn:        awssdk.String("arn:aws:iam::123456789012:policy/PassRoleEverywhere"),
+						PolicyName: awssdk.String("PassRoleEverywhere"),
+						PolicyVersionList: []iamtypes.PolicyVersion{
+							{
+								IsDefaultVersion: true,
+								Document:         awssdk.String(encodedIAMPolicy(`{"Statement":{"Effect":"Allow","Action":"iam:PassRole","Resource":"*"}}`)),
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	findings, err := runIAMWildcardPolicyScan(context.Background(), &AwsRepository{IAMClient: mock})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 3 {
+		t.Fatalf("expected 3 wildcard-policy findings, got %d", len(findings))
+	}
+
+	byResource := make(map[string]SecurityFinding, len(findings))
+	for _, finding := range findings {
+		byResource[finding.ResourceID] = finding
+	}
+
+	userFinding, ok := byResource["user/alice:inline/FullAccess"]
+	if !ok {
+		t.Fatalf("missing user policy finding: %+v", findings)
+	}
+	if userFinding.Severity != RuleSeverityCritical {
+		t.Fatalf("expected critical severity for Action * / Resource * policy, got %+v", userFinding)
+	}
+
+	groupFinding, ok := byResource["group/devops:inline/NotActionTrap"]
+	if !ok {
+		t.Fatalf("missing group policy finding: %+v", findings)
+	}
+	if groupFinding.Severity != RuleSeverityCritical {
+		t.Fatalf("expected critical severity for NotAction policy, got %+v", groupFinding)
+	}
+
+	roleFinding, ok := byResource["role/release:managed/PassRoleEverywhere"]
+	if !ok {
+		t.Fatalf("missing role managed-policy finding: %+v", findings)
+	}
+	if roleFinding.Severity != RuleSeverityHigh {
+		t.Fatalf("expected high severity for Resource * write access, got %+v", roleFinding)
+	}
+	if !strings.Contains(roleFinding.Summary, "write access on Resource *") {
+		t.Fatalf("expected role finding summary to mention Resource *, got %+v", roleFinding)
+	}
+}
+
+func encodedIAMPolicy(document string) string {
+	return url.QueryEscape(document)
+}

--- a/internal/services/aws/inspector_rules_identity_secrets_test.go
+++ b/internal/services/aws/inspector_rules_identity_secrets_test.go
@@ -16,6 +16,8 @@ type inspectorIAMMockClient struct {
 	listUsersFunc            func(ctx context.Context, params *iam.ListUsersInput, optFns ...func(*iam.Options)) (*iam.ListUsersOutput, error)
 	listAccessKeysFunc       func(ctx context.Context, params *iam.ListAccessKeysInput, optFns ...func(*iam.Options)) (*iam.ListAccessKeysOutput, error)
 	getAccessKeyLastUsedFunc func(ctx context.Context, params *iam.GetAccessKeyLastUsedInput, optFns ...func(*iam.Options)) (*iam.GetAccessKeyLastUsedOutput, error)
+	getAccountSummaryFunc    func(ctx context.Context, params *iam.GetAccountSummaryInput, optFns ...func(*iam.Options)) (*iam.GetAccountSummaryOutput, error)
+	getAuthzDetailsFunc      func(ctx context.Context, params *iam.GetAccountAuthorizationDetailsInput, optFns ...func(*iam.Options)) (*iam.GetAccountAuthorizationDetailsOutput, error)
 }
 
 func (m *inspectorIAMMockClient) ListUsers(ctx context.Context, params *iam.ListUsersInput, optFns ...func(*iam.Options)) (*iam.ListUsersOutput, error) {
@@ -27,6 +29,20 @@ func (m *inspectorIAMMockClient) ListUsers(ctx context.Context, params *iam.List
 
 func (m *inspectorIAMMockClient) GetUser(context.Context, *iam.GetUserInput, ...func(*iam.Options)) (*iam.GetUserOutput, error) {
 	return &iam.GetUserOutput{}, nil
+}
+
+func (m *inspectorIAMMockClient) GetAccountSummary(ctx context.Context, params *iam.GetAccountSummaryInput, optFns ...func(*iam.Options)) (*iam.GetAccountSummaryOutput, error) {
+	if m.getAccountSummaryFunc != nil {
+		return m.getAccountSummaryFunc(ctx, params, optFns...)
+	}
+	return &iam.GetAccountSummaryOutput{}, nil
+}
+
+func (m *inspectorIAMMockClient) GetAccountAuthorizationDetails(ctx context.Context, params *iam.GetAccountAuthorizationDetailsInput, optFns ...func(*iam.Options)) (*iam.GetAccountAuthorizationDetailsOutput, error) {
+	if m.getAuthzDetailsFunc != nil {
+		return m.getAuthzDetailsFunc(ctx, params, optFns...)
+	}
+	return &iam.GetAccountAuthorizationDetailsOutput{}, nil
 }
 
 func (m *inspectorIAMMockClient) ListGroupsForUser(context.Context, *iam.ListGroupsForUserInput, ...func(*iam.Options)) (*iam.ListGroupsForUserOutput, error) {

--- a/internal/services/aws/inspector_rules_s3.go
+++ b/internal/services/aws/inspector_rules_s3.go
@@ -2,16 +2,23 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
 )
 
 const (
 	s3PublicAllUsersURI           = "http://acs.amazonaws.com/groups/global/AllUsers"
 	s3PublicAuthenticatedUsersURI = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
+	s3InspectorRuleIDPublicACL    = "s3-bucket-public-acl"
+	s3InspectorRuleIDPublicPolicy = "s3-bucket-public-policy"
+	s3InspectorRuleIDPublicAccess = "s3-bucket-public-access-block-disabled"
+	s3InspectorRuleIDVersioning   = "s3-bucket-versioning-disabled"
 )
 
 func init() {
@@ -31,6 +38,7 @@ func runS3InspectorScan(ctx context.Context, r *AwsRepository) ([]SecurityFindin
 	for _, bucket := range buckets {
 		findings = append(findings, inspectS3BucketPublicACL(ctx, r, bucket)...)
 		findings = append(findings, inspectS3BucketPolicy(ctx, r, bucket)...)
+		findings = append(findings, inspectS3BucketPublicAccessBlock(ctx, r, bucket)...)
 		findings = append(findings, inspectS3BucketVersioning(ctx, r, bucket)...)
 	}
 
@@ -50,7 +58,7 @@ func inspectS3BucketPublicACL(ctx context.Context, r *AwsRepository, bucket S3Bu
 
 	return []SecurityFinding{
 		newS3InspectorFinding(
-			"s3-bucket-public-acl",
+			s3InspectorRuleIDPublicACL,
 			"S3 bucket ACL grants public access",
 			RuleSeverityHigh,
 			bucket.Name,
@@ -73,12 +81,40 @@ func inspectS3BucketPolicy(ctx context.Context, r *AwsRepository, bucket S3Bucke
 
 	return []SecurityFinding{
 		newS3InspectorFinding(
-			"s3-bucket-public-policy",
+			s3InspectorRuleIDPublicPolicy,
 			"S3 bucket policy allows public access",
 			RuleSeverityCritical,
 			bucket.Name,
 			"Bucket policy is public.",
 			"Restrict the bucket policy to trusted principals or enable S3 Block Public Access.",
+		),
+	}
+}
+
+func inspectS3BucketPublicAccessBlock(ctx context.Context, r *AwsRepository, bucket S3Bucket) []SecurityFinding {
+	output, err := r.S3Client.GetPublicAccessBlock(ctx, &s3.GetPublicAccessBlockInput{
+		Bucket: awssdk.String(bucket.Name),
+	})
+	if err != nil && !isMissingBucketPublicAccessBlockConfiguration(err) {
+		return nil
+	}
+
+	missing := missingBucketPublicAccessBlockSettings(nil)
+	if err == nil && output != nil {
+		missing = missingBucketPublicAccessBlockSettings(output.PublicAccessBlockConfiguration)
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+
+	return []SecurityFinding{
+		newS3InspectorFinding(
+			s3InspectorRuleIDPublicAccess,
+			"S3 bucket Block Public Access is not fully enabled",
+			RuleSeverityHigh,
+			bucket.Name,
+			fmt.Sprintf("Bucket-level Block Public Access is missing settings: %s.", strings.Join(missing, ", ")),
+			"Enable all four bucket-level S3 Block Public Access settings: BlockPublicAcls, IgnorePublicAcls, BlockPublicPolicy, RestrictPublicBuckets.",
 		),
 	}
 }
@@ -96,7 +132,7 @@ func inspectS3BucketVersioning(ctx context.Context, r *AwsRepository, bucket S3B
 
 	return []SecurityFinding{
 		newS3InspectorFinding(
-			"s3-bucket-versioning-disabled",
+			s3InspectorRuleIDVersioning,
 			"S3 bucket versioning is disabled",
 			RuleSeverityMedium,
 			bucket.Name,
@@ -104,6 +140,34 @@ func inspectS3BucketVersioning(ctx context.Context, r *AwsRepository, bucket S3B
 			"Enable bucket versioning to protect against accidental deletion and overwrites.",
 		),
 	}
+}
+
+func missingBucketPublicAccessBlockSettings(cfg *s3types.PublicAccessBlockConfiguration) []string {
+	missing := make([]string, 0, 4)
+	if cfg == nil || !awssdk.ToBool(cfg.BlockPublicAcls) {
+		missing = append(missing, "BlockPublicAcls")
+	}
+	if cfg == nil || !awssdk.ToBool(cfg.IgnorePublicAcls) {
+		missing = append(missing, "IgnorePublicAcls")
+	}
+	if cfg == nil || !awssdk.ToBool(cfg.BlockPublicPolicy) {
+		missing = append(missing, "BlockPublicPolicy")
+	}
+	if cfg == nil || !awssdk.ToBool(cfg.RestrictPublicBuckets) {
+		missing = append(missing, "RestrictPublicBuckets")
+	}
+	return missing
+}
+
+func isMissingBucketPublicAccessBlockConfiguration(err error) bool {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) && apiErr.ErrorCode() == "NoSuchPublicAccessBlockConfiguration" {
+		return true
+	}
+
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "nosuchpublicaccessblockconfiguration") ||
+		strings.Contains(text, "no such public access block configuration")
 }
 
 func bucketAclIsPublic(output *s3.GetBucketAclOutput) bool {

--- a/internal/services/aws/inspector_rules_s3_test.go
+++ b/internal/services/aws/inspector_rules_s3_test.go
@@ -2,14 +2,16 @@ package aws
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
 )
 
-func TestRunS3InspectorScan_FindsPublicACLPolicyAndVersioning(t *testing.T) {
+func TestRunS3InspectorScan_FindsPublicACLPolicyPublicAccessBlockAndVersioning(t *testing.T) {
 	mock := &mockS3Client{
 		listBucketsFunc: func(_ context.Context, _ *s3.ListBucketsInput, _ ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
 			return &s3.ListBucketsOutput{
@@ -31,6 +33,19 @@ func TestRunS3InspectorScan_FindsPublicACLPolicyAndVersioning(t *testing.T) {
 						},
 						Permission: s3types.PermissionRead,
 					},
+				},
+			}, nil
+		},
+		getPublicAccessBlockFunc: func(_ context.Context, in *s3.GetPublicAccessBlockInput, _ ...func(*s3.Options)) (*s3.GetPublicAccessBlockOutput, error) {
+			if awssdk.ToString(in.Bucket) != "public-bucket" {
+				t.Fatalf("unexpected bucket for public access block lookup: %q", awssdk.ToString(in.Bucket))
+			}
+			return &s3.GetPublicAccessBlockOutput{
+				PublicAccessBlockConfiguration: &s3types.PublicAccessBlockConfiguration{
+					BlockPublicAcls:       awssdk.Bool(false),
+					IgnorePublicAcls:      awssdk.Bool(false),
+					BlockPublicPolicy:     awssdk.Bool(false),
+					RestrictPublicBuckets: awssdk.Bool(false),
 				},
 			}, nil
 		},
@@ -56,18 +71,21 @@ func TestRunS3InspectorScan_FindsPublicACLPolicyAndVersioning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(findings) != 3 {
-		t.Fatalf("expected 3 findings, got %d", len(findings))
+	if len(findings) != 4 {
+		t.Fatalf("expected 4 findings, got %d", len(findings))
 	}
 
-	if findings[0].RuleID != "s3-bucket-public-acl" || findings[0].Severity != RuleSeverityHigh {
+	if findings[0].RuleID != s3InspectorRuleIDPublicACL || findings[0].Severity != RuleSeverityHigh {
 		t.Fatalf("unexpected ACL finding: %+v", findings[0])
 	}
-	if findings[1].RuleID != "s3-bucket-public-policy" || findings[1].Severity != RuleSeverityCritical {
+	if findings[1].RuleID != s3InspectorRuleIDPublicPolicy || findings[1].Severity != RuleSeverityCritical {
 		t.Fatalf("unexpected policy finding: %+v", findings[1])
 	}
-	if findings[2].RuleID != "s3-bucket-versioning-disabled" || findings[2].Severity != RuleSeverityMedium {
-		t.Fatalf("unexpected versioning finding: %+v", findings[2])
+	if findings[2].RuleID != s3InspectorRuleIDPublicAccess || findings[2].Severity != RuleSeverityHigh {
+		t.Fatalf("unexpected public access block finding: %+v", findings[2])
+	}
+	if findings[3].RuleID != s3InspectorRuleIDVersioning || findings[3].Severity != RuleSeverityMedium {
+		t.Fatalf("unexpected versioning finding: %+v", findings[3])
 	}
 }
 
@@ -82,6 +100,16 @@ func TestRunS3InspectorScan_IgnoresPrivateBuckets(t *testing.T) {
 		},
 		getBucketAclFunc: func(_ context.Context, _ *s3.GetBucketAclInput, _ ...func(*s3.Options)) (*s3.GetBucketAclOutput, error) {
 			return &s3.GetBucketAclOutput{}, nil
+		},
+		getPublicAccessBlockFunc: func(_ context.Context, _ *s3.GetPublicAccessBlockInput, _ ...func(*s3.Options)) (*s3.GetPublicAccessBlockOutput, error) {
+			return &s3.GetPublicAccessBlockOutput{
+				PublicAccessBlockConfiguration: &s3types.PublicAccessBlockConfiguration{
+					BlockPublicAcls:       awssdk.Bool(true),
+					IgnorePublicAcls:      awssdk.Bool(true),
+					BlockPublicPolicy:     awssdk.Bool(true),
+					RestrictPublicBuckets: awssdk.Bool(true),
+				},
+			}, nil
 		},
 		getBucketPolicyStatusFunc: func(_ context.Context, _ *s3.GetBucketPolicyStatusInput, _ ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error) {
 			return &s3.GetBucketPolicyStatusOutput{
@@ -99,6 +127,50 @@ func TestRunS3InspectorScan_IgnoresPrivateBuckets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+func TestInspectS3BucketPublicAccessBlock_FindsMissingConfiguration(t *testing.T) {
+	mock := &mockS3Client{
+		getPublicAccessBlockFunc: func(_ context.Context, _ *s3.GetPublicAccessBlockInput, _ ...func(*s3.Options)) (*s3.GetPublicAccessBlockOutput, error) {
+			return nil, &smithy.GenericAPIError{
+				Code:    "NoSuchPublicAccessBlockConfiguration",
+				Message: "bucket has no public access block configuration",
+			}
+		},
+	}
+
+	findings := inspectS3BucketPublicAccessBlock(context.Background(), &AwsRepository{S3Client: mock}, S3Bucket{Name: "bucket-a"})
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].RuleID != s3InspectorRuleIDPublicAccess || findings[0].Severity != RuleSeverityHigh {
+		t.Fatalf("unexpected finding: %+v", findings[0])
+	}
+	for _, want := range []string{"BlockPublicAcls", "IgnorePublicAcls", "BlockPublicPolicy", "RestrictPublicBuckets"} {
+		if !strings.Contains(findings[0].Summary, want) {
+			t.Fatalf("expected summary to mention %q, got %q", want, findings[0].Summary)
+		}
+	}
+}
+
+func TestInspectS3BucketPublicAccessBlock_IgnoresFullyEnabledBuckets(t *testing.T) {
+	mock := &mockS3Client{
+		getPublicAccessBlockFunc: func(_ context.Context, _ *s3.GetPublicAccessBlockInput, _ ...func(*s3.Options)) (*s3.GetPublicAccessBlockOutput, error) {
+			return &s3.GetPublicAccessBlockOutput{
+				PublicAccessBlockConfiguration: &s3types.PublicAccessBlockConfiguration{
+					BlockPublicAcls:       awssdk.Bool(true),
+					IgnorePublicAcls:      awssdk.Bool(true),
+					BlockPublicPolicy:     awssdk.Bool(true),
+					RestrictPublicBuckets: awssdk.Bool(true),
+				},
+			}, nil
+		},
+	}
+
+	findings := inspectS3BucketPublicAccessBlock(context.Background(), &AwsRepository{S3Client: mock}, S3Bucket{Name: "bucket-a"})
 	if len(findings) != 0 {
 		t.Fatalf("expected no findings, got %d", len(findings))
 	}

--- a/internal/services/aws/inspector_rules_snapshots.go
+++ b/internal/services/aws/inspector_rules_snapshots.go
@@ -1,0 +1,273 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+)
+
+const (
+	inspectorScannerSnapshotExposureName = "snapshot-exposure"
+
+	inspectorRuleIDRDSDBSnapshotPublic      = "rds-db-snapshot-public"
+	inspectorRuleIDRDSClusterSnapshotPublic = "rds-cluster-snapshot-public"
+	inspectorRuleIDEBSSnapshotPublic        = "ebs-snapshot-public"
+	rdsManualSnapshotType                   = "manual"
+)
+
+func init() {
+	registerSecurityInspectorScanner(InspectorScanner{
+		Name: inspectorScannerSnapshotExposureName,
+		Run:  runSnapshotExposureScan,
+	})
+}
+
+func runSnapshotExposureScan(ctx context.Context, repo *AwsRepository) ([]SecurityFinding, error) {
+	rdsFindings, err := inspectPublicRDSSnapshots(ctx, repo.RDSClient)
+	if err != nil {
+		return nil, err
+	}
+
+	rdsClusterFindings, err := inspectPublicRDSClusterSnapshots(ctx, repo.RDSClient)
+	if err != nil {
+		return nil, err
+	}
+
+	ebsFindings, err := inspectPublicEBSSnapshots(ctx, repo.EC2Client)
+	if err != nil {
+		return nil, err
+	}
+
+	findings := append(rdsFindings, rdsClusterFindings...)
+	findings = append(findings, ebsFindings...)
+
+	sort.Slice(findings, func(i, j int) bool {
+		left := normalizedSortKey(findings[i].ResourceID, findings[i].RuleID, findings[i].RuleName)
+		right := normalizedSortKey(findings[j].ResourceID, findings[j].RuleID, findings[j].RuleName)
+		if left == right {
+			return findings[i].Severity.Rank() < findings[j].Severity.Rank()
+		}
+		return left < right
+	})
+
+	return findings, nil
+}
+
+func inspectPublicRDSSnapshots(ctx context.Context, client RDSClientAPI) ([]SecurityFinding, error) {
+	var findings []SecurityFinding
+	marker := ""
+
+	for {
+		input := &rds.DescribeDBSnapshotsInput{
+			SnapshotType: awssdk.String(rdsManualSnapshotType),
+		}
+		if marker != "" {
+			input.Marker = awssdk.String(marker)
+		}
+
+		page, err := client.DescribeDBSnapshots(ctx, input)
+		if err != nil {
+			return nil, fmt.Errorf("failed to inspect DB snapshots: %w", err)
+		}
+
+		for _, snapshot := range page.DBSnapshots {
+			snapshotID := awssdk.ToString(snapshot.DBSnapshotIdentifier)
+			if snapshotID == "" {
+				continue
+			}
+
+			attributes, err := client.DescribeDBSnapshotAttributes(ctx, &rds.DescribeDBSnapshotAttributesInput{
+				DBSnapshotIdentifier: snapshot.DBSnapshotIdentifier,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to inspect DB snapshot attributes for %s: %w", snapshotID, err)
+			}
+
+			if attributes.DBSnapshotAttributesResult == nil || !isPublicRDSRestoreAttribute(attributes.DBSnapshotAttributesResult.DBSnapshotAttributes) {
+				continue
+			}
+
+			findings = append(findings, SecurityFinding{
+				RuleID:       inspectorRuleIDRDSDBSnapshotPublic,
+				RuleName:     "RDS DB snapshot publicly shared",
+				Severity:     RuleSeverityHigh,
+				ResourceType: "RDSSnapshot",
+				ResourceID:   snapshotID,
+				Summary: fmt.Sprintf(
+					"Manual DB snapshot %s from %s is publicly restorable.",
+					snapshotID,
+					awssdk.ToString(snapshot.DBInstanceIdentifier),
+				),
+				Recommendation: "Remove the public restore permission from the snapshot and share it only with specific AWS accounts when needed.",
+			})
+		}
+
+		if awssdk.ToString(page.Marker) == "" {
+			break
+		}
+		marker = awssdk.ToString(page.Marker)
+	}
+
+	return findings, nil
+}
+
+func inspectPublicRDSClusterSnapshots(ctx context.Context, client RDSClientAPI) ([]SecurityFinding, error) {
+	var findings []SecurityFinding
+	marker := ""
+
+	for {
+		input := &rds.DescribeDBClusterSnapshotsInput{
+			SnapshotType: awssdk.String(rdsManualSnapshotType),
+		}
+		if marker != "" {
+			input.Marker = awssdk.String(marker)
+		}
+
+		page, err := client.DescribeDBClusterSnapshots(ctx, input)
+		if err != nil {
+			return nil, fmt.Errorf("failed to inspect DB cluster snapshots: %w", err)
+		}
+
+		for _, snapshot := range page.DBClusterSnapshots {
+			snapshotID := awssdk.ToString(snapshot.DBClusterSnapshotIdentifier)
+			if snapshotID == "" {
+				continue
+			}
+
+			attributes, err := client.DescribeDBClusterSnapshotAttributes(ctx, &rds.DescribeDBClusterSnapshotAttributesInput{
+				DBClusterSnapshotIdentifier: snapshot.DBClusterSnapshotIdentifier,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to inspect DB cluster snapshot attributes for %s: %w", snapshotID, err)
+			}
+
+			if attributes.DBClusterSnapshotAttributesResult == nil || !isPublicRDSClusterRestoreAttribute(attributes.DBClusterSnapshotAttributesResult.DBClusterSnapshotAttributes) {
+				continue
+			}
+
+			findings = append(findings, SecurityFinding{
+				RuleID:       inspectorRuleIDRDSClusterSnapshotPublic,
+				RuleName:     "RDS cluster snapshot publicly shared",
+				Severity:     RuleSeverityHigh,
+				ResourceType: "RDSClusterSnapshot",
+				ResourceID:   snapshotID,
+				Summary: fmt.Sprintf(
+					"Manual DB cluster snapshot %s from %s is publicly restorable.",
+					snapshotID,
+					awssdk.ToString(snapshot.DBClusterIdentifier),
+				),
+				Recommendation: "Remove the public restore permission from the cluster snapshot and share it only with explicitly authorized AWS accounts.",
+			})
+		}
+
+		if awssdk.ToString(page.Marker) == "" {
+			break
+		}
+		marker = awssdk.ToString(page.Marker)
+	}
+
+	return findings, nil
+}
+
+func inspectPublicEBSSnapshots(ctx context.Context, client EC2ClientAPI) ([]SecurityFinding, error) {
+	var findings []SecurityFinding
+	nextToken := ""
+
+	for {
+		input := &ec2.DescribeSnapshotsInput{
+			OwnerIds: []string{"self"},
+		}
+		if nextToken != "" {
+			input.NextToken = awssdk.String(nextToken)
+		}
+
+		page, err := client.DescribeSnapshots(ctx, input)
+		if err != nil {
+			return nil, fmt.Errorf("failed to inspect EBS snapshots: %w", err)
+		}
+
+		for _, snapshot := range page.Snapshots {
+			snapshotID := awssdk.ToString(snapshot.SnapshotId)
+			if snapshotID == "" {
+				continue
+			}
+
+			attributes, err := client.DescribeSnapshotAttribute(ctx, &ec2.DescribeSnapshotAttributeInput{
+				Attribute:  ec2types.SnapshotAttributeNameCreateVolumePermission,
+				SnapshotId: snapshot.SnapshotId,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to inspect EBS snapshot permissions for %s: %w", snapshotID, err)
+			}
+
+			if !isPublicCreateVolumePermission(attributes.CreateVolumePermissions) {
+				continue
+			}
+
+			findings = append(findings, SecurityFinding{
+				RuleID:       inspectorRuleIDEBSSnapshotPublic,
+				RuleName:     "EBS snapshot publicly shared",
+				Severity:     RuleSeverityHigh,
+				ResourceType: "EBSSnapshot",
+				ResourceID:   snapshotID,
+				Summary: fmt.Sprintf(
+					"EBS snapshot %s for volume %s grants public create-volume permissions.",
+					snapshotID,
+					awssdk.ToString(snapshot.VolumeId),
+				),
+				Recommendation: "Remove the public create-volume permission and share the snapshot only with explicitly authorized AWS accounts.",
+			})
+		}
+
+		if awssdk.ToString(page.NextToken) == "" {
+			break
+		}
+		nextToken = awssdk.ToString(page.NextToken)
+	}
+
+	return findings, nil
+}
+
+func isPublicRDSRestoreAttribute(attributes []rdstypes.DBSnapshotAttribute) bool {
+	for _, attribute := range attributes {
+		if !strings.EqualFold(awssdk.ToString(attribute.AttributeName), "restore") {
+			continue
+		}
+		for _, value := range attribute.AttributeValues {
+			if strings.EqualFold(value, "all") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isPublicRDSClusterRestoreAttribute(attributes []rdstypes.DBClusterSnapshotAttribute) bool {
+	for _, attribute := range attributes {
+		if !strings.EqualFold(awssdk.ToString(attribute.AttributeName), "restore") {
+			continue
+		}
+		for _, value := range attribute.AttributeValues {
+			if strings.EqualFold(value, "all") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isPublicCreateVolumePermission(permissions []ec2types.CreateVolumePermission) bool {
+	for _, permission := range permissions {
+		if strings.EqualFold(string(permission.Group), "all") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/services/aws/inspector_rules_snapshots_test.go
+++ b/internal/services/aws/inspector_rules_snapshots_test.go
@@ -1,0 +1,183 @@
+package aws
+
+import (
+	"context"
+	"testing"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+)
+
+func TestRunSnapshotExposureScan_FindsPublicSnapshots(t *testing.T) {
+	mockRDS := &mockRDSClient{
+		describeDBSnapshotsFunc: func(context.Context, *rds.DescribeDBSnapshotsInput, ...func(*rds.Options)) (*rds.DescribeDBSnapshotsOutput, error) {
+			return &rds.DescribeDBSnapshotsOutput{
+				DBSnapshots: []rdstypes.DBSnapshot{
+					{
+						DBSnapshotIdentifier: awssdk.String("db-snap-public"),
+						DBInstanceIdentifier: awssdk.String("app-db"),
+					},
+				},
+			}, nil
+		},
+		describeDBSnapshotAttributesFunc: func(_ context.Context, params *rds.DescribeDBSnapshotAttributesInput, _ ...func(*rds.Options)) (*rds.DescribeDBSnapshotAttributesOutput, error) {
+			if awssdk.ToString(params.DBSnapshotIdentifier) != "db-snap-public" {
+				t.Fatalf("unexpected DB snapshot identifier %q", awssdk.ToString(params.DBSnapshotIdentifier))
+			}
+			return &rds.DescribeDBSnapshotAttributesOutput{
+				DBSnapshotAttributesResult: &rdstypes.DBSnapshotAttributesResult{
+					DBSnapshotAttributes: []rdstypes.DBSnapshotAttribute{
+						{
+							AttributeName:   awssdk.String("restore"),
+							AttributeValues: []string{"all"},
+						},
+					},
+				},
+			}, nil
+		},
+		describeDBClusterSnapshotsFunc: func(context.Context, *rds.DescribeDBClusterSnapshotsInput, ...func(*rds.Options)) (*rds.DescribeDBClusterSnapshotsOutput, error) {
+			return &rds.DescribeDBClusterSnapshotsOutput{
+				DBClusterSnapshots: []rdstypes.DBClusterSnapshot{
+					{
+						DBClusterSnapshotIdentifier: awssdk.String("cluster-snap-public"),
+						DBClusterIdentifier:         awssdk.String("aurora-prod"),
+					},
+				},
+			}, nil
+		},
+		describeDBClusterSnapshotAttrsFunc: func(_ context.Context, params *rds.DescribeDBClusterSnapshotAttributesInput, _ ...func(*rds.Options)) (*rds.DescribeDBClusterSnapshotAttributesOutput, error) {
+			if awssdk.ToString(params.DBClusterSnapshotIdentifier) != "cluster-snap-public" {
+				t.Fatalf("unexpected DB cluster snapshot identifier %q", awssdk.ToString(params.DBClusterSnapshotIdentifier))
+			}
+			return &rds.DescribeDBClusterSnapshotAttributesOutput{
+				DBClusterSnapshotAttributesResult: &rdstypes.DBClusterSnapshotAttributesResult{
+					DBClusterSnapshotAttributes: []rdstypes.DBClusterSnapshotAttribute{
+						{
+							AttributeName:   awssdk.String("restore"),
+							AttributeValues: []string{"all"},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	mockEC2 := &mockEC2Client{
+		describeSnapshotsFunc: func(context.Context, *ec2.DescribeSnapshotsInput, ...func(*ec2.Options)) (*ec2.DescribeSnapshotsOutput, error) {
+			return &ec2.DescribeSnapshotsOutput{
+				Snapshots: []ec2types.Snapshot{
+					{
+						SnapshotId: awssdk.String("snap-public"),
+						VolumeId:   awssdk.String("vol-123"),
+					},
+				},
+			}, nil
+		},
+		describeSnapshotAttributeFunc: func(_ context.Context, params *ec2.DescribeSnapshotAttributeInput, _ ...func(*ec2.Options)) (*ec2.DescribeSnapshotAttributeOutput, error) {
+			if awssdk.ToString(params.SnapshotId) != "snap-public" {
+				t.Fatalf("unexpected EBS snapshot identifier %q", awssdk.ToString(params.SnapshotId))
+			}
+			return &ec2.DescribeSnapshotAttributeOutput{
+				CreateVolumePermissions: []ec2types.CreateVolumePermission{
+					{Group: ec2types.PermissionGroup("all")},
+				},
+			}, nil
+		},
+	}
+
+	findings, err := runSnapshotExposureScan(context.Background(), &AwsRepository{
+		RDSClient: mockRDS,
+		EC2Client: mockEC2,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 3 {
+		t.Fatalf("expected 3 public-snapshot findings, got %d", len(findings))
+	}
+
+	expectedRuleIDs := map[string]bool{
+		inspectorRuleIDRDSDBSnapshotPublic:      false,
+		inspectorRuleIDRDSClusterSnapshotPublic: false,
+		inspectorRuleIDEBSSnapshotPublic:        false,
+	}
+	for _, finding := range findings {
+		expectedRuleIDs[finding.RuleID] = true
+		if finding.Severity != RuleSeverityHigh {
+			t.Fatalf("expected high severity for public snapshot finding, got %+v", finding)
+		}
+	}
+	for ruleID, seen := range expectedRuleIDs {
+		if !seen {
+			t.Fatalf("missing snapshot finding for %s: %+v", ruleID, findings)
+		}
+	}
+}
+
+func TestRunSnapshotExposureScan_IgnoresPrivateSnapshots(t *testing.T) {
+	mockRDS := &mockRDSClient{
+		describeDBSnapshotsFunc: func(context.Context, *rds.DescribeDBSnapshotsInput, ...func(*rds.Options)) (*rds.DescribeDBSnapshotsOutput, error) {
+			return &rds.DescribeDBSnapshotsOutput{
+				DBSnapshots: []rdstypes.DBSnapshot{{DBSnapshotIdentifier: awssdk.String("db-snap-private")}},
+			}, nil
+		},
+		describeDBSnapshotAttributesFunc: func(context.Context, *rds.DescribeDBSnapshotAttributesInput, ...func(*rds.Options)) (*rds.DescribeDBSnapshotAttributesOutput, error) {
+			return &rds.DescribeDBSnapshotAttributesOutput{
+				DBSnapshotAttributesResult: &rdstypes.DBSnapshotAttributesResult{
+					DBSnapshotAttributes: []rdstypes.DBSnapshotAttribute{
+						{
+							AttributeName:   awssdk.String("restore"),
+							AttributeValues: []string{"123456789012"},
+						},
+					},
+				},
+			}, nil
+		},
+		describeDBClusterSnapshotsFunc: func(context.Context, *rds.DescribeDBClusterSnapshotsInput, ...func(*rds.Options)) (*rds.DescribeDBClusterSnapshotsOutput, error) {
+			return &rds.DescribeDBClusterSnapshotsOutput{
+				DBClusterSnapshots: []rdstypes.DBClusterSnapshot{{DBClusterSnapshotIdentifier: awssdk.String("cluster-snap-private")}},
+			}, nil
+		},
+		describeDBClusterSnapshotAttrsFunc: func(context.Context, *rds.DescribeDBClusterSnapshotAttributesInput, ...func(*rds.Options)) (*rds.DescribeDBClusterSnapshotAttributesOutput, error) {
+			return &rds.DescribeDBClusterSnapshotAttributesOutput{
+				DBClusterSnapshotAttributesResult: &rdstypes.DBClusterSnapshotAttributesResult{
+					DBClusterSnapshotAttributes: []rdstypes.DBClusterSnapshotAttribute{
+						{
+							AttributeName:   awssdk.String("restore"),
+							AttributeValues: []string{"123456789012"},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	mockEC2 := &mockEC2Client{
+		describeSnapshotsFunc: func(context.Context, *ec2.DescribeSnapshotsInput, ...func(*ec2.Options)) (*ec2.DescribeSnapshotsOutput, error) {
+			return &ec2.DescribeSnapshotsOutput{
+				Snapshots: []ec2types.Snapshot{{SnapshotId: awssdk.String("snap-private")}},
+			}, nil
+		},
+		describeSnapshotAttributeFunc: func(context.Context, *ec2.DescribeSnapshotAttributeInput, ...func(*ec2.Options)) (*ec2.DescribeSnapshotAttributeOutput, error) {
+			return &ec2.DescribeSnapshotAttributeOutput{
+				CreateVolumePermissions: []ec2types.CreateVolumePermission{
+					{UserId: awssdk.String("123456789012")},
+				},
+			}, nil
+		},
+	}
+
+	findings, err := runSnapshotExposureScan(context.Background(), &AwsRepository{
+		RDSClient: mockRDS,
+		EC2Client: mockEC2,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings for private snapshots, got %+v", findings)
+	}
+}

--- a/internal/services/aws/rds_test.go
+++ b/internal/services/aws/rds_test.go
@@ -13,17 +13,49 @@ import (
 
 // mockRDSClient implements RDSClientAPI for testing.
 type mockRDSClient struct {
-	describeDBInstancesFunc func(ctx context.Context, params *rds.DescribeDBInstancesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error)
-	stopDBInstanceFunc      func(ctx context.Context, params *rds.StopDBInstanceInput, optFns ...func(*rds.Options)) (*rds.StopDBInstanceOutput, error)
-	startDBInstanceFunc     func(ctx context.Context, params *rds.StartDBInstanceInput, optFns ...func(*rds.Options)) (*rds.StartDBInstanceOutput, error)
-	rebootDBInstanceFunc    func(ctx context.Context, params *rds.RebootDBInstanceInput, optFns ...func(*rds.Options)) (*rds.RebootDBInstanceOutput, error)
-	stopDBClusterFunc       func(ctx context.Context, params *rds.StopDBClusterInput, optFns ...func(*rds.Options)) (*rds.StopDBClusterOutput, error)
-	startDBClusterFunc      func(ctx context.Context, params *rds.StartDBClusterInput, optFns ...func(*rds.Options)) (*rds.StartDBClusterOutput, error)
-	failoverDBClusterFunc   func(ctx context.Context, params *rds.FailoverDBClusterInput, optFns ...func(*rds.Options)) (*rds.FailoverDBClusterOutput, error)
+	describeDBInstancesFunc            func(ctx context.Context, params *rds.DescribeDBInstancesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error)
+	describeDBSnapshotsFunc            func(ctx context.Context, params *rds.DescribeDBSnapshotsInput, optFns ...func(*rds.Options)) (*rds.DescribeDBSnapshotsOutput, error)
+	describeDBSnapshotAttributesFunc   func(ctx context.Context, params *rds.DescribeDBSnapshotAttributesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBSnapshotAttributesOutput, error)
+	describeDBClusterSnapshotsFunc     func(ctx context.Context, params *rds.DescribeDBClusterSnapshotsInput, optFns ...func(*rds.Options)) (*rds.DescribeDBClusterSnapshotsOutput, error)
+	describeDBClusterSnapshotAttrsFunc func(ctx context.Context, params *rds.DescribeDBClusterSnapshotAttributesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBClusterSnapshotAttributesOutput, error)
+	stopDBInstanceFunc                 func(ctx context.Context, params *rds.StopDBInstanceInput, optFns ...func(*rds.Options)) (*rds.StopDBInstanceOutput, error)
+	startDBInstanceFunc                func(ctx context.Context, params *rds.StartDBInstanceInput, optFns ...func(*rds.Options)) (*rds.StartDBInstanceOutput, error)
+	rebootDBInstanceFunc               func(ctx context.Context, params *rds.RebootDBInstanceInput, optFns ...func(*rds.Options)) (*rds.RebootDBInstanceOutput, error)
+	stopDBClusterFunc                  func(ctx context.Context, params *rds.StopDBClusterInput, optFns ...func(*rds.Options)) (*rds.StopDBClusterOutput, error)
+	startDBClusterFunc                 func(ctx context.Context, params *rds.StartDBClusterInput, optFns ...func(*rds.Options)) (*rds.StartDBClusterOutput, error)
+	failoverDBClusterFunc              func(ctx context.Context, params *rds.FailoverDBClusterInput, optFns ...func(*rds.Options)) (*rds.FailoverDBClusterOutput, error)
 }
 
 func (m *mockRDSClient) DescribeDBInstances(ctx context.Context, params *rds.DescribeDBInstancesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error) {
 	return m.describeDBInstancesFunc(ctx, params, optFns...)
+}
+
+func (m *mockRDSClient) DescribeDBSnapshots(ctx context.Context, params *rds.DescribeDBSnapshotsInput, optFns ...func(*rds.Options)) (*rds.DescribeDBSnapshotsOutput, error) {
+	if m.describeDBSnapshotsFunc != nil {
+		return m.describeDBSnapshotsFunc(ctx, params, optFns...)
+	}
+	return &rds.DescribeDBSnapshotsOutput{}, nil
+}
+
+func (m *mockRDSClient) DescribeDBSnapshotAttributes(ctx context.Context, params *rds.DescribeDBSnapshotAttributesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBSnapshotAttributesOutput, error) {
+	if m.describeDBSnapshotAttributesFunc != nil {
+		return m.describeDBSnapshotAttributesFunc(ctx, params, optFns...)
+	}
+	return &rds.DescribeDBSnapshotAttributesOutput{}, nil
+}
+
+func (m *mockRDSClient) DescribeDBClusterSnapshots(ctx context.Context, params *rds.DescribeDBClusterSnapshotsInput, optFns ...func(*rds.Options)) (*rds.DescribeDBClusterSnapshotsOutput, error) {
+	if m.describeDBClusterSnapshotsFunc != nil {
+		return m.describeDBClusterSnapshotsFunc(ctx, params, optFns...)
+	}
+	return &rds.DescribeDBClusterSnapshotsOutput{}, nil
+}
+
+func (m *mockRDSClient) DescribeDBClusterSnapshotAttributes(ctx context.Context, params *rds.DescribeDBClusterSnapshotAttributesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBClusterSnapshotAttributesOutput, error) {
+	if m.describeDBClusterSnapshotAttrsFunc != nil {
+		return m.describeDBClusterSnapshotAttrsFunc(ctx, params, optFns...)
+	}
+	return &rds.DescribeDBClusterSnapshotAttributesOutput{}, nil
 }
 
 func (m *mockRDSClient) StopDBInstance(ctx context.Context, params *rds.StopDBInstanceInput, optFns ...func(*rds.Options)) (*rds.StopDBInstanceOutput, error) {

--- a/internal/services/aws/repository.go
+++ b/internal/services/aws/repository.go
@@ -7,9 +7,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/cloudtrail"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go-v2/service/configservice"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+	"github.com/aws/aws-sdk-go-v2/service/guardduty"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
@@ -46,8 +50,20 @@ var _ STSClientAPI = (*sts.Client)(nil)
 // Verify *cloudwatchlogs.Client satisfies CloudWatchLogsClientAPI at compile time.
 var _ CloudWatchLogsClientAPI = (*cloudwatchlogs.Client)(nil)
 
+// Verify *cloudtrail.Client satisfies CloudTrailClientAPI at compile time.
+var _ CloudTrailClientAPI = (*cloudtrail.Client)(nil)
+
+// Verify *guardduty.Client satisfies GuardDutyClientAPI at compile time.
+var _ GuardDutyClientAPI = (*guardduty.Client)(nil)
+
+// Verify *configservice.Client satisfies ConfigServiceClientAPI at compile time.
+var _ ConfigServiceClientAPI = (*configservice.Client)(nil)
+
 // Verify *ecs.Client satisfies ECSClientAPI at compile time.
 var _ ECSClientAPI = (*ecs.Client)(nil)
+
+// Verify *elasticache.Client satisfies ElastiCacheClientAPI at compile time.
+var _ ElastiCacheClientAPI = (*elasticache.Client)(nil)
 
 // Verify *s3.Client satisfies S3ClientAPI at compile time.
 var _ S3ClientAPI = (*s3.Client)(nil)
@@ -62,6 +78,10 @@ type SSMClientAPI interface {
 // RDSClientAPI is the interface for RDS operations used by AwsRepository.
 type RDSClientAPI interface {
 	DescribeDBInstances(ctx context.Context, params *rds.DescribeDBInstancesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error)
+	DescribeDBSnapshots(ctx context.Context, params *rds.DescribeDBSnapshotsInput, optFns ...func(*rds.Options)) (*rds.DescribeDBSnapshotsOutput, error)
+	DescribeDBSnapshotAttributes(ctx context.Context, params *rds.DescribeDBSnapshotAttributesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBSnapshotAttributesOutput, error)
+	DescribeDBClusterSnapshots(ctx context.Context, params *rds.DescribeDBClusterSnapshotsInput, optFns ...func(*rds.Options)) (*rds.DescribeDBClusterSnapshotsOutput, error)
+	DescribeDBClusterSnapshotAttributes(ctx context.Context, params *rds.DescribeDBClusterSnapshotAttributesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBClusterSnapshotAttributesOutput, error)
 	StopDBInstance(ctx context.Context, params *rds.StopDBInstanceInput, optFns ...func(*rds.Options)) (*rds.StopDBInstanceOutput, error)
 	StartDBInstance(ctx context.Context, params *rds.StartDBInstanceInput, optFns ...func(*rds.Options)) (*rds.StartDBInstanceOutput, error)
 	RebootDBInstance(ctx context.Context, params *rds.RebootDBInstanceInput, optFns ...func(*rds.Options)) (*rds.RebootDBInstanceOutput, error)
@@ -88,6 +108,8 @@ type SecretsManagerClientAPI interface {
 type IAMClientAPI interface {
 	ListUsers(ctx context.Context, params *iam.ListUsersInput, optFns ...func(*iam.Options)) (*iam.ListUsersOutput, error)
 	GetUser(ctx context.Context, params *iam.GetUserInput, optFns ...func(*iam.Options)) (*iam.GetUserOutput, error)
+	GetAccountSummary(ctx context.Context, params *iam.GetAccountSummaryInput, optFns ...func(*iam.Options)) (*iam.GetAccountSummaryOutput, error)
+	GetAccountAuthorizationDetails(ctx context.Context, params *iam.GetAccountAuthorizationDetailsInput, optFns ...func(*iam.Options)) (*iam.GetAccountAuthorizationDetailsOutput, error)
 	ListGroupsForUser(ctx context.Context, params *iam.ListGroupsForUserInput, optFns ...func(*iam.Options)) (*iam.ListGroupsForUserOutput, error)
 	ListAttachedUserPolicies(ctx context.Context, params *iam.ListAttachedUserPoliciesInput, optFns ...func(*iam.Options)) (*iam.ListAttachedUserPoliciesOutput, error)
 	ListMFADevices(ctx context.Context, params *iam.ListMFADevicesInput, optFns ...func(*iam.Options)) (*iam.ListMFADevicesOutput, error)
@@ -109,6 +131,24 @@ type CloudWatchLogsClientAPI interface {
 	FilterLogEvents(ctx context.Context, params *cloudwatchlogs.FilterLogEventsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.FilterLogEventsOutput, error)
 }
 
+// CloudTrailClientAPI is the interface for CloudTrail operations used by AwsRepository.
+type CloudTrailClientAPI interface {
+	DescribeTrails(ctx context.Context, params *cloudtrail.DescribeTrailsInput, optFns ...func(*cloudtrail.Options)) (*cloudtrail.DescribeTrailsOutput, error)
+	GetTrailStatus(ctx context.Context, params *cloudtrail.GetTrailStatusInput, optFns ...func(*cloudtrail.Options)) (*cloudtrail.GetTrailStatusOutput, error)
+}
+
+// GuardDutyClientAPI is the interface for GuardDuty operations used by AwsRepository.
+type GuardDutyClientAPI interface {
+	ListDetectors(ctx context.Context, params *guardduty.ListDetectorsInput, optFns ...func(*guardduty.Options)) (*guardduty.ListDetectorsOutput, error)
+	GetDetector(ctx context.Context, params *guardduty.GetDetectorInput, optFns ...func(*guardduty.Options)) (*guardduty.GetDetectorOutput, error)
+}
+
+// ConfigServiceClientAPI is the interface for AWS Config operations used by AwsRepository.
+type ConfigServiceClientAPI interface {
+	DescribeConfigurationRecorders(ctx context.Context, params *configservice.DescribeConfigurationRecordersInput, optFns ...func(*configservice.Options)) (*configservice.DescribeConfigurationRecordersOutput, error)
+	DescribeConfigurationRecorderStatus(ctx context.Context, params *configservice.DescribeConfigurationRecorderStatusInput, optFns ...func(*configservice.Options)) (*configservice.DescribeConfigurationRecorderStatusOutput, error)
+}
+
 // ECSClientAPI is the interface for ECS operations used by AwsRepository.
 type ECSClientAPI interface {
 	ListClusters(ctx context.Context, params *ecs.ListClustersInput, optFns ...func(*ecs.Options)) (*ecs.ListClustersOutput, error)
@@ -126,13 +166,21 @@ type S3ClientAPI interface {
 	HeadObject(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
 	GetBucketLocation(ctx context.Context, params *s3.GetBucketLocationInput, optFns ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error)
 	GetBucketAcl(ctx context.Context, params *s3.GetBucketAclInput, optFns ...func(*s3.Options)) (*s3.GetBucketAclOutput, error)
+	GetPublicAccessBlock(ctx context.Context, params *s3.GetPublicAccessBlockInput, optFns ...func(*s3.Options)) (*s3.GetPublicAccessBlockOutput, error)
 	GetBucketPolicyStatus(ctx context.Context, params *s3.GetBucketPolicyStatusInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error)
 	GetBucketVersioning(ctx context.Context, params *s3.GetBucketVersioningInput, optFns ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error)
+}
+
+// ElastiCacheClientAPI is the interface for ElastiCache operations used by AwsRepository.
+type ElastiCacheClientAPI interface {
+	DescribeReplicationGroups(ctx context.Context, params *elasticache.DescribeReplicationGroupsInput, optFns ...func(*elasticache.Options)) (*elasticache.DescribeReplicationGroupsOutput, error)
 }
 
 // EC2ClientAPI is the interface for EC2 operations used by AwsRepository.
 type EC2ClientAPI interface {
 	ec2.DescribeInstancesAPIClient
+	DescribeSnapshots(ctx context.Context, params *ec2.DescribeSnapshotsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSnapshotsOutput, error)
+	DescribeSnapshotAttribute(ctx context.Context, params *ec2.DescribeSnapshotAttributeInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSnapshotAttributeOutput, error)
 	DescribeVpcs(ctx context.Context, params *ec2.DescribeVpcsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error)
 	DescribeSubnets(ctx context.Context, params *ec2.DescribeSubnetsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error)
 	DescribeNetworkInterfaces(ctx context.Context, params *ec2.DescribeNetworkInterfacesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeNetworkInterfacesOutput, error)
@@ -162,7 +210,7 @@ type CallerIdentity struct {
 	UserID  string
 }
 
-// AwsRepository holds AWS SDK clients for EC2, SSM, RDS, Route53, STS, Secrets Manager, IAM, CloudWatch Logs, and ECS.
+// AwsRepository holds AWS SDK clients for the AWS services used throughout unic.
 type AwsRepository struct {
 	EC2Client            EC2ClientAPI
 	SSMClient            SSMClientAPI
@@ -172,7 +220,11 @@ type AwsRepository struct {
 	IAMClient            IAMClientAPI
 	STSClient            STSClientAPI
 	CloudWatchLogsClient CloudWatchLogsClientAPI
+	CloudTrailClient     CloudTrailClientAPI
+	GuardDutyClient      GuardDutyClientAPI
+	ConfigServiceClient  ConfigServiceClientAPI
 	ECSClient            ECSClientAPI
+	ElastiCacheClient    ElastiCacheClientAPI
 	S3Client             S3ClientAPI
 	Region               string
 	Profile              string
@@ -232,7 +284,11 @@ func NewAwsRepository(ctx context.Context, cfg *config.Config) (*AwsRepository, 
 		IAMClient:            iam.NewFromConfig(awsCfg),
 		STSClient:            sts.NewFromConfig(awsCfg),
 		CloudWatchLogsClient: cloudwatchlogs.NewFromConfig(awsCfg),
+		CloudTrailClient:     cloudtrail.NewFromConfig(awsCfg),
+		GuardDutyClient:      guardduty.NewFromConfig(awsCfg),
+		ConfigServiceClient:  configservice.NewFromConfig(awsCfg),
 		ECSClient:            ecs.NewFromConfig(awsCfg),
+		ElastiCacheClient:    elasticache.NewFromConfig(awsCfg),
 		S3Client:             s3.NewFromConfig(awsCfg),
 		Region:               cfg.Region,
 		Profile:              cfg.Profile,

--- a/internal/services/aws/s3_test.go
+++ b/internal/services/aws/s3_test.go
@@ -18,6 +18,7 @@ type mockS3Client struct {
 	headObjectFunc            func(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
 	getBucketLocationFunc     func(ctx context.Context, params *s3.GetBucketLocationInput, optFns ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error)
 	getBucketAclFunc          func(ctx context.Context, params *s3.GetBucketAclInput, optFns ...func(*s3.Options)) (*s3.GetBucketAclOutput, error)
+	getPublicAccessBlockFunc  func(ctx context.Context, params *s3.GetPublicAccessBlockInput, optFns ...func(*s3.Options)) (*s3.GetPublicAccessBlockOutput, error)
 	getBucketPolicyStatusFunc func(ctx context.Context, params *s3.GetBucketPolicyStatusInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error)
 	getBucketVersioningFunc   func(ctx context.Context, params *s3.GetBucketVersioningInput, optFns ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error)
 }
@@ -46,6 +47,13 @@ func (m *mockS3Client) GetBucketAcl(ctx context.Context, params *s3.GetBucketAcl
 		return m.getBucketAclFunc(ctx, params, optFns...)
 	}
 	return &s3.GetBucketAclOutput{}, nil
+}
+
+func (m *mockS3Client) GetPublicAccessBlock(ctx context.Context, params *s3.GetPublicAccessBlockInput, optFns ...func(*s3.Options)) (*s3.GetPublicAccessBlockOutput, error) {
+	if m.getPublicAccessBlockFunc != nil {
+		return m.getPublicAccessBlockFunc(ctx, params, optFns...)
+	}
+	return &s3.GetPublicAccessBlockOutput{}, nil
 }
 
 func (m *mockS3Client) GetBucketPolicyStatus(ctx context.Context, params *s3.GetBucketPolicyStatusInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error) {

--- a/internal/services/aws/vpc_test.go
+++ b/internal/services/aws/vpc_test.go
@@ -20,6 +20,8 @@ type mockEC2Client struct {
 	describeVpcsFunc                    func(ctx context.Context, params *ec2.DescribeVpcsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error)
 	describeSubnetsFunc                 func(ctx context.Context, params *ec2.DescribeSubnetsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error)
 	describeInstancesFunc               func(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
+	describeSnapshotsFunc               func(ctx context.Context, params *ec2.DescribeSnapshotsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSnapshotsOutput, error)
+	describeSnapshotAttributeFunc       func(ctx context.Context, params *ec2.DescribeSnapshotAttributeInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSnapshotAttributeOutput, error)
 	describeNetworkInterfacesFunc       func(ctx context.Context, params *ec2.DescribeNetworkInterfacesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeNetworkInterfacesOutput, error)
 	describeInternetGatewaysFunc        func(ctx context.Context, params *ec2.DescribeInternetGatewaysInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInternetGatewaysOutput, error)
 	describeVpcEndpointsFunc            func(ctx context.Context, params *ec2.DescribeVpcEndpointsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcEndpointsOutput, error)
@@ -53,6 +55,20 @@ func (m *mockEC2Client) DescribeInstances(ctx context.Context, params *ec2.Descr
 		return m.describeInstancesFunc(ctx, params, optFns...)
 	}
 	return &ec2.DescribeInstancesOutput{}, nil
+}
+
+func (m *mockEC2Client) DescribeSnapshots(ctx context.Context, params *ec2.DescribeSnapshotsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSnapshotsOutput, error) {
+	if m.describeSnapshotsFunc != nil {
+		return m.describeSnapshotsFunc(ctx, params, optFns...)
+	}
+	return &ec2.DescribeSnapshotsOutput{}, nil
+}
+
+func (m *mockEC2Client) DescribeSnapshotAttribute(ctx context.Context, params *ec2.DescribeSnapshotAttributeInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSnapshotAttributeOutput, error) {
+	if m.describeSnapshotAttributeFunc != nil {
+		return m.describeSnapshotAttributeFunc(ctx, params, optFns...)
+	}
+	return &ec2.DescribeSnapshotAttributeOutput{}, nil
 }
 
 func (m *mockEC2Client) DescribeNetworkInterfaces(ctx context.Context, params *ec2.DescribeNetworkInterfacesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeNetworkInterfacesOutput, error) {


### PR DESCRIPTION

### Summary

- add Security Inspector coverage for S3 Block Public Access, root-account hardening, wildcard IAM policies, public snapshot exposure, CloudTrail baseline checks, GuardDuty and AWS Config baseline checks, and ElastiCache for Valkey security checks
- extend the AWS repository client seams and shared test mocks needed for the new scans
- update README.md coverage text and carry forward the feature skill instruction to check open PRs before implementation

### Related Issues

Closes #99
Closes #100
Closes #101
Closes #102
Closes #103
Closes #104
Closes #105

### Validation

- `make test`
- `make build`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed
- [x] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented
