### PR TITLE
refactor: add dedicated inspector mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It combines a Bubble Tea application, Cobra-based CLI commands, and AWS SDK v2 c
 - Open a context-aware keyboard shortcut help screen with `?`
 - Show animated loading indicators while async AWS data is being fetched
 - Perform operational workflows such as SSM sessions, RDS control, Route53 record changes, ECS exec, and IAM access key rotation
-- Open the Security Inspector workflow and review built-in findings for network exposure, RDS, IAM, Secrets Manager, S3, snapshot sharing, CloudTrail, GuardDuty, AWS Config, and ElastiCache for Valkey
+- Press `i` from the service picker to enter Inspector mode, then open the Security Inspector workflow for built-in findings across network exposure, RDS, IAM, Secrets Manager, S3, snapshot sharing, CloudTrail, GuardDuty, AWS Config, and ElastiCache for Valkey
 
 ## Documentation Map
 
@@ -193,6 +193,8 @@ Context ordering:
 
 ## Current Features
 
+### AWS Service Catalog
+
 | Service | Feature |
 |---|---|
 | EC2 | SSM Session Manager |
@@ -208,9 +210,15 @@ Context ordering:
 | IAM | IAM User Browser |
 | IAM | ListAccessKeys |
 | IAM | RotateAccessKey |
-| Inspector | Security Scan |
 
-The Inspector feature ships built-in rule packs for Security Group exposure, RDS encryption/public access/backups and public snapshot sharing, IAM access key age/root-account hardening/wildcard policies, Secrets Manager rotation age, S3 public access/Block Public Access/versioning, CloudTrail baseline coverage, GuardDuty and AWS Config baseline controls, and ElastiCache for Valkey encryption/backup/access-control checks.
+### Inspector Mode
+
+| Workflow | Status | Notes |
+|---|---|---|
+| Security Inspector | Ready | Runs built-in rule packs and opens severity-filtered findings |
+| Checklist Inspector | Planned | Reserved Inspector-mode slot for future checklist-style workflows |
+
+Security Inspector ships built-in rule packs for Security Group exposure, RDS encryption/public access/backups and public snapshot sharing, IAM access key age/root-account hardening/wildcard policies, Secrets Manager rotation age, S3 public access/Block Public Access/versioning, CloudTrail baseline coverage, GuardDuty and AWS Config baseline controls, and ElastiCache for Valkey encryption/backup/access-control checks.
 
 ## TUI Navigation
 
@@ -223,6 +231,7 @@ The Inspector feature ships built-in rule packs for Security Group exposure, RDS
 | `Esc` | Go back |
 | `q` | Quit from top-level screens |
 | `H` | Jump to service list |
+| `i` | Enter Inspector mode from the service list |
 | `C` | Open context picker |
 | `/` | Toggle filter mode on supported screens |
 | `?` | Toggle context-aware shortcut help |
@@ -240,7 +249,8 @@ The Inspector feature ships built-in rule packs for Security Group exposure, RDS
 | IAM Key Rotation | `r` rotate, `c` copy exports, `a` apply and verify, `d` deactivate old key, `x` delete old key |
 | CloudWatch Logs | log groups/streams load 10 at a time, `n` load more, `1`-`6` time presets, `t` live tail, `f` filter pattern, `w` wrap toggle, `h/l` horizontal scroll |
 | ECS Exec | `r` refresh, `Enter` drill down / exec |
-| Inspector | `r` run/rescan, `1`-`5` severity filter, `Enter` finding detail |
+| Inspector Mode | `i` open mode from the service list, `Enter` open the selected workflow |
+| Security Inspector | `r` run/rescan, `1`-`5` severity filter, `Enter` finding detail |
 | Context Picker | `a` add context, type or `/` filter, `s` setup selected context and quit, `y` copy selected exports and quit, `u` clear shell context and quit with a final confirmation message |
 
 Filtering is currently available on EC2 instances, IAM users, VPCs/subnets, RDS instances, Route53 zones/records, CloudWatch log groups/streams, Secrets Manager resources, ECS clusters/services, S3 buckets/objects, and the context picker.

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -93,10 +93,20 @@ Current repository clients include:
 Pattern:
 
 - `repository.go` initializes SDK clients
-- `inspector*.go` owns Security Inspector scan orchestration and finding models
 - `*_model.go` defines UI-facing data models
 - `*.go` implements service operations
 - tests use mock client interfaces per AWS service
+
+### `internal/inspector/`
+
+Cross-service inspector workflows and rule packs.
+
+Pattern:
+
+- workflow-local finding/report models live here
+- Security Inspector scan orchestration and rule registration live here
+- rule packs still depend on `internal/services/aws` repository methods and client interfaces rather than raw SDK setup
+- this package is the growth path for future inspector workflows such as Checklist Inspector
 
 ### `internal/app/`
 
@@ -169,7 +179,7 @@ Current screen families include:
 - CloudWatch Logs group/stream/viewer flows
 - ECS cluster/service/task/container flows
 - S3 bucket/object/detail flows
-- Inspector home/scanning/results/detail flows
+- Inspector mode home, workflow placeholder, and security findings/detail flows
 - context picker, context add, and TUI-native context setup/export/unset flows
 - SSO account / role selection and exit notice flows
 - loading and error screens
@@ -181,6 +191,7 @@ When adding a feature:
 1. add service or feature constants in `internal/domain/model.go`
 2. register them in `internal/domain/catalog.go`
 3. add repository methods and models under `internal/services/aws/`
-4. wire the screen flow in `internal/app/`
-5. add tests for repository logic and app transitions
+4. for cross-service inspector work, add workflow/rule logic under `internal/inspector/`
+5. wire the screen flow in `internal/app/`
+6. add tests for repository logic and app transitions
 6. update README and `docs/` if behavior is user-visible

--- a/docs/architecture.ko.md
+++ b/docs/architecture.ko.md
@@ -93,10 +93,20 @@ repository와 서비스별 AWS 연동 계층이다.
 패턴:
 
 - `repository.go`에서 SDK client 초기화
-- `inspector*.go`에서 Security Inspector 스캔 orchestration과 finding 모델 관리
 - `*_model.go`에서 UI 친화적 모델 정의
 - `*.go`에서 실제 서비스 로직 구현
 - 테스트에서는 AWS 서비스별 mock interface 사용
+
+### `internal/inspector/`
+
+cross-service inspector workflow와 rule pack을 담당한다.
+
+패턴:
+
+- workflow 전용 finding/report 모델은 여기서 관리
+- Security Inspector 스캔 orchestration과 rule 등록은 여기서 관리
+- rule pack은 raw SDK setup 대신 `internal/services/aws` repository 메서드와 client interface에 의존
+- Checklist Inspector 같은 후속 inspector workflow도 이 패턴으로 확장
 
 ### `internal/app/`
 
@@ -169,7 +179,7 @@ UNIC은 현재 세 가지 인증 모드를 지원한다.
 - CloudWatch Logs group/stream/viewer
 - ECS cluster/service/task/container
 - S3 bucket/object/detail
-- Inspector home/scanning/results/detail
+- Inspector mode home, workflow placeholder, security findings/detail
 - context picker, context add, TUI-native context setup/export/unset
 - SSO account / role selection, exit notice
 - loading, error
@@ -181,6 +191,7 @@ UNIC은 현재 세 가지 인증 모드를 지원한다.
 1. `internal/domain/model.go`에 service/feature 상수 추가
 2. `internal/domain/catalog.go`에 등록
 3. `internal/services/aws/`에 repository 메서드와 모델 추가
-4. `internal/app/`에 화면 전환 연결
-5. repository 로직과 app 전환 테스트 작성
+4. cross-service inspector 작업이면 `internal/inspector/`에 workflow/rule 로직 추가
+5. `internal/app/`에 화면 전환 연결
+6. repository 로직과 app 전환 테스트 작성
 6. 사용자에게 보이는 동작이면 README와 `docs/` 갱신

--- a/docs/project-overview.en.md
+++ b/docs/project-overview.en.md
@@ -19,15 +19,15 @@ Implemented service areas currently include:
 - CloudWatch Logs
 - ECS
 - S3
-- Inspector
+- Inspector mode
 
 The application already includes interactive mutation flows, polling-based status flows, context helpers, and per-service drill-down screens.
 
 ## Primary User Flows
 
 1. Run `unic` to enter the TUI
-2. Select a service and feature from the catalog
-3. Drill into resource lists and detail views
+2. Select an AWS service and feature from the catalog, or press `i` to enter Inspector mode
+3. Drill into resource lists, inspector workflows, and detail views
 4. Execute supported actions when available
 5. Use `unic env` or `unic context setup` when shell exports are needed
 
@@ -49,8 +49,9 @@ cmd/unic/                 entrypoint
 internal/cli/             Cobra commands
 internal/config/          config load/save and context helpers
 internal/auth/            env export and interactive setup logic
-internal/domain/          service catalog and feature enums
+internal/domain/          AWS service catalog and feature enums
 internal/services/aws/    AWS repository, models, and service operations
+internal/inspector/       cross-service inspector workflows, findings, and rule packs
 internal/app/             Bubble Tea model, screens, styles, messages
 ```
 

--- a/docs/project-overview.ko.md
+++ b/docs/project-overview.ko.md
@@ -19,15 +19,15 @@ UNIC은 다음 세 가지를 결합한 Go 기반 AWS 터미널 콘솔이다.
 - CloudWatch Logs
 - ECS
 - S3
-- Inspector
+- Inspector mode
 
 애플리케이션은 이미 상호작용형 변경 작업 플로우, polling 기반 상태 확인, context helper, 서비스별 drill-down 화면을 포함한다.
 
 ## 주요 사용자 흐름
 
 1. `unic`으로 TUI에 진입한다
-2. 카탈로그에서 서비스와 기능을 선택한다
-3. 리소스 목록과 상세 화면으로 drill-down 한다
+2. 카탈로그에서 AWS 서비스와 기능을 선택하거나 `i`로 Inspector mode에 진입한다
+3. 리소스 목록, inspector workflow, 상세 화면으로 drill-down 한다
 4. 가능한 액션을 수행한다
 5. 쉘 export가 필요하면 `unic env` 또는 `unic context setup`을 사용한다
 
@@ -49,8 +49,9 @@ cmd/unic/                 진입점
 internal/cli/             Cobra 명령
 internal/config/          config 로드/저장, context helper
 internal/auth/            env export, interactive setup
-internal/domain/          서비스 카탈로그와 feature enum
+internal/domain/          AWS 서비스 카탈로그와 feature enum
 internal/services/aws/    AWS repository, 모델, 서비스 로직
+internal/inspector/       cross-service inspector workflow, finding, rule pack
 internal/app/             Bubble Tea 모델, 화면, 스타일, 메시지
 ```
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -11,6 +11,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"unic/internal/config"
 	"unic/internal/domain"
+	"unic/internal/inspector"
 	awsservice "unic/internal/services/aws"
 	"unic/internal/update"
 )
@@ -62,6 +63,7 @@ const (
 	screenS3ObjectList
 	screenS3ObjectDetail
 	screenInspectorHome
+	screenInspectorWorkflowPlaceholder
 	screenInspectorScanning
 	screenInspectorResults
 	screenInspectorFindingDetail
@@ -240,11 +242,13 @@ type Model struct {
 	selectedS3Object  *awsservice.S3ObjectDetail
 
 	// Inspector browser state
-	inspectorReport          *awsservice.SecurityScanReport
-	inspectorFindings        []awsservice.SecurityFinding
+	inspectorWorkflows       []inspector.Workflow
+	inspectorWorkflowIdx     int
+	inspectorReport          *inspector.SecurityScanReport
+	inspectorFindings        []inspector.SecurityFinding
 	inspectorIdx             int
-	inspectorSeverityFilter  awsservice.RuleSeverity
-	selectedInspectorFinding *awsservice.SecurityFinding
+	inspectorSeverityFilter  inspector.RuleSeverity
+	selectedInspectorFinding *inspector.SecurityFinding
 
 	// Context picker
 	configPath         string
@@ -303,16 +307,17 @@ func New(cfg *config.Config, configPath string, version string) Model {
 	services := domain.Catalog()
 	filterTI := newFilterInput()
 	model := Model{
-		cfg:            cfg,
-		configPath:     configPath,
-		currentVersion: version,
-		screen:         screenContextPicker,
-		ctxPrevScreen:  screenServiceList,
-		services:       services,
-		loadingSpinner: newLoadingSpinner(),
-		filterTI:       filterTI,
-		filters:        make(map[filterTarget]string),
-		contextTable:   newContextTable(),
+		cfg:                cfg,
+		configPath:         configPath,
+		currentVersion:     version,
+		screen:             screenContextPicker,
+		ctxPrevScreen:      screenServiceList,
+		services:           services,
+		inspectorWorkflows: inspector.Workflows(),
+		loadingSpinner:     newLoadingSpinner(),
+		filterTI:           filterTI,
+		filters:            make(map[filterTarget]string),
+		contextTable:       newContextTable(),
 	}
 	model.cwLogs = newCloudWatchLogsModel()
 	return model
@@ -526,6 +531,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateS3ObjectDetail(msg)
 		case screenInspectorHome:
 			return m.updateInspectorHome(msg)
+		case screenInspectorWorkflowPlaceholder:
+			return m.updateInspectorWorkflowPlaceholder(msg)
 		case screenInspectorResults:
 			return m.updateInspectorResults(msg)
 		case screenInspectorFindingDetail:
@@ -613,6 +620,8 @@ func (m Model) updateServiceList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.svcIdx < len(m.services)-1 {
 			m.svcIdx++
 		}
+	case "i":
+		m.enterInspectorMode()
 	case "enter":
 		if m.svcIdx < len(m.services) {
 			m.features = m.services[m.svcIdx].Features
@@ -685,14 +694,6 @@ func (m Model) updateFeatureList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m.startLoading(m.loadIAMKeys())
 			case domain.FeatureECSExec:
 				return m.startLoading(m.loadECSClusters())
-			case domain.FeatureSecurityScan:
-				m.inspectorReport = nil
-				m.inspectorFindings = nil
-				m.inspectorIdx = 0
-				m.inspectorSeverityFilter = ""
-				m.selectedInspectorFinding = nil
-				m.screen = screenInspectorHome
-				return m, nil
 			}
 		}
 	}
@@ -779,6 +780,8 @@ func (m Model) View() string {
 		v = m.viewS3ObjectDetail()
 	case screenInspectorHome:
 		v = m.viewInspectorHome()
+	case screenInspectorWorkflowPlaceholder:
+		v = m.viewInspectorWorkflowPlaceholder()
 	case screenInspectorScanning:
 		v = m.viewInspectorScanning()
 	case screenInspectorResults:
@@ -861,7 +864,7 @@ func (m Model) viewServiceList() string {
 
 	b.WriteString(m.renderListPanel(panel.String()))
 	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("↑/↓: navigate • enter: select • esc: context • q: quit"))
+	b.WriteString(m.renderHelpBar("↑/↓: navigate • enter: select • i: Inspector mode • esc: context • q: quit"))
 	return b.String()
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -10,6 +10,7 @@ import (
 
 	"unic/internal/config"
 	"unic/internal/domain"
+	"unic/internal/inspector"
 	awsservice "unic/internal/services/aws"
 )
 
@@ -1333,17 +1334,11 @@ func TestS3FeatureStartsBucketLoading(t *testing.T) {
 	}
 }
 
-func TestInspectorFeatureEntersHomeScreen(t *testing.T) {
+func TestServiceListInspectorKeyEntersHomeScreen(t *testing.T) {
 	m := New(testConfig(), "", "dev")
-	for _, svc := range m.services {
-		if svc.Name == domain.ServiceInspector {
-			m.features = svc.Features
-			break
-		}
-	}
-	m.screen = screenFeatureList
+	m.screen = screenServiceList
 
-	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
 	model := updated.(Model)
 	if model.screen != screenInspectorHome {
 		t.Fatalf("expected inspector home screen, got %d", model.screen)
@@ -1369,13 +1364,13 @@ func TestInspectorHomeStartsDedicatedScanFlow(t *testing.T) {
 
 func TestHandleInspectorScanLoadedMsgShowsResults(t *testing.T) {
 	m := New(testConfig(), "", "dev")
-	report := &awsservice.SecurityScanReport{
+	report := &inspector.SecurityScanReport{
 		ScannerCount: 1,
-		Findings: []awsservice.SecurityFinding{
+		Findings: []inspector.SecurityFinding{
 			{
 				RuleID:         "sg-public-ssh",
 				RuleName:       "SSH exposed to the internet",
-				Severity:       awsservice.RuleSeverityHigh,
+				Severity:       inspector.RuleSeverityHigh,
 				ResourceType:   "SecurityGroup",
 				ResourceID:     "sg-123456",
 				Summary:        "Ingress rule allows TCP/22 from 0.0.0.0/0.",
@@ -1401,20 +1396,20 @@ func TestHandleInspectorScanLoadedMsgShowsResults(t *testing.T) {
 func TestInspectorResultsSeverityFilterNarrowsFindings(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenInspectorResults
-	m.inspectorReport = &awsservice.SecurityScanReport{
-		Findings: []awsservice.SecurityFinding{
-			{RuleName: "Critical finding", Severity: awsservice.RuleSeverityCritical, ResourceID: "sg-1"},
-			{RuleName: "Medium finding", Severity: awsservice.RuleSeverityMedium, ResourceID: "db-1"},
+	m.inspectorReport = &inspector.SecurityScanReport{
+		Findings: []inspector.SecurityFinding{
+			{RuleName: "Critical finding", Severity: inspector.RuleSeverityCritical, ResourceID: "sg-1"},
+			{RuleName: "Medium finding", Severity: inspector.RuleSeverityMedium, ResourceID: "db-1"},
 		},
 	}
 	m.applyInspectorSeverityFilter()
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
 	model := updated.(Model)
-	if model.inspectorSeverityFilter != awsservice.RuleSeverityCritical {
+	if model.inspectorSeverityFilter != inspector.RuleSeverityCritical {
 		t.Fatalf("expected critical severity filter, got %q", model.inspectorSeverityFilter)
 	}
-	if len(model.inspectorFindings) != 1 || model.inspectorFindings[0].Severity != awsservice.RuleSeverityCritical {
+	if len(model.inspectorFindings) != 1 || model.inspectorFindings[0].Severity != inspector.RuleSeverityCritical {
 		t.Fatalf("expected only critical findings, got %+v", model.inspectorFindings)
 	}
 }
@@ -1422,10 +1417,10 @@ func TestInspectorResultsSeverityFilterNarrowsFindings(t *testing.T) {
 func TestInspectorResultsEnterShowsDetail(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenInspectorResults
-	m.inspectorFindings = []awsservice.SecurityFinding{
+	m.inspectorFindings = []inspector.SecurityFinding{
 		{
 			RuleName:       "SSH exposed to the internet",
-			Severity:       awsservice.RuleSeverityHigh,
+			Severity:       inspector.RuleSeverityHigh,
 			ResourceID:     "sg-123456",
 			Summary:        "Ingress rule allows SSH from anywhere.",
 			Recommendation: "Restrict SSH ingress to trusted sources.",
@@ -1439,6 +1434,21 @@ func TestInspectorResultsEnterShowsDetail(t *testing.T) {
 	}
 	if model.selectedInspectorFinding == nil {
 		t.Fatal("expected selected inspector finding")
+	}
+}
+
+func TestInspectorHomeChecklistEntersPlaceholder(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenInspectorHome
+	m.inspectorWorkflowIdx = 1
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model := updated.(Model)
+	if model.screen != screenInspectorWorkflowPlaceholder {
+		t.Fatalf("expected checklist placeholder screen, got %d", model.screen)
+	}
+	if cmd != nil {
+		t.Fatal("expected no command for placeholder workflow")
 	}
 }
 

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -18,7 +18,7 @@ type helpSection struct {
 func (m Model) viewHelp() string {
 	var b strings.Builder
 	b.WriteString(m.renderStatusBar())
-	b.WriteString(titleStyle.Render("Keyboard Shortcuts"))
+	b.WriteString(m.renderModeTitle("Keyboard Shortcuts"))
 	b.WriteString("\n")
 	b.WriteString(dimStyle.Render(fmt.Sprintf("Screen: %s", m.helpScreenTitle())))
 	b.WriteString("\n\n")
@@ -113,6 +113,7 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 		return []helpShortcut{
 			{"↑/↓, j/k", "Move between AWS services"},
 			{"enter", "Open the selected service"},
+			{"i", "Open Inspector mode"},
 			{"esc", "Open the context picker"},
 			{"q", "Quit unic"},
 		}
@@ -377,8 +378,13 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 		}
 	case screenInspectorHome:
 		return []helpShortcut{
-			{"enter / r", "Run the security scan"},
-			{"q / esc", "Go back to the feature list"},
+			{"↑/↓, j/k", "Move between inspector workflows"},
+			{"enter", "Open the selected inspector workflow"},
+			{"q / esc", "Return to the service list"},
+		}
+	case screenInspectorWorkflowPlaceholder:
+		return []helpShortcut{
+			{"q / esc", "Go back to Inspector mode"},
 		}
 	case screenInspectorScanning:
 		return []helpShortcut{
@@ -390,7 +396,7 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 			{"1-5", "Filter findings by severity"},
 			{"enter", "Open the selected finding detail"},
 			{"r", "Run the security scan again"},
-			{"q / esc", "Go back to the Inspector home screen"},
+			{"q / esc", "Go back to Inspector mode"},
 		}
 	case screenInspectorFindingDetail:
 		return []helpShortcut{
@@ -606,7 +612,9 @@ func (m Model) helpScreenTitle() string {
 	case screenS3ObjectDetail:
 		return "S3 Object Detail"
 	case screenInspectorHome:
-		return "Inspector Home"
+		return "Inspector Mode"
+	case screenInspectorWorkflowPlaceholder:
+		return "Inspector Workflow"
 	case screenInspectorScanning:
 		return "Inspector Scanning"
 	case screenInspectorResults:

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"unic/internal/config"
+	"unic/internal/inspector"
 	awsservice "unic/internal/services/aws"
 )
 
@@ -200,5 +201,5 @@ type ecsExecDoneMsg struct {
 }
 
 type inspectorScanLoadedMsg struct {
-	report *awsservice.SecurityScanReport
+	report *inspector.SecurityScanReport
 }

--- a/internal/app/screen_inspector.go
+++ b/internal/app/screen_inspector.go
@@ -8,6 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"unic/internal/inspector"
 	awsservice "unic/internal/services/aws"
 )
 
@@ -18,12 +19,38 @@ var (
 	inspectorSeverityLowStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("114")).Bold(true)
 )
 
-var inspectorSeverityFilters = []awsservice.RuleSeverity{
+var inspectorSeverityFilters = []inspector.RuleSeverity{
 	"",
-	awsservice.RuleSeverityCritical,
-	awsservice.RuleSeverityHigh,
-	awsservice.RuleSeverityMedium,
-	awsservice.RuleSeverityLow,
+	inspector.RuleSeverityCritical,
+	inspector.RuleSeverityHigh,
+	inspector.RuleSeverityMedium,
+	inspector.RuleSeverityLow,
+}
+
+func (m *Model) ensureInspectorWorkflows() {
+	if len(m.inspectorWorkflows) == 0 {
+		m.inspectorWorkflows = inspector.Workflows()
+	}
+	if m.inspectorWorkflowIdx >= len(m.inspectorWorkflows) {
+		m.inspectorWorkflowIdx = 0
+	}
+}
+
+func (m *Model) enterInspectorMode() {
+	m.ensureInspectorWorkflows()
+	m.screen = screenInspectorHome
+	m.selectedInspectorFinding = nil
+	m.inspectorIdx = 0
+}
+
+func (m Model) currentInspectorWorkflow() inspector.Workflow {
+	if len(m.inspectorWorkflows) == 0 {
+		return inspector.Workflow{}
+	}
+	if m.inspectorWorkflowIdx < 0 || m.inspectorWorkflowIdx >= len(m.inspectorWorkflows) {
+		return m.inspectorWorkflows[0]
+	}
+	return m.inspectorWorkflows[m.inspectorWorkflowIdx]
 }
 
 func (m Model) handleInspectorMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
@@ -41,9 +68,47 @@ func (m Model) handleInspectorMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 func (m Model) updateInspectorHome(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "q", "esc":
-		m.screen = screenFeatureList
-	case "enter", "r":
+		m.screen = screenServiceList
+	case "up", "k":
+		if m.inspectorWorkflowIdx > 0 {
+			m.inspectorWorkflowIdx--
+		}
+	case "down", "j":
+		if m.inspectorWorkflowIdx < len(m.inspectorWorkflows)-1 {
+			m.inspectorWorkflowIdx++
+		}
+	case "r":
+		if m.currentInspectorWorkflow().Kind == inspector.WorkflowSecurity {
+			return m.startInspectorScan()
+		}
+	case "enter":
+		return m.openInspectorWorkflow()
+	}
+	return m, nil
+}
+
+func (m Model) openInspectorWorkflow() (tea.Model, tea.Cmd) {
+	workflow := m.currentInspectorWorkflow()
+	switch workflow.Kind {
+	case inspector.WorkflowSecurity:
+		if m.inspectorReport != nil {
+			m.applyInspectorSeverityFilter()
+			m.screen = screenInspectorResults
+			return m, nil
+		}
 		return m.startInspectorScan()
+	case inspector.WorkflowChecklist:
+		m.screen = screenInspectorWorkflowPlaceholder
+		return m, nil
+	default:
+		return m, nil
+	}
+}
+
+func (m Model) updateInspectorWorkflowPlaceholder(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "esc":
+		m.screen = screenInspectorHome
 	}
 	return m, nil
 }
@@ -104,7 +169,7 @@ func (m Model) loadSecurityScan() tea.Cmd {
 			return errMsg{err: err}
 		}
 
-		report, err := repo.RunSecurityScan(ctx)
+		report, err := inspector.RunSecurityScan(ctx, repo)
 		if err != nil {
 			return errMsg{err: err}
 		}
@@ -119,7 +184,7 @@ func (m *Model) applyInspectorSeverityFilter() {
 		return
 	}
 
-	var filtered []awsservice.SecurityFinding
+	var filtered []inspector.SecurityFinding
 	for _, finding := range m.inspectorReport.Findings {
 		if finding.MatchesSeverity(m.inspectorSeverityFilter) {
 			filtered = append(filtered, finding)
@@ -129,38 +194,97 @@ func (m *Model) applyInspectorSeverityFilter() {
 }
 
 func (m Model) viewInspectorHome() string {
+	selected := m.currentInspectorWorkflow()
+
+	var b strings.Builder
+	var panel strings.Builder
+	b.WriteString(m.renderStatusBar())
+	b.WriteString(m.renderModeTitle("Inspector Mode"))
+	b.WriteString("\n")
+	b.WriteString(dimStyle.Render("Cross-service workflows with inspection-focused chrome and shared AWS context."))
+	b.WriteString("\n\n")
+
+	for i, workflow := range m.inspectorWorkflows {
+		cursor := "  "
+		nameStyle := normalStyle
+		badgeStyle := inspectorReadyStyle
+		if !workflow.Available {
+			badgeStyle = inspectorPlannedStyle
+		}
+		if i == m.inspectorWorkflowIdx {
+			cursor = "> "
+			nameStyle = inspectorSelectedStyle
+		}
+
+		row := fmt.Sprintf("%s%-22s %s", cursor, workflow.Title, badgeStyle.Render("["+workflow.StatusLabel()+"]"))
+		panel.WriteString(nameStyle.Render(row))
+		panel.WriteString("\n")
+		if i == m.inspectorWorkflowIdx {
+			panel.WriteString(dimStyle.Render("    " + workflow.Description))
+			panel.WriteString("\n")
+		}
+	}
+
+	panel.WriteString("\n")
+	panel.WriteString(inspectorSectionStyle.Render("Selected Workflow"))
+	panel.WriteString("\n")
+	switch selected.Kind {
+	case inspector.WorkflowSecurity:
+		panel.WriteString(normalStyle.Render("  Run the built-in security rule packs across the active AWS context."))
+		panel.WriteString("\n")
+		panel.WriteString(dimStyle.Render(fmt.Sprintf("  Registered rule packs: %d", inspector.RegisteredSecurityInspectorScannerCount())))
+		panel.WriteString("\n")
+		if m.inspectorReport != nil {
+			panel.WriteString(dimStyle.Render(fmt.Sprintf(
+				"  Last scan: %s • findings:%d • warnings:%d",
+				m.inspectorReport.ScannedAt.Local().Format("2006-01-02 15:04:05"),
+				len(m.inspectorReport.Findings),
+				len(m.inspectorReport.Warnings),
+			)))
+			panel.WriteString("\n")
+		}
+		panel.WriteString(inspectorAccentStyle.Render("  Enter opens the latest findings or starts a fresh scan. Press r to force a new scan."))
+	case inspector.WorkflowChecklist:
+		panel.WriteString(normalStyle.Render("  Checklist Inspector will live in this mode shell once the workflow engine ships."))
+		panel.WriteString("\n")
+		panel.WriteString(dimStyle.Render("  The dedicated Inspector mode is now separate from the AWS service picker so future cross-service audits do not pretend to be a service."))
+	default:
+		panel.WriteString(dimStyle.Render("  No inspector workflows are registered."))
+	}
+
+	b.WriteString(m.renderListPanel(panel.String()))
+	b.WriteString("\n\n")
+	b.WriteString(m.renderHelpBar("↑/↓: choose workflow • enter: open • r: run security workflow • esc: services • H: home"))
+	return b.String()
+}
+
+func (m Model) viewInspectorWorkflowPlaceholder() string {
+	workflow := m.currentInspectorWorkflow()
+
 	var b strings.Builder
 	b.WriteString(m.renderStatusBar())
-	b.WriteString(titleStyle.Render("Inspector"))
+	b.WriteString(m.renderModeTitle(workflow.Title))
 	b.WriteString("\n\n")
-	b.WriteString(normalStyle.Render("  Run built-in security scans against the active AWS context."))
+	b.WriteString(normalStyle.Render("  This workflow now has a dedicated place in Inspector mode, but the underlying engine is not implemented yet."))
 	b.WriteString("\n")
-	b.WriteString(normalStyle.Render("  Built-in rule packs cover Security Groups, RDS, IAM access keys, Secrets Manager, and S3 buckets."))
+	b.WriteString(dimStyle.Render("  Security Inspector is live today; Checklist Inspector will plug into this same shell when #60 lands."))
+	b.WriteString("\n\n")
+	b.WriteString(renderDetailLine("Status", inspectorPlannedStyle.Render(workflow.StatusLabel())))
 	b.WriteString("\n")
-	b.WriteString(dimStyle.Render(fmt.Sprintf("  Registered rule packs: %d", awsservice.RegisteredSecurityInspectorScannerCount())))
-	b.WriteString("\n")
-	if m.inspectorReport != nil {
-		b.WriteString(dimStyle.Render(fmt.Sprintf(
-			"  Last scan: %s • findings:%d • warnings:%d",
-			m.inspectorReport.ScannedAt.Local().Format("2006-01-02 15:04:05"),
-			len(m.inspectorReport.Findings),
-			len(m.inspectorReport.Warnings),
-		)))
-		b.WriteString("\n")
-	}
-	b.WriteString("\n")
-	b.WriteString(m.renderHelpBar("enter/r: run security scan • esc: back • H: home"))
+	b.WriteString(renderDetailLine("Description", normalStyle.Render(workflow.Description)))
+	b.WriteString("\n\n")
+	b.WriteString(m.renderHelpBar("esc: back • H: home"))
 	return b.String()
 }
 
 func (m Model) viewInspectorScanning() string {
 	var b strings.Builder
 	b.WriteString(m.renderStatusBar())
-	b.WriteString(titleStyle.Render("Inspector — Security Scan"))
+	b.WriteString(m.renderModeTitle("Inspector Mode — Security Scan"))
 	b.WriteString("\n\n")
-	b.WriteString(titleStyle.Render(fmt.Sprintf("%s Running built-in rule packs...", m.loadingSpinner.View())))
+	b.WriteString(inspectorTitleStyle.Render(fmt.Sprintf("%s Running built-in rule packs...", m.loadingSpinner.View())))
 	b.WriteString("\n")
-	b.WriteString(dimStyle.Render("  Checking network exposure, backups, key age, secret rotation, and S3 bucket posture."))
+	b.WriteString(dimStyle.Render("  Checking network exposure, backups, key age, secret rotation, logging baselines, and bucket posture."))
 	return b.String()
 }
 
@@ -168,7 +292,7 @@ func (m Model) viewInspectorResults() string {
 	var b strings.Builder
 	var panel strings.Builder
 	b.WriteString(m.renderStatusBar())
-	b.WriteString(titleStyle.Render("Inspector Findings"))
+	b.WriteString(m.renderModeTitle("Security Inspector Findings"))
 	b.WriteString("\n")
 
 	if m.inspectorReport != nil {
@@ -224,7 +348,7 @@ func (m Model) viewInspectorResults() string {
 			textStyle := normalStyle
 			if i == m.inspectorIdx {
 				cursor = "> "
-				textStyle = selectedStyle
+				textStyle = inspectorSelectedStyle
 			}
 
 			resource := inspectorShorten(inspectorFindingResource(finding), resourceWidth)
@@ -240,7 +364,7 @@ func (m Model) viewInspectorResults() string {
 
 	b.WriteString(m.renderListPanel(panel.String()))
 	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("↑/↓: navigate • 1-5: severity • enter: detail • r: rescan • esc: back • H: home"))
+	b.WriteString(m.renderHelpBar("↑/↓: navigate • 1-5: severity • enter: detail • r: rescan • esc: Inspector mode • H: home"))
 	return b.String()
 }
 
@@ -252,7 +376,7 @@ func (m Model) viewInspectorFindingDetail() string {
 	finding := m.selectedInspectorFinding
 	var b strings.Builder
 	b.WriteString(m.renderStatusBar())
-	b.WriteString(titleStyle.Render("Inspector Finding Detail"))
+	b.WriteString(m.renderModeTitle("Security Inspector Finding"))
 	b.WriteString("\n\n")
 
 	b.WriteString(renderDetailLine("Severity", renderInspectorSeverity(finding.Severity)))
@@ -276,12 +400,12 @@ func (m Model) viewInspectorFindingDetail() string {
 	}
 	paragraph := lipgloss.NewStyle().Width(width)
 
-	b.WriteString(titleStyle.Render("Summary"))
+	b.WriteString(inspectorSectionStyle.Render("Summary"))
 	b.WriteString("\n\n")
 	b.WriteString(paragraph.Render("  " + finding.Summary))
 	b.WriteString("\n\n")
 
-	b.WriteString(titleStyle.Render("Recommendation"))
+	b.WriteString(inspectorSectionStyle.Render("Recommendation"))
 	b.WriteString("\n\n")
 	b.WriteString(paragraph.Render("  " + finding.Recommendation))
 	b.WriteString("\n\n")
@@ -295,7 +419,7 @@ func (m Model) renderInspectorSeveritySelector() string {
 	for idx, severity := range inspectorSeverityFilters {
 		label := fmt.Sprintf("%d:%s", idx+1, severity.Label())
 		if severity == m.inspectorSeverityFilter {
-			parts = append(parts, selectedStyle.Render("["+label+"]"))
+			parts = append(parts, inspectorSelectedStyle.Render("["+label+"]"))
 		} else {
 			parts = append(parts, dimStyle.Render(" "+label+" "))
 		}
@@ -303,7 +427,7 @@ func (m Model) renderInspectorSeveritySelector() string {
 	return strings.Join(parts, " ")
 }
 
-func inspectorFindingResource(finding awsservice.SecurityFinding) string {
+func inspectorFindingResource(finding inspector.SecurityFinding) string {
 	if finding.ResourceID != "" {
 		return finding.ResourceID
 	}
@@ -313,15 +437,15 @@ func inspectorFindingResource(finding awsservice.SecurityFinding) string {
 	return "-"
 }
 
-func renderInspectorSeverity(severity awsservice.RuleSeverity) string {
+func renderInspectorSeverity(severity inspector.RuleSeverity) string {
 	switch severity {
-	case awsservice.RuleSeverityCritical:
+	case inspector.RuleSeverityCritical:
 		return inspectorSeverityCriticalStyle.Render(string(severity))
-	case awsservice.RuleSeverityHigh:
+	case inspector.RuleSeverityHigh:
 		return inspectorSeverityHighStyle.Render(string(severity))
-	case awsservice.RuleSeverityMedium:
+	case inspector.RuleSeverityMedium:
 		return inspectorSeverityMediumStyle.Render(string(severity))
-	case awsservice.RuleSeverityLow:
+	case inspector.RuleSeverityLow:
 		return inspectorSeverityLowStyle.Render(string(severity))
 	default:
 		return dimStyle.Render(string(severity))

--- a/internal/app/styles.go
+++ b/internal/app/styles.go
@@ -10,22 +10,31 @@ import (
 )
 
 var (
-	titleStyle       = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39"))
-	selectedStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("170"))
-	normalStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
-	dimStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
-	errorStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)
-	successStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("42")).Bold(true)
-	warningStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true)
-	infoStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("117"))
-	pathNodeStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("81")).Bold(true)
-	pathLineStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("67"))
-	filterStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
-	statusBarStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Background(lipgloss.Color("236"))
-	listPanelStyle   = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("240")).Padding(0, 1)
-	helpStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Background(lipgloss.Color("237"))
-	detailLabelStyle = dimStyle.Copy().Width(14)
-	exitPanelStyle   = lipgloss.NewStyle().
+	titleStyle              = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39"))
+	selectedStyle           = lipgloss.NewStyle().Foreground(lipgloss.Color("170"))
+	normalStyle             = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+	dimStyle                = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	errorStyle              = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)
+	successStyle            = lipgloss.NewStyle().Foreground(lipgloss.Color("42")).Bold(true)
+	warningStyle            = lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true)
+	infoStyle               = lipgloss.NewStyle().Foreground(lipgloss.Color("117"))
+	pathNodeStyle           = lipgloss.NewStyle().Foreground(lipgloss.Color("81")).Bold(true)
+	pathLineStyle           = lipgloss.NewStyle().Foreground(lipgloss.Color("67"))
+	filterStyle             = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+	statusBarStyle          = lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Background(lipgloss.Color("236"))
+	listPanelStyle          = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("240")).Padding(0, 1)
+	helpStyle               = lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Background(lipgloss.Color("237"))
+	inspectorTitleStyle     = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("203"))
+	inspectorSelectedStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("216")).Bold(true)
+	inspectorAccentStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("209"))
+	inspectorSectionStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("173")).Bold(true)
+	inspectorReadyStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("215")).Bold(true)
+	inspectorPlannedStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("95")).Bold(true)
+	inspectorStatusBarStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("252")).Background(lipgloss.Color("52"))
+	inspectorListPanelStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("160")).Padding(0, 1)
+	inspectorHelpStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("252")).Background(lipgloss.Color("53"))
+	detailLabelStyle        = dimStyle.Copy().Width(14)
+	exitPanelStyle          = lipgloss.NewStyle().
 				Border(lipgloss.DoubleBorder()).
 				BorderForeground(lipgloss.Color("39")).
 				Foreground(lipgloss.Color("252")).
@@ -42,6 +51,43 @@ var (
 			Foreground(lipgloss.Color("214")).
 			Bold(true)
 )
+
+func (m Model) inspectorModeActive() bool {
+	switch m.screen {
+	case screenInspectorHome, screenInspectorWorkflowPlaceholder, screenInspectorScanning, screenInspectorResults, screenInspectorFindingDetail:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m Model) currentStatusBarStyle() lipgloss.Style {
+	if m.inspectorModeActive() {
+		return inspectorStatusBarStyle
+	}
+	return statusBarStyle
+}
+
+func (m Model) currentListPanelStyle() lipgloss.Style {
+	if m.inspectorModeActive() {
+		return inspectorListPanelStyle
+	}
+	return listPanelStyle
+}
+
+func (m Model) currentHelpStyle() lipgloss.Style {
+	if m.inspectorModeActive() {
+		return inspectorHelpStyle
+	}
+	return helpStyle
+}
+
+func (m Model) renderModeTitle(title string) string {
+	if m.inspectorModeActive() {
+		return inspectorTitleStyle.Render(title)
+	}
+	return titleStyle.Render(title)
+}
 
 func (m Model) renderStatusBar() string {
 	var leftParts []string
@@ -65,6 +111,9 @@ func (m Model) renderStatusBar() string {
 	if m.callerIdentity != nil && m.callerIdentity.Account != "" {
 		leftParts = append(leftParts, fmt.Sprintf("account:%s", m.callerIdentity.Account))
 	}
+	if m.inspectorModeActive() {
+		leftParts = append(leftParts, inspectorAccentStyle.Render("mode:inspector"))
+	}
 
 	if m.updateAvailable != "" {
 		hint := "unic update"
@@ -87,7 +136,7 @@ func (m Model) renderStatusBar() string {
 		width = leftMinWidth + rightMinWidth
 	}
 	if rightText == "" {
-		return statusBarStyle.Copy().Width(width).Align(lipgloss.Left).Render(leftText) + "\n\n"
+		return m.currentStatusBarStyle().Copy().Width(width).Align(lipgloss.Left).Render(leftText) + "\n\n"
 	}
 
 	leftWidth := width - rightMinWidth
@@ -98,15 +147,15 @@ func (m Model) renderStatusBar() string {
 
 	bar := lipgloss.JoinHorizontal(
 		lipgloss.Top,
-		statusBarStyle.Copy().Width(leftWidth).Align(lipgloss.Left).Render(leftText),
-		statusBarStyle.Copy().Width(rightWidth).Align(lipgloss.Right).Render(rightText),
+		m.currentStatusBarStyle().Copy().Width(leftWidth).Align(lipgloss.Left).Render(leftText),
+		m.currentStatusBarStyle().Copy().Width(rightWidth).Align(lipgloss.Right).Render(rightText),
 	)
 	return bar + "\n\n"
 }
 
 func (m Model) renderListPanel(content string) string {
 	content = strings.TrimRight(content, "\n")
-	style := listPanelStyle
+	style := m.currentListPanelStyle()
 	if m.width > 0 {
 		style = style.MaxWidth(max(m.width, 1))
 	}
@@ -115,7 +164,7 @@ func (m Model) renderListPanel(content string) string {
 
 func (m Model) renderHelpBar(content string) string {
 	content = " " + strings.TrimSpace(content)
-	style := helpStyle
+	style := m.currentHelpStyle()
 	if m.width > 0 {
 		style = style.Width(m.width)
 	}

--- a/internal/app/styles_test.go
+++ b/internal/app/styles_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -43,6 +44,46 @@ func TestRenderStatusBarUsesFullWidthAndUpdateHint(t *testing.T) {
 		if !strings.Contains(plain, want) {
 			t.Fatalf("expected status bar to contain %q, got %q", want, plain)
 		}
+	}
+}
+
+func TestInspectorModeStatusBarAddsModeMarkerAndDifferentChrome(t *testing.T) {
+	regular := New(testConfig(), "", "dev")
+	regular.width = 80
+	regular.cfg.ContextName = "prod"
+	regular.screen = screenServiceList
+
+	inspectorMode := New(testConfig(), "", "dev")
+	inspectorMode.width = 80
+	inspectorMode.cfg.ContextName = "prod"
+	inspectorMode.screen = screenInspectorHome
+
+	regularBar := regular.renderStatusBar()
+	inspectorBar := inspectorMode.renderStatusBar()
+	if regularBar == inspectorBar {
+		t.Fatal("expected inspector mode status bar styling to differ from the regular service flow")
+	}
+	if !strings.Contains(stripANSI(inspectorBar), "mode:inspector") {
+		t.Fatalf("expected inspector status bar to include mode marker, got %q", stripANSI(inspectorBar))
+	}
+}
+
+func TestInspectorModeHelpBarUsesDifferentStyling(t *testing.T) {
+	regular := New(testConfig(), "", "dev")
+	regular.width = 48
+	regular.screen = screenServiceList
+
+	inspectorMode := New(testConfig(), "", "dev")
+	inspectorMode.width = 48
+	inspectorMode.screen = screenInspectorHome
+
+	regularBar := regular.renderHelpBar("esc: back • H: home")
+	inspectorBar := inspectorMode.renderHelpBar("esc: back • H: home")
+	if reflect.DeepEqual(regular.currentHelpStyle(), inspectorMode.currentHelpStyle()) {
+		t.Fatal("expected inspector help bar styling to differ from the regular service flow")
+	}
+	if stripANSI(regularBar) != stripANSI(inspectorBar) {
+		t.Fatalf("expected inspector styling to keep the visible help text unchanged, got regular=%q inspector=%q", stripANSI(regularBar), stripANSI(inspectorBar))
 	}
 }
 

--- a/internal/domain/catalog.go
+++ b/internal/domain/catalog.go
@@ -100,14 +100,5 @@ func Catalog() []Service {
 				},
 			},
 		},
-		{
-			Name: ServiceInspector,
-			Features: []Feature{
-				{
-					Kind:        FeatureSecurityScan,
-					Description: "Run built-in security scans and review findings by severity",
-				},
-			},
-		},
 	}
 }

--- a/internal/domain/catalog_test.go
+++ b/internal/domain/catalog_test.go
@@ -160,21 +160,12 @@ func TestCatalogContainsS3BrowserFeature(t *testing.T) {
 	t.Error("S3 service not found in catalog")
 }
 
-func TestCatalogContainsInspectorSecurityScanFeature(t *testing.T) {
+func TestCatalogDoesNotContainInspectorPseudoService(t *testing.T) {
 	services := Catalog()
 
 	for _, svc := range services {
-		if svc.Name != ServiceInspector {
-			continue
+		if svc.Name == "Inspector" {
+			t.Fatal("inspector should not be listed as a regular AWS service")
 		}
-		if len(svc.Features) != 1 {
-			t.Fatalf("expected 1 Inspector feature, got %d", len(svc.Features))
-		}
-		if svc.Features[0].Kind != FeatureSecurityScan {
-			t.Fatalf("expected Security Scan feature, got %s", svc.Features[0].Kind)
-		}
-		return
 	}
-
-	t.Error("Inspector service not found in catalog")
 }

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -13,7 +13,6 @@ const (
 	ServiceCloudWatchLogs AwsService = "CloudWatch Logs"
 	ServiceECS            AwsService = "ECS"
 	ServiceS3             AwsService = "S3"
-	ServiceInspector      AwsService = "Inspector"
 )
 
 // FeatureKind represents a specific feature within a service.
@@ -33,7 +32,6 @@ const (
 	FeatureCloudWatchLogsBrowser FeatureKind = "CloudWatch Logs Browser"
 	FeatureECSExec               FeatureKind = "ECS Exec Sessions"
 	FeatureS3Browser             FeatureKind = "S3 Browser"
-	FeatureSecurityScan          FeatureKind = "Security Scan"
 )
 
 // Feature describes a selectable feature under an AWS service.

--- a/internal/inspector/inspector.go
+++ b/internal/inspector/inspector.go
@@ -1,4 +1,4 @@
-package aws
+package inspector
 
 import (
 	"context"
@@ -44,7 +44,7 @@ func RegisteredSecurityInspectorScannerCount() int {
 	return len(listSecurityInspectorScanners())
 }
 
-func (r *AwsRepository) RunSecurityScan(ctx context.Context) (*SecurityScanReport, error) {
+func RunSecurityScan(ctx context.Context, repo *AwsRepository) (*SecurityScanReport, error) {
 	scanners := listSecurityInspectorScanners()
 	report := &SecurityScanReport{
 		ScannerCount: len(scanners),
@@ -58,7 +58,7 @@ func (r *AwsRepository) RunSecurityScan(ctx context.Context) (*SecurityScanRepor
 		default:
 		}
 
-		findings, err := scanner.Run(ctx, r)
+		findings, err := scanner.Run(ctx, repo)
 		if err != nil {
 			report.Warnings = append(report.Warnings, fmt.Sprintf("%s: %v", scanner.Name, err))
 			continue

--- a/internal/inspector/inspector_model.go
+++ b/internal/inspector/inspector_model.go
@@ -1,10 +1,66 @@
-package aws
+package inspector
 
 import (
 	"fmt"
 	"strings"
 	"time"
+
+	awsservice "unic/internal/services/aws"
 )
+
+type WorkflowKind string
+
+const (
+	WorkflowSecurity  WorkflowKind = "security"
+	WorkflowChecklist WorkflowKind = "checklist"
+)
+
+type Workflow struct {
+	Kind        WorkflowKind
+	Title       string
+	Description string
+	Available   bool
+}
+
+func Workflows() []Workflow {
+	return []Workflow{
+		{
+			Kind:        WorkflowSecurity,
+			Title:       "Security Inspector",
+			Description: "Cross-service security findings for network exposure, identity, storage, logging, and baseline posture.",
+			Available:   true,
+		},
+		{
+			Kind:        WorkflowChecklist,
+			Title:       "Checklist Inspector",
+			Description: "Planned guided readiness and rollout checks for infrastructure workflows that span multiple AWS services.",
+			Available:   false,
+		},
+	}
+}
+
+func (w Workflow) StatusLabel() string {
+	if w.Available {
+		return "READY"
+	}
+	return "PLANNED"
+}
+
+type AwsRepository = awsservice.AwsRepository
+type AccessKey = awsservice.AccessKey
+type CloudTrailClientAPI = awsservice.CloudTrailClientAPI
+type ConfigServiceClientAPI = awsservice.ConfigServiceClientAPI
+type EC2ClientAPI = awsservice.EC2ClientAPI
+type ElastiCacheClientAPI = awsservice.ElastiCacheClientAPI
+type GuardDutyClientAPI = awsservice.GuardDutyClientAPI
+type IAMClientAPI = awsservice.IAMClientAPI
+type RDSClientAPI = awsservice.RDSClientAPI
+type S3Bucket = awsservice.S3Bucket
+type Secret = awsservice.Secret
+type SecurityGroup = awsservice.SecurityGroup
+type SecurityGroupRule = awsservice.SecurityGroupRule
+type SecretsManagerClientAPI = awsservice.SecretsManagerClientAPI
+type RDSInstance = awsservice.RDSInstance
 
 type RuleSeverity string
 

--- a/internal/inspector/inspector_rules_baselines.go
+++ b/internal/inspector/inspector_rules_baselines.go
@@ -1,4 +1,4 @@
-package aws
+package inspector
 
 import (
 	"context"

--- a/internal/inspector/inspector_rules_baselines_test.go
+++ b/internal/inspector/inspector_rules_baselines_test.go
@@ -1,4 +1,4 @@
-package aws
+package inspector
 
 import (
 	"context"

--- a/internal/inspector/inspector_rules_elasticache.go
+++ b/internal/inspector/inspector_rules_elasticache.go
@@ -1,4 +1,4 @@
-package aws
+package inspector
 
 import (
 	"context"

--- a/internal/inspector/inspector_rules_elasticache_test.go
+++ b/internal/inspector/inspector_rules_elasticache_test.go
@@ -1,4 +1,4 @@
-package aws
+package inspector
 
 import (
 	"context"

--- a/internal/inspector/inspector_rules_iam_account.go
+++ b/internal/inspector/inspector_rules_iam_account.go
@@ -1,4 +1,4 @@
-package aws
+package inspector
 
 import (
 	"context"

--- a/internal/inspector/inspector_rules_iam_account_test.go
+++ b/internal/inspector/inspector_rules_iam_account_test.go
@@ -1,4 +1,4 @@
-package aws
+package inspector
 
 import (
 	"context"

--- a/internal/inspector/inspector_rules_identity_secrets.go
+++ b/internal/inspector/inspector_rules_identity_secrets.go
@@ -1,4 +1,4 @@
-package aws
+package inspector
 
 import (
 	"context"
@@ -45,7 +45,7 @@ func inspectIAMAccessKeyAges(ctx context.Context, repo *AwsRepository, now time.
 		}
 
 		for _, user := range page.Users {
-			keys, err := repo.listUserAccessKeys(ctx, user.UserName)
+			keys, err := repo.ListUserAccessKeys(ctx, user.UserName)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/inspector/inspector_rules_identity_secrets_test.go
+++ b/internal/inspector/inspector_rules_identity_secrets_test.go
@@ -1,4 +1,4 @@
-package aws
+package inspector
 
 import (
 	"context"

--- a/internal/inspector/inspector_rules_network_rds.go
+++ b/internal/inspector/inspector_rules_network_rds.go
@@ -1,4 +1,4 @@
-package aws
+package inspector
 
 import (
 	"context"

--- a/internal/inspector/inspector_rules_network_rds_test.go
+++ b/internal/inspector/inspector_rules_network_rds_test.go
@@ -1,4 +1,4 @@
-package aws
+package inspector
 
 import "testing"
 

--- a/internal/inspector/inspector_rules_s3.go
+++ b/internal/inspector/inspector_rules_s3.go
@@ -1,4 +1,4 @@
-package aws
+package inspector
 
 import (
 	"context"

--- a/internal/inspector/inspector_rules_s3_test.go
+++ b/internal/inspector/inspector_rules_s3_test.go
@@ -1,4 +1,4 @@
-package aws
+package inspector
 
 import (
 	"context"

--- a/internal/inspector/inspector_rules_snapshots.go
+++ b/internal/inspector/inspector_rules_snapshots.go
@@ -1,4 +1,4 @@
-package aws
+package inspector
 
 import (
 	"context"

--- a/internal/inspector/inspector_rules_snapshots_test.go
+++ b/internal/inspector/inspector_rules_snapshots_test.go
@@ -1,4 +1,4 @@
-package aws
+package inspector
 
 import (
 	"context"

--- a/internal/inspector/inspector_test.go
+++ b/internal/inspector/inspector_test.go
@@ -1,4 +1,4 @@
-package aws
+package inspector
 
 import (
 	"context"
@@ -63,7 +63,7 @@ func TestRunSecurityScanSortsFindingsBySeverityAndResource(t *testing.T) {
 		},
 	})
 
-	report, err := (&AwsRepository{}).RunSecurityScan(context.Background())
+	report, err := RunSecurityScan(context.Background(), &AwsRepository{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestRunSecurityScanCollectsWarningsAndContinues(t *testing.T) {
 		},
 	})
 
-	report, err := (&AwsRepository{}).RunSecurityScan(context.Background())
+	report, err := RunSecurityScan(context.Background(), &AwsRepository{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestRunSecurityScanStopsWhenContextCanceledBetweenScanners(t *testing.T) {
 		},
 	})
 
-	report, err := (&AwsRepository{}).RunSecurityScan(ctx)
+	report, err := RunSecurityScan(ctx, &AwsRepository{})
 	if err == nil {
 		t.Fatal("expected context cancellation error")
 	}

--- a/internal/inspector/sort.go
+++ b/internal/inspector/sort.go
@@ -1,0 +1,13 @@
+package inspector
+
+import "strings"
+
+func normalizedSortKey(values ...string) string {
+	for _, value := range values {
+		key := strings.ToLower(strings.TrimSpace(value))
+		if key != "" {
+			return key
+		}
+	}
+	return ""
+}

--- a/internal/inspector/test_helpers_test.go
+++ b/internal/inspector/test_helpers_test.go
@@ -1,0 +1,351 @@
+package inspector
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+type mockS3Client struct {
+	listBucketsFunc           func(ctx context.Context, params *s3.ListBucketsInput, optFns ...func(*s3.Options)) (*s3.ListBucketsOutput, error)
+	listObjectsV2Func         func(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+	headObjectFunc            func(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
+	getBucketLocationFunc     func(ctx context.Context, params *s3.GetBucketLocationInput, optFns ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error)
+	getBucketAclFunc          func(ctx context.Context, params *s3.GetBucketAclInput, optFns ...func(*s3.Options)) (*s3.GetBucketAclOutput, error)
+	getPublicAccessBlockFunc  func(ctx context.Context, params *s3.GetPublicAccessBlockInput, optFns ...func(*s3.Options)) (*s3.GetPublicAccessBlockOutput, error)
+	getBucketPolicyStatusFunc func(ctx context.Context, params *s3.GetBucketPolicyStatusInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error)
+	getBucketVersioningFunc   func(ctx context.Context, params *s3.GetBucketVersioningInput, optFns ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error)
+}
+
+func (m *mockS3Client) ListBuckets(ctx context.Context, params *s3.ListBucketsInput, optFns ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
+	return m.listBucketsFunc(ctx, params, optFns...)
+}
+
+func (m *mockS3Client) ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	if m.listObjectsV2Func != nil {
+		return m.listObjectsV2Func(ctx, params, optFns...)
+	}
+	return &s3.ListObjectsV2Output{}, nil
+}
+
+func (m *mockS3Client) HeadObject(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
+	if m.headObjectFunc != nil {
+		return m.headObjectFunc(ctx, params, optFns...)
+	}
+	return &s3.HeadObjectOutput{}, nil
+}
+
+func (m *mockS3Client) GetBucketLocation(ctx context.Context, params *s3.GetBucketLocationInput, optFns ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error) {
+	if m.getBucketLocationFunc != nil {
+		return m.getBucketLocationFunc(ctx, params, optFns...)
+	}
+	return &s3.GetBucketLocationOutput{}, nil
+}
+
+func (m *mockS3Client) GetBucketAcl(ctx context.Context, params *s3.GetBucketAclInput, optFns ...func(*s3.Options)) (*s3.GetBucketAclOutput, error) {
+	if m.getBucketAclFunc != nil {
+		return m.getBucketAclFunc(ctx, params, optFns...)
+	}
+	return &s3.GetBucketAclOutput{}, nil
+}
+
+func (m *mockS3Client) GetPublicAccessBlock(ctx context.Context, params *s3.GetPublicAccessBlockInput, optFns ...func(*s3.Options)) (*s3.GetPublicAccessBlockOutput, error) {
+	if m.getPublicAccessBlockFunc != nil {
+		return m.getPublicAccessBlockFunc(ctx, params, optFns...)
+	}
+	return &s3.GetPublicAccessBlockOutput{}, nil
+}
+
+func (m *mockS3Client) GetBucketPolicyStatus(ctx context.Context, params *s3.GetBucketPolicyStatusInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error) {
+	if m.getBucketPolicyStatusFunc != nil {
+		return m.getBucketPolicyStatusFunc(ctx, params, optFns...)
+	}
+	return &s3.GetBucketPolicyStatusOutput{}, nil
+}
+
+func (m *mockS3Client) GetBucketVersioning(ctx context.Context, params *s3.GetBucketVersioningInput, optFns ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error) {
+	if m.getBucketVersioningFunc != nil {
+		return m.getBucketVersioningFunc(ctx, params, optFns...)
+	}
+	return &s3.GetBucketVersioningOutput{}, nil
+}
+
+type mockRDSClient struct {
+	describeDBInstancesFunc            func(ctx context.Context, params *rds.DescribeDBInstancesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error)
+	describeDBSnapshotsFunc            func(ctx context.Context, params *rds.DescribeDBSnapshotsInput, optFns ...func(*rds.Options)) (*rds.DescribeDBSnapshotsOutput, error)
+	describeDBSnapshotAttributesFunc   func(ctx context.Context, params *rds.DescribeDBSnapshotAttributesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBSnapshotAttributesOutput, error)
+	describeDBClusterSnapshotsFunc     func(ctx context.Context, params *rds.DescribeDBClusterSnapshotsInput, optFns ...func(*rds.Options)) (*rds.DescribeDBClusterSnapshotsOutput, error)
+	describeDBClusterSnapshotAttrsFunc func(ctx context.Context, params *rds.DescribeDBClusterSnapshotAttributesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBClusterSnapshotAttributesOutput, error)
+	stopDBInstanceFunc                 func(ctx context.Context, params *rds.StopDBInstanceInput, optFns ...func(*rds.Options)) (*rds.StopDBInstanceOutput, error)
+	startDBInstanceFunc                func(ctx context.Context, params *rds.StartDBInstanceInput, optFns ...func(*rds.Options)) (*rds.StartDBInstanceOutput, error)
+	rebootDBInstanceFunc               func(ctx context.Context, params *rds.RebootDBInstanceInput, optFns ...func(*rds.Options)) (*rds.RebootDBInstanceOutput, error)
+	stopDBClusterFunc                  func(ctx context.Context, params *rds.StopDBClusterInput, optFns ...func(*rds.Options)) (*rds.StopDBClusterOutput, error)
+	startDBClusterFunc                 func(ctx context.Context, params *rds.StartDBClusterInput, optFns ...func(*rds.Options)) (*rds.StartDBClusterOutput, error)
+	failoverDBClusterFunc              func(ctx context.Context, params *rds.FailoverDBClusterInput, optFns ...func(*rds.Options)) (*rds.FailoverDBClusterOutput, error)
+}
+
+func (m *mockRDSClient) DescribeDBInstances(ctx context.Context, params *rds.DescribeDBInstancesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error) {
+	if m.describeDBInstancesFunc != nil {
+		return m.describeDBInstancesFunc(ctx, params, optFns...)
+	}
+	return &rds.DescribeDBInstancesOutput{}, nil
+}
+
+func (m *mockRDSClient) DescribeDBSnapshots(ctx context.Context, params *rds.DescribeDBSnapshotsInput, optFns ...func(*rds.Options)) (*rds.DescribeDBSnapshotsOutput, error) {
+	if m.describeDBSnapshotsFunc != nil {
+		return m.describeDBSnapshotsFunc(ctx, params, optFns...)
+	}
+	return &rds.DescribeDBSnapshotsOutput{}, nil
+}
+
+func (m *mockRDSClient) DescribeDBSnapshotAttributes(ctx context.Context, params *rds.DescribeDBSnapshotAttributesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBSnapshotAttributesOutput, error) {
+	if m.describeDBSnapshotAttributesFunc != nil {
+		return m.describeDBSnapshotAttributesFunc(ctx, params, optFns...)
+	}
+	return &rds.DescribeDBSnapshotAttributesOutput{}, nil
+}
+
+func (m *mockRDSClient) DescribeDBClusterSnapshots(ctx context.Context, params *rds.DescribeDBClusterSnapshotsInput, optFns ...func(*rds.Options)) (*rds.DescribeDBClusterSnapshotsOutput, error) {
+	if m.describeDBClusterSnapshotsFunc != nil {
+		return m.describeDBClusterSnapshotsFunc(ctx, params, optFns...)
+	}
+	return &rds.DescribeDBClusterSnapshotsOutput{}, nil
+}
+
+func (m *mockRDSClient) DescribeDBClusterSnapshotAttributes(ctx context.Context, params *rds.DescribeDBClusterSnapshotAttributesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBClusterSnapshotAttributesOutput, error) {
+	if m.describeDBClusterSnapshotAttrsFunc != nil {
+		return m.describeDBClusterSnapshotAttrsFunc(ctx, params, optFns...)
+	}
+	return &rds.DescribeDBClusterSnapshotAttributesOutput{}, nil
+}
+
+func (m *mockRDSClient) StopDBInstance(ctx context.Context, params *rds.StopDBInstanceInput, optFns ...func(*rds.Options)) (*rds.StopDBInstanceOutput, error) {
+	if m.stopDBInstanceFunc != nil {
+		return m.stopDBInstanceFunc(ctx, params, optFns...)
+	}
+	return &rds.StopDBInstanceOutput{}, nil
+}
+
+func (m *mockRDSClient) StartDBInstance(ctx context.Context, params *rds.StartDBInstanceInput, optFns ...func(*rds.Options)) (*rds.StartDBInstanceOutput, error) {
+	if m.startDBInstanceFunc != nil {
+		return m.startDBInstanceFunc(ctx, params, optFns...)
+	}
+	return &rds.StartDBInstanceOutput{}, nil
+}
+
+func (m *mockRDSClient) RebootDBInstance(ctx context.Context, params *rds.RebootDBInstanceInput, optFns ...func(*rds.Options)) (*rds.RebootDBInstanceOutput, error) {
+	if m.rebootDBInstanceFunc != nil {
+		return m.rebootDBInstanceFunc(ctx, params, optFns...)
+	}
+	return &rds.RebootDBInstanceOutput{}, nil
+}
+
+func (m *mockRDSClient) StopDBCluster(ctx context.Context, params *rds.StopDBClusterInput, optFns ...func(*rds.Options)) (*rds.StopDBClusterOutput, error) {
+	if m.stopDBClusterFunc != nil {
+		return m.stopDBClusterFunc(ctx, params, optFns...)
+	}
+	return &rds.StopDBClusterOutput{}, nil
+}
+
+func (m *mockRDSClient) StartDBCluster(ctx context.Context, params *rds.StartDBClusterInput, optFns ...func(*rds.Options)) (*rds.StartDBClusterOutput, error) {
+	if m.startDBClusterFunc != nil {
+		return m.startDBClusterFunc(ctx, params, optFns...)
+	}
+	return &rds.StartDBClusterOutput{}, nil
+}
+
+func (m *mockRDSClient) FailoverDBCluster(ctx context.Context, params *rds.FailoverDBClusterInput, optFns ...func(*rds.Options)) (*rds.FailoverDBClusterOutput, error) {
+	if m.failoverDBClusterFunc != nil {
+		return m.failoverDBClusterFunc(ctx, params, optFns...)
+	}
+	return &rds.FailoverDBClusterOutput{}, nil
+}
+
+type mockEC2Client struct {
+	describeVpcsFunc                    func(ctx context.Context, params *ec2.DescribeVpcsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error)
+	describeSubnetsFunc                 func(ctx context.Context, params *ec2.DescribeSubnetsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error)
+	describeInstancesFunc               func(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
+	describeSnapshotsFunc               func(ctx context.Context, params *ec2.DescribeSnapshotsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSnapshotsOutput, error)
+	describeSnapshotAttributeFunc       func(ctx context.Context, params *ec2.DescribeSnapshotAttributeInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSnapshotAttributeOutput, error)
+	describeNetworkInterfacesFunc       func(ctx context.Context, params *ec2.DescribeNetworkInterfacesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeNetworkInterfacesOutput, error)
+	describeInternetGatewaysFunc        func(ctx context.Context, params *ec2.DescribeInternetGatewaysInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInternetGatewaysOutput, error)
+	describeVpcEndpointsFunc            func(ctx context.Context, params *ec2.DescribeVpcEndpointsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcEndpointsOutput, error)
+	describeVpcPeeringConnectionsFunc   func(ctx context.Context, params *ec2.DescribeVpcPeeringConnectionsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcPeeringConnectionsOutput, error)
+	describeTransitGatewaysFunc         func(ctx context.Context, params *ec2.DescribeTransitGatewaysInput, optFns ...func(*ec2.Options)) (*ec2.DescribeTransitGatewaysOutput, error)
+	describeTransitGatewayAttachFunc    func(ctx context.Context, params *ec2.DescribeTransitGatewayAttachmentsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeTransitGatewayAttachmentsOutput, error)
+	describeVpnGatewaysFunc             func(ctx context.Context, params *ec2.DescribeVpnGatewaysInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpnGatewaysOutput, error)
+	describeVpcEndpointServicesFunc     func(ctx context.Context, params *ec2.DescribeVpcEndpointServiceConfigurationsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcEndpointServiceConfigurationsOutput, error)
+	createNetworkInsightsPathFunc       func(ctx context.Context, params *ec2.CreateNetworkInsightsPathInput, optFns ...func(*ec2.Options)) (*ec2.CreateNetworkInsightsPathOutput, error)
+	startNetworkInsightsAnalysisFunc    func(ctx context.Context, params *ec2.StartNetworkInsightsAnalysisInput, optFns ...func(*ec2.Options)) (*ec2.StartNetworkInsightsAnalysisOutput, error)
+	describeNetworkInsightsAnalysesFunc func(ctx context.Context, params *ec2.DescribeNetworkInsightsAnalysesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeNetworkInsightsAnalysesOutput, error)
+	deleteNetworkInsightsAnalysisFunc   func(ctx context.Context, params *ec2.DeleteNetworkInsightsAnalysisInput, optFns ...func(*ec2.Options)) (*ec2.DeleteNetworkInsightsAnalysisOutput, error)
+	deleteNetworkInsightsPathFunc       func(ctx context.Context, params *ec2.DeleteNetworkInsightsPathInput, optFns ...func(*ec2.Options)) (*ec2.DeleteNetworkInsightsPathOutput, error)
+	describeSecurityGroupsFunc          func(ctx context.Context, params *ec2.DescribeSecurityGroupsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error)
+	authorizeSGIngressFunc              func(ctx context.Context, params *ec2.AuthorizeSecurityGroupIngressInput, optFns ...func(*ec2.Options)) (*ec2.AuthorizeSecurityGroupIngressOutput, error)
+	authorizeSGEgressFunc               func(ctx context.Context, params *ec2.AuthorizeSecurityGroupEgressInput, optFns ...func(*ec2.Options)) (*ec2.AuthorizeSecurityGroupEgressOutput, error)
+	revokeSGIngressFunc                 func(ctx context.Context, params *ec2.RevokeSecurityGroupIngressInput, optFns ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupIngressOutput, error)
+	revokeSGEgressFunc                  func(ctx context.Context, params *ec2.RevokeSecurityGroupEgressInput, optFns ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupEgressOutput, error)
+}
+
+func (m *mockEC2Client) DescribeVpcs(ctx context.Context, params *ec2.DescribeVpcsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error) {
+	if m.describeVpcsFunc != nil {
+		return m.describeVpcsFunc(ctx, params, optFns...)
+	}
+	return &ec2.DescribeVpcsOutput{}, nil
+}
+
+func (m *mockEC2Client) DescribeSubnets(ctx context.Context, params *ec2.DescribeSubnetsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error) {
+	if m.describeSubnetsFunc != nil {
+		return m.describeSubnetsFunc(ctx, params, optFns...)
+	}
+	return &ec2.DescribeSubnetsOutput{}, nil
+}
+
+func (m *mockEC2Client) DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	if m.describeInstancesFunc != nil {
+		return m.describeInstancesFunc(ctx, params, optFns...)
+	}
+	return &ec2.DescribeInstancesOutput{}, nil
+}
+
+func (m *mockEC2Client) DescribeSnapshots(ctx context.Context, params *ec2.DescribeSnapshotsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSnapshotsOutput, error) {
+	if m.describeSnapshotsFunc != nil {
+		return m.describeSnapshotsFunc(ctx, params, optFns...)
+	}
+	return &ec2.DescribeSnapshotsOutput{}, nil
+}
+
+func (m *mockEC2Client) DescribeSnapshotAttribute(ctx context.Context, params *ec2.DescribeSnapshotAttributeInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSnapshotAttributeOutput, error) {
+	if m.describeSnapshotAttributeFunc != nil {
+		return m.describeSnapshotAttributeFunc(ctx, params, optFns...)
+	}
+	return &ec2.DescribeSnapshotAttributeOutput{}, nil
+}
+
+func (m *mockEC2Client) DescribeNetworkInterfaces(ctx context.Context, params *ec2.DescribeNetworkInterfacesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeNetworkInterfacesOutput, error) {
+	if m.describeNetworkInterfacesFunc != nil {
+		return m.describeNetworkInterfacesFunc(ctx, params, optFns...)
+	}
+	return &ec2.DescribeNetworkInterfacesOutput{}, nil
+}
+
+func (m *mockEC2Client) DescribeInternetGateways(ctx context.Context, params *ec2.DescribeInternetGatewaysInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInternetGatewaysOutput, error) {
+	if m.describeInternetGatewaysFunc != nil {
+		return m.describeInternetGatewaysFunc(ctx, params, optFns...)
+	}
+	return &ec2.DescribeInternetGatewaysOutput{}, nil
+}
+
+func (m *mockEC2Client) DescribeVpcEndpoints(ctx context.Context, params *ec2.DescribeVpcEndpointsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcEndpointsOutput, error) {
+	if m.describeVpcEndpointsFunc != nil {
+		return m.describeVpcEndpointsFunc(ctx, params, optFns...)
+	}
+	return &ec2.DescribeVpcEndpointsOutput{}, nil
+}
+
+func (m *mockEC2Client) DescribeVpcPeeringConnections(ctx context.Context, params *ec2.DescribeVpcPeeringConnectionsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcPeeringConnectionsOutput, error) {
+	if m.describeVpcPeeringConnectionsFunc != nil {
+		return m.describeVpcPeeringConnectionsFunc(ctx, params, optFns...)
+	}
+	return &ec2.DescribeVpcPeeringConnectionsOutput{}, nil
+}
+
+func (m *mockEC2Client) DescribeTransitGateways(ctx context.Context, params *ec2.DescribeTransitGatewaysInput, optFns ...func(*ec2.Options)) (*ec2.DescribeTransitGatewaysOutput, error) {
+	if m.describeTransitGatewaysFunc != nil {
+		return m.describeTransitGatewaysFunc(ctx, params, optFns...)
+	}
+	return &ec2.DescribeTransitGatewaysOutput{}, nil
+}
+
+func (m *mockEC2Client) DescribeTransitGatewayAttachments(ctx context.Context, params *ec2.DescribeTransitGatewayAttachmentsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeTransitGatewayAttachmentsOutput, error) {
+	if m.describeTransitGatewayAttachFunc != nil {
+		return m.describeTransitGatewayAttachFunc(ctx, params, optFns...)
+	}
+	return &ec2.DescribeTransitGatewayAttachmentsOutput{}, nil
+}
+
+func (m *mockEC2Client) DescribeVpnGateways(ctx context.Context, params *ec2.DescribeVpnGatewaysInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpnGatewaysOutput, error) {
+	if m.describeVpnGatewaysFunc != nil {
+		return m.describeVpnGatewaysFunc(ctx, params, optFns...)
+	}
+	return &ec2.DescribeVpnGatewaysOutput{}, nil
+}
+
+func (m *mockEC2Client) DescribeVpcEndpointServiceConfigurations(ctx context.Context, params *ec2.DescribeVpcEndpointServiceConfigurationsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcEndpointServiceConfigurationsOutput, error) {
+	if m.describeVpcEndpointServicesFunc != nil {
+		return m.describeVpcEndpointServicesFunc(ctx, params, optFns...)
+	}
+	return &ec2.DescribeVpcEndpointServiceConfigurationsOutput{}, nil
+}
+
+func (m *mockEC2Client) CreateNetworkInsightsPath(ctx context.Context, params *ec2.CreateNetworkInsightsPathInput, optFns ...func(*ec2.Options)) (*ec2.CreateNetworkInsightsPathOutput, error) {
+	if m.createNetworkInsightsPathFunc != nil {
+		return m.createNetworkInsightsPathFunc(ctx, params, optFns...)
+	}
+	return &ec2.CreateNetworkInsightsPathOutput{}, nil
+}
+
+func (m *mockEC2Client) StartNetworkInsightsAnalysis(ctx context.Context, params *ec2.StartNetworkInsightsAnalysisInput, optFns ...func(*ec2.Options)) (*ec2.StartNetworkInsightsAnalysisOutput, error) {
+	if m.startNetworkInsightsAnalysisFunc != nil {
+		return m.startNetworkInsightsAnalysisFunc(ctx, params, optFns...)
+	}
+	return &ec2.StartNetworkInsightsAnalysisOutput{}, nil
+}
+
+func (m *mockEC2Client) DescribeNetworkInsightsAnalyses(ctx context.Context, params *ec2.DescribeNetworkInsightsAnalysesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeNetworkInsightsAnalysesOutput, error) {
+	if m.describeNetworkInsightsAnalysesFunc != nil {
+		return m.describeNetworkInsightsAnalysesFunc(ctx, params, optFns...)
+	}
+	return &ec2.DescribeNetworkInsightsAnalysesOutput{}, nil
+}
+
+func (m *mockEC2Client) DeleteNetworkInsightsAnalysis(ctx context.Context, params *ec2.DeleteNetworkInsightsAnalysisInput, optFns ...func(*ec2.Options)) (*ec2.DeleteNetworkInsightsAnalysisOutput, error) {
+	if m.deleteNetworkInsightsAnalysisFunc != nil {
+		return m.deleteNetworkInsightsAnalysisFunc(ctx, params, optFns...)
+	}
+	return &ec2.DeleteNetworkInsightsAnalysisOutput{}, nil
+}
+
+func (m *mockEC2Client) DeleteNetworkInsightsPath(ctx context.Context, params *ec2.DeleteNetworkInsightsPathInput, optFns ...func(*ec2.Options)) (*ec2.DeleteNetworkInsightsPathOutput, error) {
+	if m.deleteNetworkInsightsPathFunc != nil {
+		return m.deleteNetworkInsightsPathFunc(ctx, params, optFns...)
+	}
+	return &ec2.DeleteNetworkInsightsPathOutput{}, nil
+}
+
+func (m *mockEC2Client) DescribeSecurityGroups(ctx context.Context, params *ec2.DescribeSecurityGroupsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error) {
+	if m.describeSecurityGroupsFunc != nil {
+		return m.describeSecurityGroupsFunc(ctx, params, optFns...)
+	}
+	return &ec2.DescribeSecurityGroupsOutput{}, nil
+}
+
+func (m *mockEC2Client) AuthorizeSecurityGroupIngress(ctx context.Context, params *ec2.AuthorizeSecurityGroupIngressInput, optFns ...func(*ec2.Options)) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
+	if m.authorizeSGIngressFunc != nil {
+		return m.authorizeSGIngressFunc(ctx, params, optFns...)
+	}
+	return &ec2.AuthorizeSecurityGroupIngressOutput{}, nil
+}
+
+func (m *mockEC2Client) AuthorizeSecurityGroupEgress(ctx context.Context, params *ec2.AuthorizeSecurityGroupEgressInput, optFns ...func(*ec2.Options)) (*ec2.AuthorizeSecurityGroupEgressOutput, error) {
+	if m.authorizeSGEgressFunc != nil {
+		return m.authorizeSGEgressFunc(ctx, params, optFns...)
+	}
+	return &ec2.AuthorizeSecurityGroupEgressOutput{}, nil
+}
+
+func (m *mockEC2Client) RevokeSecurityGroupIngress(ctx context.Context, params *ec2.RevokeSecurityGroupIngressInput, optFns ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupIngressOutput, error) {
+	if m.revokeSGIngressFunc != nil {
+		return m.revokeSGIngressFunc(ctx, params, optFns...)
+	}
+	return &ec2.RevokeSecurityGroupIngressOutput{}, nil
+}
+
+func (m *mockEC2Client) RevokeSecurityGroupEgress(ctx context.Context, params *ec2.RevokeSecurityGroupEgressInput, optFns ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupEgressOutput, error) {
+	if m.revokeSGEgressFunc != nil {
+		return m.revokeSGEgressFunc(ctx, params, optFns...)
+	}
+	return &ec2.RevokeSecurityGroupEgressOutput{}, nil
+}

--- a/internal/services/aws/iam.go
+++ b/internal/services/aws/iam.go
@@ -289,6 +289,10 @@ func (r *AwsRepository) listUserAccessKeys(ctx context.Context, userName string)
 	return keys, nil
 }
 
+func (r *AwsRepository) ListUserAccessKeys(ctx context.Context, userName string) ([]AccessKey, error) {
+	return r.listUserAccessKeys(ctx, userName)
+}
+
 func (r *AwsRepository) listUserGroups(ctx context.Context, userName string) ([]string, error) {
 	input := &iam.ListGroupsForUserInput{
 		UserName: awssdk.String(userName),


### PR DESCRIPTION
### Summary

- move inspector orchestration, findings, and rule packs into internal/inspector
- remove Inspector from the AWS service catalog and enter a dedicated Inspector mode with i
- add a distinct Inspector-mode color scheme and workflow chooser with live Security Inspector and a Checklist placeholder
- update README and architecture/project-overview docs to reflect the new package and UX split
- no breaking changes intended

### Related Issues

Closes #113

### Validation

- make test
- make build

### Checklist

- [x] Scope is focused
- [x] Branch name follows docs/branch-naming-harness.md
- [x] Documentation harness reviewed (docs/documentation-harness.md)
- [x] README updated if user-facing behavior changed
- [x] Relevant docs pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented
