### PR TITLE
feat: add Checklist Inspector v1 for infrastructure readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It combines a Bubble Tea application, Cobra-based CLI commands, and AWS SDK v2 c
 - Open a context-aware keyboard shortcut help screen with `?`
 - Show animated loading indicators while async AWS data is being fetched
 - Perform operational workflows such as SSM sessions, RDS control, Route53 record changes, ECS exec, and IAM access key rotation
-- Press `i` from the service picker to enter Inspector mode, then open the Security Inspector workflow for built-in findings across network exposure, RDS, IAM, Secrets Manager, S3, snapshot sharing, CloudTrail, GuardDuty, AWS Config, and ElastiCache for Valkey
+- Press `i` from the service picker to enter Inspector mode, then run either the Security Inspector workflow for built-in findings or the Checklist Inspector workflow for YAML-driven readiness checks across RDS, security groups, and secrets. Checklist files can be loaded from the in-TUI picker or preloaded with `--checklist <path>`
 
 ## Documentation Map
 
@@ -72,6 +72,7 @@ make build
 unic
 unic --profile my-profile
 unic --region ap-northeast-2
+unic --checklist ./checklists/readiness.yaml   # optional: pre-load a checklist at startup
 unic --verbose
 ```
 
@@ -216,9 +217,45 @@ Context ordering:
 | Workflow | Status | Notes |
 |---|---|---|
 | Security Inspector | Ready | Runs built-in rule packs and opens severity-filtered findings |
-| Checklist Inspector | Planned | Reserved Inspector-mode slot for future checklist-style workflows |
+| Checklist Inspector | Ready | Runs a YAML checklist and reports pass/fail per check with resource context and mismatch details |
 
 Security Inspector ships built-in rule packs for Security Group exposure, RDS encryption/public access/backups and public snapshot sharing, IAM access key age/root-account hardening/wildcard policies, Secrets Manager rotation age, S3 public access/Block Public Access/versioning, CloudTrail baseline coverage, GuardDuty and AWS Config baseline controls, and ElastiCache for Valkey encryption/backup/access-control checks.
+
+Checklist Inspector can load a YAML file either from the Inspector-mode file picker or from `--checklist` at startup, and currently supports three check types:
+
+- `rds` for expected DB instance state such as status, engine, class, Multi-AZ, encryption, public access, and backup retention
+- `security_group` for required or forbidden ingress/egress rule matchers
+- `secret` for rotation state, KMS key ID, and required JSON value keys
+
+Minimal checklist example:
+
+```yaml
+name: Production Readiness
+checks:
+  - type: rds
+    resource: prod-db
+    expect:
+      publicly_accessible: false
+      storage_encrypted: true
+      backup_retention_days: 7
+
+  - type: security_group
+    resource: sg-web
+    expect:
+      ingress_absent:
+        - protocol: tcp
+          from_port: 22
+          to_port: 22
+          cidr: 0.0.0.0/0
+
+  - type: secret
+    resource: prod/app
+    expect:
+      rotation_enabled: true
+      value_keys:
+        - username
+        - password
+```
 
 ## TUI Navigation
 
@@ -249,8 +286,9 @@ Security Inspector ships built-in rule packs for Security Group exposure, RDS en
 | IAM Key Rotation | `r` rotate, `c` copy exports, `a` apply and verify, `d` deactivate old key, `x` delete old key |
 | CloudWatch Logs | log groups/streams load 10 at a time, `n` load more, `1`-`6` time presets, `t` live tail, `f` filter pattern, `w` wrap toggle, `h/l` horizontal scroll |
 | ECS Exec | `r` refresh, `Enter` drill down / exec |
-| Inspector Mode | `i` open mode from the service list, `Enter` open the selected workflow |
+| Inspector Mode | `i` open mode from the service list, `Enter` open the selected workflow, `l` open the checklist file picker |
 | Security Inspector | `r` run/rescan, `1`-`5` severity filter, `Enter` finding detail |
+| Checklist Inspector | `l` load or switch checklist files, `r` run/rerun the loaded checklist, `Enter` result detail |
 | Context Picker | `a` add context, type or `/` filter, `s` setup selected context and quit, `y` copy selected exports and quit, `u` clear shell context and quit with a final confirmation message |
 
 Shared list filters now use fuzzy matching with inline match highlighting. Filtering is currently available on EC2 instances, IAM users, VPCs, subnets, RDS instances, Route53 zones/records, CloudWatch log groups/streams, Secrets Manager resources, ECS clusters/services, S3 buckets/objects, and the context picker.

--- a/cmd/unic/main.go
+++ b/cmd/unic/main.go
@@ -43,7 +43,7 @@ func main() {
 			"auth_type", string(cfg.AuthType),
 		)
 
-		p := tea.NewProgram(app.New(cfg, configPath, cli.Version), tea.WithAltScreen())
+		p := tea.NewProgram(app.New(cfg, configPath, cli.Version, cli.Checklist()), tea.WithAltScreen())
 		if _, err := p.Run(); err != nil {
 			return fmt.Errorf("TUI error: %w", err)
 		}

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -105,8 +105,9 @@ Pattern:
 
 - workflow-local finding/report models live here
 - Security Inspector scan orchestration and rule registration live here
+- Checklist Inspector YAML schema loading, checklist result models, and readiness runners live here
 - rule packs still depend on `internal/services/aws` repository methods and client interfaces rather than raw SDK setup
-- this package is the growth path for future inspector workflows such as Checklist Inspector
+- this package remains the growth path for future inspector workflows beyond Security and Checklist Inspector
 
 ### `internal/app/`
 
@@ -180,7 +181,7 @@ Current screen families include:
 - CloudWatch Logs group/stream/viewer flows
 - ECS cluster/service/task/container flows
 - S3 bucket/object/detail flows
-- Inspector mode home, workflow placeholder, and security findings/detail flows
+- Inspector mode home, checklist setup, security findings/detail, and checklist results/detail flows
 - context picker, context add, and TUI-native context setup/export/unset flows
 - SSO account / role selection and exit notice flows
 - loading and error screens

--- a/docs/architecture.ko.md
+++ b/docs/architecture.ko.md
@@ -105,8 +105,9 @@ cross-service inspector workflow와 rule pack을 담당한다.
 
 - workflow 전용 finding/report 모델은 여기서 관리
 - Security Inspector 스캔 orchestration과 rule 등록은 여기서 관리
+- Checklist Inspector YAML schema 로딩, checklist 결과 모델, readiness runner도 여기서 관리
 - rule pack은 raw SDK setup 대신 `internal/services/aws` repository 메서드와 client interface에 의존
-- Checklist Inspector 같은 후속 inspector workflow도 이 패턴으로 확장
+- Security / Checklist Inspector 이후의 후속 inspector workflow도 이 패턴으로 확장
 
 ### `internal/app/`
 
@@ -180,7 +181,7 @@ UNIC은 현재 세 가지 인증 모드를 지원한다.
 - CloudWatch Logs group/stream/viewer
 - ECS cluster/service/task/container
 - S3 bucket/object/detail
-- Inspector mode home, workflow placeholder, security findings/detail
+- Inspector mode home, checklist setup, security findings/detail, checklist results/detail
 - context picker, context add, TUI-native context setup/export/unset
 - SSO account / role selection, exit notice
 - loading, error

--- a/docs/project-overview.en.md
+++ b/docs/project-overview.en.md
@@ -27,9 +27,10 @@ The application already includes interactive mutation flows, polling-based statu
 
 1. Run `unic` to enter the TUI
 2. Select an AWS service and feature from the catalog, or press `i` to enter Inspector mode
-3. Drill into resource lists, inspector workflows, and detail views
-4. Execute supported actions when available
-5. Use `unic env` or `unic context setup` when shell exports are needed
+3. Optionally start `unic --checklist <path>` to pre-load Checklist Inspector, or load a YAML readiness file from the in-TUI checklist picker
+4. Drill into resource lists, inspector workflows, and detail views
+5. Execute supported actions when available
+6. Use `unic env` or `unic context setup` when shell exports are needed
 
 ## Configuration and Auth
 

--- a/docs/project-overview.ko.md
+++ b/docs/project-overview.ko.md
@@ -27,9 +27,10 @@ UNIC은 다음 세 가지를 결합한 Go 기반 AWS 터미널 콘솔이다.
 
 1. `unic`으로 TUI에 진입한다
 2. 카탈로그에서 AWS 서비스와 기능을 선택하거나 `i`로 Inspector mode에 진입한다
-3. 리소스 목록, inspector workflow, 상세 화면으로 drill-down 한다
-4. 가능한 액션을 수행한다
-5. 쉘 export가 필요하면 `unic env` 또는 `unic context setup`을 사용한다
+3. Checklist Inspector가 필요하면 `unic --checklist <path>`로 미리 넘겨 실행하거나, TUI 내부 checklist picker에서 YAML readiness 파일을 불러온다
+4. 리소스 목록, inspector workflow, 상세 화면으로 drill-down 한다
+5. 가능한 액션을 수행한다
+6. 쉘 export가 필요하면 `unic env` 또는 `unic context setup`을 사용한다
 
 ## 설정과 인증
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -64,9 +64,12 @@ const (
 	screenS3ObjectDetail
 	screenInspectorHome
 	screenInspectorWorkflowPlaceholder
+	screenInspectorChecklistPicker
 	screenInspectorScanning
 	screenInspectorResults
 	screenInspectorFindingDetail
+	screenInspectorChecklistResults
+	screenInspectorChecklistDetail
 	screenContextPicker
 	screenContextAdd
 	screenContextSSOAccountList
@@ -243,13 +246,22 @@ type Model struct {
 	selectedS3Object  *awsservice.S3ObjectDetail
 
 	// Inspector browser state
-	inspectorWorkflows       []inspector.Workflow
-	inspectorWorkflowIdx     int
-	inspectorReport          *inspector.SecurityScanReport
-	inspectorFindings        []inspector.SecurityFinding
-	inspectorIdx             int
-	inspectorSeverityFilter  inspector.RuleSeverity
-	selectedInspectorFinding *inspector.SecurityFinding
+	inspectorWorkflows        []inspector.Workflow
+	inspectorWorkflowIdx      int
+	inspectorChecklistPath    string
+	inspectorChecklistDir     string
+	inspectorChecklistFiles   []checklistPickerEntry
+	filteredChecklistFiles    []checklistPickerEntry
+	inspectorChecklistFileIdx int
+	inspectorChecklistError   string
+	inspectorReport           *inspector.SecurityScanReport
+	inspectorFindings         []inspector.SecurityFinding
+	inspectorIdx              int
+	inspectorSeverityFilter   inspector.RuleSeverity
+	selectedInspectorFinding  *inspector.SecurityFinding
+	inspectorChecklistReport  *inspector.ChecklistReport
+	inspectorChecklistIdx     int
+	selectedChecklistResult   *inspector.ChecklistResult
 
 	// Context picker
 	configPath         string
@@ -304,21 +316,26 @@ type Model struct {
 }
 
 // New creates a new app Model.
-func New(cfg *config.Config, configPath string, version string) Model {
+func New(cfg *config.Config, configPath string, version string, checklistPath ...string) Model {
 	services := domain.Catalog()
 	filterTI := newFilterInput()
+	var configuredChecklistPath string
+	if len(checklistPath) > 0 {
+		configuredChecklistPath = checklistPath[0]
+	}
 	model := Model{
-		cfg:                cfg,
-		configPath:         configPath,
-		currentVersion:     version,
-		screen:             screenContextPicker,
-		ctxPrevScreen:      screenServiceList,
-		services:           services,
-		inspectorWorkflows: inspector.Workflows(),
-		loadingSpinner:     newLoadingSpinner(),
-		filterTI:           filterTI,
-		filters:            make(map[filterTarget]string),
-		contextTable:       newContextTable(),
+		cfg:                    cfg,
+		configPath:             configPath,
+		currentVersion:         version,
+		screen:                 screenContextPicker,
+		ctxPrevScreen:          screenServiceList,
+		services:               services,
+		inspectorChecklistPath: configuredChecklistPath,
+		inspectorWorkflows:     inspector.Workflows(configuredChecklistPath),
+		loadingSpinner:         newLoadingSpinner(),
+		filterTI:               filterTI,
+		filters:                make(map[filterTarget]string),
+		contextTable:           newContextTable(),
 	}
 	model.cwLogs = newCloudWatchLogsModel()
 	return model
@@ -534,10 +551,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateInspectorHome(msg)
 		case screenInspectorWorkflowPlaceholder:
 			return m.updateInspectorWorkflowPlaceholder(msg)
+		case screenInspectorChecklistPicker:
+			return m.updateInspectorChecklistPicker(msg)
 		case screenInspectorResults:
 			return m.updateInspectorResults(msg)
 		case screenInspectorFindingDetail:
 			return m.updateInspectorFindingDetail(msg)
+		case screenInspectorChecklistResults:
+			return m.updateInspectorChecklistResults(msg)
+		case screenInspectorChecklistDetail:
+			return m.updateInspectorChecklistDetail(msg)
 		case screenSecurityGroupList:
 			return m.updateSecurityGroupList(msg)
 		case screenSecurityGroupDetail:
@@ -783,12 +806,18 @@ func (m Model) View() string {
 		v = m.viewInspectorHome()
 	case screenInspectorWorkflowPlaceholder:
 		v = m.viewInspectorWorkflowPlaceholder()
+	case screenInspectorChecklistPicker:
+		v = m.viewInspectorChecklistPicker()
 	case screenInspectorScanning:
 		v = m.viewInspectorScanning()
 	case screenInspectorResults:
 		v = m.viewInspectorResults()
 	case screenInspectorFindingDetail:
 		v = m.viewInspectorFindingDetail()
+	case screenInspectorChecklistResults:
+		v = m.viewInspectorChecklistResults()
+	case screenInspectorChecklistDetail:
+		v = m.viewInspectorChecklistDetail()
 	case screenSecurityGroupList:
 		v = m.viewSecurityGroupList()
 	case screenSecurityGroupDetail:

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +18,16 @@ import (
 
 func testConfig() *config.Config {
 	return &config.Config{Profile: "default", Region: "us-east-1"}
+}
+
+func writeChecklistFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write checklist file %s: %v", path, err)
+	}
+	return path
 }
 
 func TestNewModelNotQuitting(t *testing.T) {
@@ -1393,6 +1405,20 @@ func TestHandleInspectorScanLoadedMsgShowsResults(t *testing.T) {
 	}
 }
 
+func TestNewModelMarksChecklistWorkflowReadyWhenConfigured(t *testing.T) {
+	m := New(testConfig(), "", "dev", "/tmp/checklist.yaml")
+
+	if len(m.inspectorWorkflows) < 2 {
+		t.Fatalf("expected checklist workflow to be present, got %d workflows", len(m.inspectorWorkflows))
+	}
+	if !m.inspectorWorkflows[1].Available {
+		t.Fatalf("expected checklist workflow to be available, got %+v", m.inspectorWorkflows[1])
+	}
+	if got := m.inspectorWorkflows[1].StatusLabel(); got != "READY" {
+		t.Fatalf("expected READY status label, got %q", got)
+	}
+}
+
 func TestInspectorResultsSeverityFilterNarrowsFindings(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenInspectorResults
@@ -1437,18 +1463,187 @@ func TestInspectorResultsEnterShowsDetail(t *testing.T) {
 	}
 }
 
-func TestInspectorHomeChecklistEntersPlaceholder(t *testing.T) {
-	m := New(testConfig(), "", "dev")
+func TestHandleInspectorChecklistLoadedMsgShowsResults(t *testing.T) {
+	m := New(testConfig(), "", "dev", "/tmp/checklist.yaml")
+	report := &inspector.ChecklistReport{
+		ChecklistName: "Readiness",
+		Results: []inspector.ChecklistResult{
+			{
+				CheckID:  "secret-ready",
+				Title:    "Secret readiness",
+				Type:     inspector.ChecklistCheckSecret,
+				Resource: "prod/app",
+				Passed:   false,
+				Summary:  "1 expectation(s) did not match.",
+				Details:  []string{"missing value key \"password\""},
+			},
+		},
+	}
+
+	updated, _, handled := m.handleInspectorMsg(inspectorChecklistLoadedMsg{report: report})
+	if !handled {
+		t.Fatal("expected checklist scan message to be handled")
+	}
+
+	model := updated.(Model)
+	if model.screen != screenInspectorChecklistResults {
+		t.Fatalf("expected checklist results screen, got %d", model.screen)
+	}
+	if model.inspectorChecklistReport == nil || len(model.inspectorChecklistReport.Results) != 1 {
+		t.Fatalf("expected stored checklist report, got %+v", model.inspectorChecklistReport)
+	}
+}
+
+func TestInspectorHomeChecklistStartsDedicatedScanWhenConfigured(t *testing.T) {
+	m := New(testConfig(), "", "dev", "/tmp/checklist.yaml")
 	m.screen = screenInspectorHome
 	m.inspectorWorkflowIdx = 1
 
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	model := updated.(Model)
-	if model.screen != screenInspectorWorkflowPlaceholder {
-		t.Fatalf("expected checklist placeholder screen, got %d", model.screen)
+	if model.screen != screenInspectorScanning {
+		t.Fatalf("expected inspector scanning screen, got %d", model.screen)
+	}
+	if cmd == nil {
+		t.Fatal("expected checklist scan command")
+	}
+}
+
+func TestInspectorHomeChecklistOpensPickerWhenUnconfigured(t *testing.T) {
+	dir := t.TempDir()
+	checklistPath := writeChecklistFile(t, dir, "readiness.yaml", `
+name: Readiness
+checks:
+  - type: secret
+    resource: prod/app
+    expect:
+      rotation_enabled: true
+`)
+
+	m := New(testConfig(), "", "dev")
+	m.screen = screenInspectorHome
+	m.inspectorWorkflowIdx = 1
+	m.inspectorChecklistDir = dir
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model := updated.(Model)
+	if model.screen != screenInspectorChecklistPicker {
+		t.Fatalf("expected checklist picker screen, got %d", model.screen)
 	}
 	if cmd != nil {
-		t.Fatal("expected no command for placeholder workflow")
+		t.Fatal("expected no command when opening the checklist picker")
+	}
+	if len(model.filteredChecklistFiles) == 0 {
+		t.Fatal("expected checklist picker entries to be loaded")
+	}
+
+	found := false
+	for _, entry := range model.filteredChecklistFiles {
+		if entry.Path == checklistPath {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected picker to include %s, got %+v", checklistPath, model.filteredChecklistFiles)
+	}
+}
+
+func TestInspectorChecklistPickerEnterFileStartsScan(t *testing.T) {
+	dir := t.TempDir()
+	checklistPath := writeChecklistFile(t, dir, "readiness.yaml", `
+name: Readiness
+checks:
+  - type: secret
+    resource: prod/app
+    expect:
+      rotation_enabled: true
+`)
+
+	m := New(testConfig(), "", "dev")
+	m.screen = screenInspectorHome
+	m.inspectorWorkflowIdx = 1
+	m.inspectorChecklistDir = dir
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model := updated.(Model)
+	for i, entry := range model.filteredChecklistFiles {
+		if entry.Path == checklistPath {
+			model.inspectorChecklistFileIdx = i
+			break
+		}
+	}
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	if model.screen != screenInspectorScanning {
+		t.Fatalf("expected checklist scan screen, got %d", model.screen)
+	}
+	if cmd == nil {
+		t.Fatal("expected checklist scan command")
+	}
+	if model.inspectorChecklistPath != checklistPath {
+		t.Fatalf("expected checklist path %q, got %q", checklistPath, model.inspectorChecklistPath)
+	}
+	if !model.inspectorWorkflows[1].Available {
+		t.Fatalf("expected checklist workflow to be available after load, got %+v", model.inspectorWorkflows[1])
+	}
+}
+
+func TestInspectorChecklistPickerInvalidFileStaysOnPicker(t *testing.T) {
+	dir := t.TempDir()
+	checklistPath := writeChecklistFile(t, dir, "broken.yaml", "not: [valid")
+
+	m := New(testConfig(), "", "dev")
+	m.screen = screenInspectorHome
+	m.inspectorWorkflowIdx = 1
+	m.inspectorChecklistDir = dir
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model := updated.(Model)
+	for i, entry := range model.filteredChecklistFiles {
+		if entry.Path == checklistPath {
+			model.inspectorChecklistFileIdx = i
+			break
+		}
+	}
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	if model.screen != screenInspectorChecklistPicker {
+		t.Fatalf("expected checklist picker screen, got %d", model.screen)
+	}
+	if cmd != nil {
+		t.Fatal("expected no checklist scan command for an invalid file")
+	}
+	if model.inspectorChecklistError == "" {
+		t.Fatal("expected checklist picker error for invalid YAML")
+	}
+}
+
+func TestInspectorChecklistResultsEnterShowsDetail(t *testing.T) {
+	m := New(testConfig(), "", "dev", "/tmp/checklist.yaml")
+	m.screen = screenInspectorChecklistResults
+	m.inspectorChecklistReport = &inspector.ChecklistReport{
+		Results: []inspector.ChecklistResult{
+			{
+				CheckID:  "db-ready",
+				Title:    "Database baseline",
+				Type:     inspector.ChecklistCheckRDS,
+				Resource: "prod-db",
+				Passed:   true,
+				Summary:  "All expectations matched.",
+			},
+		},
+	}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model := updated.(Model)
+	if model.screen != screenInspectorChecklistDetail {
+		t.Fatalf("expected checklist detail screen, got %d", model.screen)
+	}
+	if model.selectedChecklistResult == nil {
+		t.Fatal("expected selected checklist result")
 	}
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1621,6 +1621,31 @@ func TestInspectorChecklistPickerInvalidFileStaysOnPicker(t *testing.T) {
 	}
 }
 
+func TestOpenChecklistPickerErrorReturnsUpdatedModel(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	lockedDir := filepath.Join(t.TempDir(), "locked")
+	if err := os.Mkdir(lockedDir, 0o755); err != nil {
+		t.Fatalf("failed to create locked checklist dir: %v", err)
+	}
+	if err := os.Chmod(lockedDir, 0o000); err != nil {
+		t.Fatalf("failed to lock checklist dir: %v", err)
+	}
+	defer os.Chmod(lockedDir, 0o755)
+
+	m.inspectorChecklistDir = lockedDir
+
+	updated, cmd := m.openChecklistPicker()
+	if cmd != nil {
+		t.Fatal("expected no command when checklist picker loading fails")
+	}
+	if updated.screen != screenError {
+		t.Fatalf("expected error screen, got %d", updated.screen)
+	}
+	if updated.errMsg == "" {
+		t.Fatal("expected error message when checklist picker directory cannot be loaded")
+	}
+}
+
 func TestInspectorChecklistResultsEnterShowsDetail(t *testing.T) {
 	m := New(testConfig(), "", "dev", "/tmp/checklist.yaml")
 	m.screen = screenInspectorChecklistResults

--- a/internal/app/filter.go
+++ b/internal/app/filter.go
@@ -27,6 +27,7 @@ const (
 	filterContexts
 	filterVPCs
 	filterSubnets
+	filterInspectorChecklistFiles
 )
 
 // Filterable is implemented by any type that supports text-based filtering.
@@ -183,6 +184,9 @@ func (m *Model) applyFilterTarget(target filterTarget) {
 	case filterSubnets:
 		m.filteredSubnets = applyFilter(m.subnets, m.filterValue(target))
 		m.subnetIdx = 0
+	case filterInspectorChecklistFiles:
+		m.filteredChecklistFiles = applyFilter(m.inspectorChecklistFiles, m.filterValue(target))
+		m.inspectorChecklistFileIdx = 0
 	}
 }
 

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -382,15 +382,25 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 		return []helpShortcut{
 			{"↑/↓, j/k", "Move between inspector workflows"},
 			{"enter", "Open the selected inspector workflow"},
+			{"l", "Open the checklist file picker when Checklist Inspector is selected"},
+			{"r", "Run the selected workflow when it is configured"},
 			{"q / esc", "Return to the service list"},
 		}
 	case screenInspectorWorkflowPlaceholder:
 		return []helpShortcut{
+			{"enter / l", "Open the checklist file picker"},
+			{"q / esc", "Go back to Inspector mode"},
+		}
+	case screenInspectorChecklistPicker:
+		return []helpShortcut{
+			{"↑/↓, j/k", "Move between checklist folders and files"},
+			{"/", "Start filtering entries"},
+			{"enter", "Open the selected folder or load the selected checklist"},
 			{"q / esc", "Go back to Inspector mode"},
 		}
 	case screenInspectorScanning:
 		return []helpShortcut{
-			{"Wait", "The security scan is still running"},
+			{"Wait", "The selected inspector workflow is still running"},
 		}
 	case screenInspectorResults:
 		return []helpShortcut{
@@ -404,6 +414,20 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 		return []helpShortcut{
 			{"r", "Run the security scan again"},
 			{"q / esc", "Go back to the findings list"},
+		}
+	case screenInspectorChecklistResults:
+		return []helpShortcut{
+			{"↑/↓, j/k", "Move between checklist results"},
+			{"enter", "Open the selected checklist result"},
+			{"l", "Open the checklist file picker"},
+			{"r", "Run the checklist again"},
+			{"q / esc", "Go back to Inspector mode"},
+		}
+	case screenInspectorChecklistDetail:
+		return []helpShortcut{
+			{"l", "Open the checklist file picker"},
+			{"r", "Run the checklist again"},
+			{"q / esc", "Go back to the checklist results"},
 		}
 	case screenContextPicker:
 		shortcuts := []helpShortcut{
@@ -616,13 +640,19 @@ func (m Model) helpScreenTitle() string {
 	case screenInspectorHome:
 		return "Inspector Mode"
 	case screenInspectorWorkflowPlaceholder:
-		return "Inspector Workflow"
+		return "Inspector Workflow Setup"
+	case screenInspectorChecklistPicker:
+		return "Checklist File Picker"
 	case screenInspectorScanning:
-		return "Inspector Scanning"
+		return "Inspector Workflow Scan"
 	case screenInspectorResults:
 		return "Inspector Findings"
 	case screenInspectorFindingDetail:
 		return "Inspector Finding Detail"
+	case screenInspectorChecklistResults:
+		return "Checklist Inspector Results"
+	case screenInspectorChecklistDetail:
+		return "Checklist Inspector Detail"
 	case screenContextPicker:
 		return "Context Picker"
 	case screenContextAdd:

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -203,3 +203,7 @@ type ecsExecDoneMsg struct {
 type inspectorScanLoadedMsg struct {
 	report *inspector.SecurityScanReport
 }
+
+type inspectorChecklistLoadedMsg struct {
+	report *inspector.ChecklistReport
+}

--- a/internal/app/screen_inspector.go
+++ b/internal/app/screen_inspector.go
@@ -3,6 +3,9 @@ package app
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -17,6 +20,8 @@ var (
 	inspectorSeverityHighStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("208")).Bold(true)
 	inspectorSeverityMediumStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("220")).Bold(true)
 	inspectorSeverityLowStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("114")).Bold(true)
+	inspectorChecklistPassStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("114")).Bold(true)
+	inspectorChecklistFailStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("203")).Bold(true)
 )
 
 var inspectorSeverityFilters = []inspector.RuleSeverity{
@@ -27,20 +32,39 @@ var inspectorSeverityFilters = []inspector.RuleSeverity{
 	inspector.RuleSeverityLow,
 }
 
-func (m *Model) ensureInspectorWorkflows() {
-	if len(m.inspectorWorkflows) == 0 {
-		m.inspectorWorkflows = inspector.Workflows()
-	}
+type checklistPickerEntry struct {
+	Name     string
+	Path     string
+	IsDir    bool
+	IsParent bool
+}
+
+func (e checklistPickerEntry) FilterText() string {
+	return strings.ToLower(fmt.Sprintf("%s %s", e.Name, e.Path))
+}
+
+func (m *Model) refreshInspectorWorkflows() {
+	m.inspectorWorkflows = inspector.Workflows(m.inspectorChecklistPath)
 	if m.inspectorWorkflowIdx >= len(m.inspectorWorkflows) {
 		m.inspectorWorkflowIdx = 0
 	}
+}
+
+func (m *Model) ensureInspectorWorkflows() {
+	if len(m.inspectorWorkflows) == 0 {
+		m.refreshInspectorWorkflows()
+		return
+	}
+	m.refreshInspectorWorkflows()
 }
 
 func (m *Model) enterInspectorMode() {
 	m.ensureInspectorWorkflows()
 	m.screen = screenInspectorHome
 	m.selectedInspectorFinding = nil
+	m.selectedChecklistResult = nil
 	m.inspectorIdx = 0
+	m.inspectorChecklistIdx = 0
 }
 
 func (m Model) currentInspectorWorkflow() inspector.Workflow {
@@ -53,6 +77,133 @@ func (m Model) currentInspectorWorkflow() inspector.Workflow {
 	return m.inspectorWorkflows[m.inspectorWorkflowIdx]
 }
 
+func (m Model) checklistWorkflowIndex() int {
+	for i, workflow := range m.inspectorWorkflows {
+		if workflow.Kind == inspector.WorkflowChecklist {
+			return i
+		}
+	}
+	return 0
+}
+
+func (m Model) initialChecklistPickerDir() string {
+	if dir := strings.TrimSpace(m.inspectorChecklistDir); dir != "" && checklistPickerDirExists(dir) {
+		return dir
+	}
+
+	checklistPath := strings.TrimSpace(m.inspectorChecklistPath)
+	if checklistPath != "" {
+		dir := filepath.Dir(checklistPath)
+		if checklistPickerDirExists(dir) {
+			return dir
+		}
+	}
+
+	cwd, err := os.Getwd()
+	if err == nil {
+		candidate := filepath.Join(cwd, "checklists")
+		if checklistPickerDirExists(candidate) {
+			return candidate
+		}
+		if checklistPickerDirExists(cwd) {
+			return cwd
+		}
+	}
+
+	return "."
+}
+
+func checklistPickerDirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func (m *Model) loadChecklistPickerEntries(dir string) error {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve checklist directory %s: %w", dir, err)
+	}
+
+	entries, err := os.ReadDir(absDir)
+	if err != nil {
+		return fmt.Errorf("failed to read checklist directory %s: %w", absDir, err)
+	}
+
+	items := make([]checklistPickerEntry, 0, len(entries)+1)
+	parent := filepath.Dir(absDir)
+	if parent != absDir {
+		items = append(items, checklistPickerEntry{
+			Name:     "..",
+			Path:     parent,
+			IsDir:    true,
+			IsParent: true,
+		})
+	}
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+
+		if entry.IsDir() {
+			items = append(items, checklistPickerEntry{
+				Name:  name,
+				Path:  filepath.Join(absDir, name),
+				IsDir: true,
+			})
+			continue
+		}
+
+		ext := strings.ToLower(filepath.Ext(name))
+		if ext != ".yaml" && ext != ".yml" {
+			continue
+		}
+
+		items = append(items, checklistPickerEntry{
+			Name: name,
+			Path: filepath.Join(absDir, name),
+		})
+	}
+
+	sort.SliceStable(items, func(i, j int) bool {
+		left := items[i]
+		right := items[j]
+		switch {
+		case left.IsParent != right.IsParent:
+			return left.IsParent
+		case left.IsDir != right.IsDir:
+			return left.IsDir
+		default:
+			return strings.ToLower(left.Name) < strings.ToLower(right.Name)
+		}
+	})
+
+	m.inspectorChecklistDir = absDir
+	m.inspectorChecklistFiles = items
+	m.inspectorChecklistError = ""
+	m.inspectorChecklistFileIdx = 0
+	m.storeFilterValue(filterInspectorChecklistFiles, "")
+	if m.activeFilter == filterInspectorChecklistFiles {
+		m.filterTI.Reset()
+		m.deactivateFilter()
+	}
+	m.applyFilterTarget(filterInspectorChecklistFiles)
+	return nil
+}
+
+func (m Model) openChecklistPicker() (tea.Model, tea.Cmd) {
+	if err := m.loadChecklistPickerEntries(m.initialChecklistPickerDir()); err != nil {
+		m.errMsg = err.Error()
+		m.screen = screenError
+		return m, nil
+	}
+
+	m.inspectorWorkflowIdx = m.checklistWorkflowIndex()
+	m.screen = screenInspectorChecklistPicker
+	return m, nil
+}
+
 func (m Model) handleInspectorMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 	switch msg := msg.(type) {
 	case inspectorScanLoadedMsg:
@@ -60,6 +211,12 @@ func (m Model) handleInspectorMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		m.selectedInspectorFinding = nil
 		m.applyInspectorSeverityFilter()
 		m.screen = screenInspectorResults
+		return m, nil, true
+	case inspectorChecklistLoadedMsg:
+		m.inspectorChecklistReport = msg.report
+		m.selectedChecklistResult = nil
+		m.inspectorChecklistIdx = 0
+		m.screen = screenInspectorChecklistResults
 		return m, nil, true
 	}
 	return m, nil, false
@@ -78,8 +235,12 @@ func (m Model) updateInspectorHome(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.inspectorWorkflowIdx++
 		}
 	case "r":
-		if m.currentInspectorWorkflow().Kind == inspector.WorkflowSecurity {
-			return m.startInspectorScan()
+		if m.currentInspectorWorkflow().Available {
+			return m.startInspectorWorkflow(m.currentInspectorWorkflow().Kind)
+		}
+	case "l":
+		if m.currentInspectorWorkflow().Kind == inspector.WorkflowChecklist {
+			return m.openChecklistPicker()
 		}
 	case "enter":
 		return m.openInspectorWorkflow()
@@ -89,6 +250,14 @@ func (m Model) updateInspectorHome(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m Model) openInspectorWorkflow() (tea.Model, tea.Cmd) {
 	workflow := m.currentInspectorWorkflow()
+	if workflow.Kind == inspector.WorkflowChecklist && !workflow.Available {
+		return m.openChecklistPicker()
+	}
+	if !workflow.Available {
+		m.screen = screenInspectorWorkflowPlaceholder
+		return m, nil
+	}
+
 	switch workflow.Kind {
 	case inspector.WorkflowSecurity:
 		if m.inspectorReport != nil {
@@ -96,17 +265,27 @@ func (m Model) openInspectorWorkflow() (tea.Model, tea.Cmd) {
 			m.screen = screenInspectorResults
 			return m, nil
 		}
-		return m.startInspectorScan()
 	case inspector.WorkflowChecklist:
-		m.screen = screenInspectorWorkflowPlaceholder
-		return m, nil
-	default:
-		return m, nil
+		if m.inspectorChecklistReport != nil {
+			m.inspectorChecklistIdx = 0
+			m.screen = screenInspectorChecklistResults
+			return m, nil
+		}
 	}
+	return m.startInspectorWorkflow(workflow.Kind)
 }
 
 func (m Model) updateInspectorWorkflowPlaceholder(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
+	case "l":
+		if m.currentInspectorWorkflow().Kind == inspector.WorkflowChecklist {
+			return m.openChecklistPicker()
+		}
+	case "enter":
+		if m.currentInspectorWorkflow().Kind == inspector.WorkflowChecklist {
+			return m.openChecklistPicker()
+		}
+		m.screen = screenInspectorHome
 	case "q", "esc":
 		m.screen = screenInspectorHome
 	}
@@ -133,7 +312,7 @@ func (m Model) updateInspectorResults(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.screen = screenInspectorFindingDetail
 		}
 	case "r":
-		return m.startInspectorScan()
+		return m.startInspectorWorkflow(inspector.WorkflowSecurity)
 	case "1", "2", "3", "4", "5":
 		idx := int(msg.String()[0] - '1')
 		if idx >= 0 && idx < len(inspectorSeverityFilters) {
@@ -149,9 +328,109 @@ func (m Model) updateInspectorFindingDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd)
 	case "q", "esc":
 		m.screen = screenInspectorResults
 	case "r":
-		return m.startInspectorScan()
+		return m.startInspectorWorkflow(inspector.WorkflowSecurity)
 	}
 	return m, nil
+}
+
+func (m Model) updateInspectorChecklistResults(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "esc":
+		m.selectedChecklistResult = nil
+		m.screen = screenInspectorHome
+	case "l":
+		return m.openChecklistPicker()
+	case "up", "k":
+		if m.inspectorChecklistIdx > 0 {
+			m.inspectorChecklistIdx--
+		}
+	case "down", "j":
+		if m.inspectorChecklistReport != nil && m.inspectorChecklistIdx < len(m.inspectorChecklistReport.Results)-1 {
+			m.inspectorChecklistIdx++
+		}
+	case "enter":
+		if m.inspectorChecklistReport != nil && len(m.inspectorChecklistReport.Results) > 0 && m.inspectorChecklistIdx < len(m.inspectorChecklistReport.Results) {
+			selected := m.inspectorChecklistReport.Results[m.inspectorChecklistIdx]
+			m.selectedChecklistResult = &selected
+			m.screen = screenInspectorChecklistDetail
+		}
+	case "r":
+		return m.startInspectorWorkflow(inspector.WorkflowChecklist)
+	}
+	return m, nil
+}
+
+func (m Model) updateInspectorChecklistDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "esc":
+		m.screen = screenInspectorChecklistResults
+	case "l":
+		return m.openChecklistPicker()
+	case "r":
+		return m.startInspectorWorkflow(inspector.WorkflowChecklist)
+	}
+	return m, nil
+}
+
+func (m Model) updateInspectorChecklistPicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if cmd, handled := m.updateSharedFilter(msg, filterInspectorChecklistFiles); handled {
+		return m, cmd
+	}
+
+	switch msg.String() {
+	case "q", "esc":
+		m.screen = screenInspectorHome
+	case "up", "k":
+		if m.inspectorChecklistFileIdx > 0 {
+			m.inspectorChecklistFileIdx--
+		}
+	case "down", "j":
+		if m.inspectorChecklistFileIdx < len(m.filteredChecklistFiles)-1 {
+			m.inspectorChecklistFileIdx++
+		}
+	case "/":
+		return m, m.activateFilter(filterInspectorChecklistFiles)
+	case "enter":
+		if len(m.filteredChecklistFiles) == 0 || m.inspectorChecklistFileIdx >= len(m.filteredChecklistFiles) {
+			return m, nil
+		}
+
+		selected := m.filteredChecklistFiles[m.inspectorChecklistFileIdx]
+		if selected.IsDir {
+			if err := m.loadChecklistPickerEntries(selected.Path); err != nil {
+				m.inspectorChecklistError = err.Error()
+			}
+			return m, nil
+		}
+
+		if _, err := inspector.LoadChecklist(selected.Path); err != nil {
+			m.inspectorChecklistError = err.Error()
+			return m, nil
+		}
+
+		m.inspectorChecklistPath = selected.Path
+		m.inspectorChecklistDir = filepath.Dir(selected.Path)
+		m.inspectorChecklistReport = nil
+		m.selectedChecklistResult = nil
+		m.inspectorChecklistIdx = 0
+		m.inspectorChecklistError = ""
+		m.refreshInspectorWorkflows()
+		m.inspectorWorkflowIdx = m.checklistWorkflowIndex()
+		return m.startChecklistScan()
+	}
+
+	return m, nil
+}
+
+func (m Model) startInspectorWorkflow(kind inspector.WorkflowKind) (tea.Model, tea.Cmd) {
+	switch kind {
+	case inspector.WorkflowChecklist:
+		return m.startChecklistScan()
+	case inspector.WorkflowSecurity:
+		fallthrough
+	default:
+		return m.startInspectorScan()
+	}
 }
 
 func (m Model) startInspectorScan() (tea.Model, tea.Cmd) {
@@ -159,6 +438,13 @@ func (m Model) startInspectorScan() (tea.Model, tea.Cmd) {
 	m.screen = screenInspectorScanning
 	m.loadingSpinner = newLoadingSpinner()
 	return m, tea.Batch(m.loadingSpinner.Tick, m.loadSecurityScan())
+}
+
+func (m Model) startChecklistScan() (tea.Model, tea.Cmd) {
+	m.selectedChecklistResult = nil
+	m.screen = screenInspectorScanning
+	m.loadingSpinner = newLoadingSpinner()
+	return m, tea.Batch(m.loadingSpinner.Tick, m.loadChecklistScan())
 }
 
 func (m Model) loadSecurityScan() tea.Cmd {
@@ -174,6 +460,32 @@ func (m Model) loadSecurityScan() tea.Cmd {
 			return errMsg{err: err}
 		}
 		return inspectorScanLoadedMsg{report: report}
+	}
+}
+
+func (m Model) loadChecklistScan() tea.Cmd {
+	return func() tea.Msg {
+		checklistPath := strings.TrimSpace(m.inspectorChecklistPath)
+		if checklistPath == "" {
+			return errMsg{err: fmt.Errorf("Checklist Inspector requires a loaded checklist file")}
+		}
+
+		checklist, err := inspector.LoadChecklist(checklistPath)
+		if err != nil {
+			return errMsg{err: err}
+		}
+
+		ctx := context.Background()
+		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
+		if err != nil {
+			return errMsg{err: err}
+		}
+
+		report, err := inspector.RunChecklist(ctx, repo, checklist)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		return inspectorChecklistLoadedMsg{report: report}
 	}
 }
 
@@ -245,16 +557,33 @@ func (m Model) viewInspectorHome() string {
 		}
 		panel.WriteString(inspectorAccentStyle.Render("  Enter opens the latest findings or starts a fresh scan. Press r to force a new scan."))
 	case inspector.WorkflowChecklist:
-		panel.WriteString(normalStyle.Render("  Checklist Inspector will live in this mode shell once the workflow engine ships."))
-		panel.WriteString("\n")
-		panel.WriteString(dimStyle.Render("  The dedicated Inspector mode is now separate from the AWS service picker so future cross-service audits do not pretend to be a service."))
+		if selected.Available {
+			panel.WriteString(normalStyle.Render("  Run the configured YAML checklist against the current AWS context."))
+			panel.WriteString("\n")
+			panel.WriteString(dimStyle.Render(fmt.Sprintf("  Checklist file: %s", m.inspectorChecklistPath)))
+			panel.WriteString("\n")
+			if m.inspectorChecklistReport != nil {
+				panel.WriteString(dimStyle.Render(fmt.Sprintf(
+					"  Last run: %s • pass:%d • fail:%d",
+					m.inspectorChecklistReport.ScannedAt.Local().Format("2006-01-02 15:04:05"),
+					m.inspectorChecklistReport.PassedCount,
+					m.inspectorChecklistReport.FailedCount,
+				)))
+				panel.WriteString("\n")
+			}
+			panel.WriteString(inspectorAccentStyle.Render("  Enter opens the latest report or starts a fresh scan. Press l to choose another file or r to force a new scan."))
+		} else {
+			panel.WriteString(normalStyle.Render("  Choose a YAML checklist file inside the TUI to enable checklist-driven readiness checks."))
+			panel.WriteString("\n")
+			panel.WriteString(dimStyle.Render("  Press enter or l to open the checklist file picker. You can still pass --checklist <path> at launch if you prefer."))
+		}
 	default:
 		panel.WriteString(dimStyle.Render("  No inspector workflows are registered."))
 	}
 
 	b.WriteString(m.renderListPanel(panel.String()))
 	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("↑/↓: choose workflow • enter: open • r: run security workflow • esc: services • H: home"))
+	b.WriteString(m.renderHelpBar("↑/↓: choose workflow • enter: open • l: load checklist • r: run selected workflow • esc: services • H: home"))
 	return b.String()
 }
 
@@ -265,26 +594,130 @@ func (m Model) viewInspectorWorkflowPlaceholder() string {
 	b.WriteString(m.renderStatusBar())
 	b.WriteString(m.renderModeTitle(workflow.Title))
 	b.WriteString("\n\n")
-	b.WriteString(normalStyle.Render("  This workflow now has a dedicated place in Inspector mode, but the underlying engine is not implemented yet."))
-	b.WriteString("\n")
-	b.WriteString(dimStyle.Render("  Security Inspector is live today; Checklist Inspector will plug into this same shell when #60 lands."))
+	if workflow.Kind == inspector.WorkflowChecklist {
+		b.WriteString(normalStyle.Render("  Checklist Inspector needs a checklist file before it can run."))
+		b.WriteString("\n")
+		b.WriteString(dimStyle.Render("  Press enter or l to open the file picker and load a YAML checklist for RDS, security groups, and secrets."))
+		b.WriteString("\n\n")
+		b.WriteString(renderDetailLine("Status", inspectorPlannedStyle.Render(workflow.StatusLabel())))
+		b.WriteString("\n")
+		b.WriteString(renderDetailLine("Description", normalStyle.Render(workflow.Description)))
+		b.WriteString("\n")
+		b.WriteString(renderDetailLine("Optional CLI", normalStyle.Render("unic --checklist ./checklists/readiness.yaml")))
+	} else {
+		b.WriteString(normalStyle.Render("  This workflow is not available yet."))
+		b.WriteString("\n\n")
+		b.WriteString(renderDetailLine("Status", inspectorPlannedStyle.Render(workflow.StatusLabel())))
+		b.WriteString("\n")
+		b.WriteString(renderDetailLine("Description", normalStyle.Render(workflow.Description)))
+	}
 	b.WriteString("\n\n")
-	b.WriteString(renderDetailLine("Status", inspectorPlannedStyle.Render(workflow.StatusLabel())))
+	b.WriteString(m.renderHelpBar("enter: load checklist • esc: back • H: home"))
+	return b.String()
+}
+
+func (m Model) viewInspectorChecklistPicker() string {
+	var b strings.Builder
+	var panel strings.Builder
+	b.WriteString(m.renderStatusBar())
+	b.WriteString(m.renderModeTitle("Checklist File Picker"))
 	b.WriteString("\n")
-	b.WriteString(renderDetailLine("Description", normalStyle.Render(workflow.Description)))
+	b.WriteString(dimStyle.Render("Browse folders and choose a .yaml or .yml file to load into Checklist Inspector."))
+	b.WriteString("\n")
+	b.WriteString(dimStyle.Render("Directory: " + m.inspectorChecklistDir))
+	if strings.TrimSpace(m.inspectorChecklistPath) != "" {
+		b.WriteString("\n")
+		b.WriteString(dimStyle.Render("Loaded: " + m.inspectorChecklistPath))
+	}
+	b.WriteString("\n")
+
+	b.WriteString(m.renderFilterValue(filterInspectorChecklistFiles))
 	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("esc: back • H: home"))
+
+	if m.inspectorChecklistError != "" {
+		panel.WriteString(errorStyle.Render("  " + m.inspectorChecklistError))
+		panel.WriteString("\n\n")
+	}
+
+	if len(m.filteredChecklistFiles) == 0 {
+		panel.WriteString(dimStyle.Render("  No checklist files or folders match the current filter"))
+		panel.WriteString("\n")
+	} else {
+		typeCol := lipgloss.NewStyle().Width(8)
+		panel.WriteString(dimStyle.Render("  " + typeCol.Render("TYPE") + "NAME"))
+		panel.WriteString("\n")
+
+		visibleLines := max(m.height-14, 5)
+		start := 0
+		if m.inspectorChecklistFileIdx >= visibleLines {
+			start = m.inspectorChecklistFileIdx - visibleLines + 1
+		}
+		end := min(start+visibleLines, len(m.filteredChecklistFiles))
+
+		for i := start; i < end; i++ {
+			entry := m.filteredChecklistFiles[i]
+			cursor := "  "
+			textStyle := normalStyle
+			if i == m.inspectorChecklistFileIdx {
+				cursor = "> "
+				textStyle = inspectorSelectedStyle
+			}
+
+			entryType := "file"
+			if entry.IsDir {
+				entryType = "dir"
+			}
+
+			name := entry.Name
+			if entry.IsDir && !entry.IsParent {
+				name += "/"
+			}
+			if entry.Path == m.inspectorChecklistPath {
+				name += " [loaded]"
+			}
+
+			row := cursor +
+				typeCol.Inherit(dimStyle).Render(entryType) +
+				textStyle.Render(m.renderHighlightedValue(filterInspectorChecklistFiles, name))
+			panel.WriteString(row)
+			panel.WriteString("\n")
+		}
+
+		panel.WriteString("\n")
+		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d entries", len(m.filteredChecklistFiles), len(m.inspectorChecklistFiles))))
+	}
+
+	b.WriteString(m.renderListPanel(panel.String()))
+	b.WriteString("\n\n")
+	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • enter: open/load • esc: Inspector mode • H: home"))
 	return b.String()
 }
 
 func (m Model) viewInspectorScanning() string {
+	var title string
+	var description string
+
+	switch m.currentInspectorWorkflow().Kind {
+	case inspector.WorkflowChecklist:
+		title = "Inspector Mode — Checklist Scan"
+		description = "  Verifying RDS instances, security groups, and secrets against the supplied checklist YAML."
+	default:
+		title = "Inspector Mode — Security Scan"
+		description = "  Checking network exposure, backups, key age, secret rotation, logging baselines, and bucket posture."
+	}
+
 	var b strings.Builder
 	b.WriteString(m.renderStatusBar())
-	b.WriteString(m.renderModeTitle("Inspector Mode — Security Scan"))
+	b.WriteString(m.renderModeTitle(title))
 	b.WriteString("\n\n")
-	b.WriteString(inspectorTitleStyle.Render(fmt.Sprintf("%s Running built-in rule packs...", m.loadingSpinner.View())))
+	switch m.currentInspectorWorkflow().Kind {
+	case inspector.WorkflowChecklist:
+		b.WriteString(inspectorTitleStyle.Render(fmt.Sprintf("%s Running checklist expectations...", m.loadingSpinner.View())))
+	default:
+		b.WriteString(inspectorTitleStyle.Render(fmt.Sprintf("%s Running built-in rule packs...", m.loadingSpinner.View())))
+	}
 	b.WriteString("\n")
-	b.WriteString(dimStyle.Render("  Checking network exposure, backups, key age, secret rotation, logging baselines, and bucket posture."))
+	b.WriteString(dimStyle.Render(description))
 	return b.String()
 }
 
@@ -353,7 +786,7 @@ func (m Model) viewInspectorResults() string {
 
 			resource := inspectorShorten(inspectorFindingResource(finding), resourceWidth)
 			row := cursor +
-				padInspectorSeverity(renderInspectorSeverity(finding.Severity), 11) +
+				padInspectorText(renderInspectorSeverity(finding.Severity), 11) +
 				" " +
 				resourceCol.Inherit(textStyle).Render(resource) +
 				textStyle.Render(finding.RuleName)
@@ -414,6 +847,134 @@ func (m Model) viewInspectorFindingDetail() string {
 	return b.String()
 }
 
+func (m Model) viewInspectorChecklistResults() string {
+	var b strings.Builder
+	var panel strings.Builder
+	b.WriteString(m.renderStatusBar())
+	b.WriteString(m.renderModeTitle("Checklist Inspector Results"))
+	b.WriteString("\n")
+
+	if m.inspectorChecklistReport != nil {
+		b.WriteString(dimStyle.Render(fmt.Sprintf(
+			"Checklist: %s  Scanned: %s  Pass: %d  Fail: %d",
+			m.inspectorChecklistReport.ChecklistName,
+			m.inspectorChecklistReport.ScannedAt.Local().Format("2006-01-02 15:04:05"),
+			m.inspectorChecklistReport.PassedCount,
+			m.inspectorChecklistReport.FailedCount,
+		)))
+		b.WriteString("\n")
+		if m.inspectorChecklistReport.SourcePath != "" {
+			b.WriteString(dimStyle.Render("Source: " + m.inspectorChecklistReport.SourcePath))
+			b.WriteString("\n")
+		}
+	}
+	b.WriteString("\n")
+
+	if m.inspectorChecklistReport == nil || len(m.inspectorChecklistReport.Results) == 0 {
+		panel.WriteString(dimStyle.Render("  No checklist results"))
+		panel.WriteString("\n")
+	} else {
+		typeWidth := 16
+		resourceWidth := 24
+		for _, result := range m.inspectorChecklistReport.Results {
+			resourceWidth = max(resourceWidth, len(checklistResultResource(result)))
+		}
+		if resourceWidth > 34 {
+			resourceWidth = 34
+		}
+
+		typeCol := lipgloss.NewStyle().Width(typeWidth)
+		resourceCol := lipgloss.NewStyle().Width(resourceWidth)
+		panel.WriteString(dimStyle.Render("  STATUS " + typeCol.Render("TYPE") + resourceCol.Render("RESOURCE") + "CHECK"))
+		panel.WriteString("\n")
+
+		visibleLines := max(m.height-14, 5)
+		start := 0
+		if m.inspectorChecklistIdx >= visibleLines {
+			start = m.inspectorChecklistIdx - visibleLines + 1
+		}
+		end := min(start+visibleLines, len(m.inspectorChecklistReport.Results))
+
+		for i := start; i < end; i++ {
+			result := m.inspectorChecklistReport.Results[i]
+			cursor := "  "
+			textStyle := normalStyle
+			if i == m.inspectorChecklistIdx {
+				cursor = "> "
+				textStyle = inspectorSelectedStyle
+			}
+
+			row := cursor +
+				padInspectorText(renderChecklistStatus(result.Passed), 6) +
+				" " +
+				typeCol.Inherit(textStyle).Render(string(result.Type)) +
+				resourceCol.Inherit(textStyle).Render(inspectorShorten(checklistResultResource(result), resourceWidth)) +
+				textStyle.Render(result.Title)
+			panel.WriteString(row)
+			panel.WriteString("\n")
+		}
+	}
+
+	b.WriteString(m.renderListPanel(panel.String()))
+	b.WriteString("\n\n")
+	b.WriteString(m.renderHelpBar("↑/↓: navigate • enter: detail • l: load checklist • r: rerun checklist • esc: Inspector mode • H: home"))
+	return b.String()
+}
+
+func (m Model) viewInspectorChecklistDetail() string {
+	if m.selectedChecklistResult == nil {
+		return ""
+	}
+
+	result := m.selectedChecklistResult
+	var b strings.Builder
+	b.WriteString(m.renderStatusBar())
+	b.WriteString(m.renderModeTitle("Checklist Inspector Detail"))
+	b.WriteString("\n\n")
+
+	b.WriteString(renderDetailLine("Status", renderChecklistStatus(result.Passed)))
+	b.WriteString("\n")
+	b.WriteString(renderDetailLine("Check", normalStyle.Render(result.Title)))
+	b.WriteString("\n")
+	b.WriteString(renderDetailLine("Check ID", normalStyle.Render(result.CheckID)))
+	b.WriteString("\n")
+	b.WriteString(renderDetailLine("Type", normalStyle.Render(string(result.Type))))
+	b.WriteString("\n")
+	b.WriteString(renderDetailLine("Target", normalStyle.Render(result.Resource)))
+	b.WriteString("\n")
+	if result.ResourceContext != "" && result.ResourceContext != result.Resource {
+		b.WriteString(renderDetailLine("Matched", normalStyle.Render(result.ResourceContext)))
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+
+	width := 80
+	if m.width > 0 {
+		width = max(m.width-4, 40)
+	}
+	paragraph := lipgloss.NewStyle().Width(width)
+
+	b.WriteString(inspectorSectionStyle.Render("Summary"))
+	b.WriteString("\n\n")
+	b.WriteString(paragraph.Render("  " + result.Summary))
+	b.WriteString("\n\n")
+
+	b.WriteString(inspectorSectionStyle.Render("Details"))
+	b.WriteString("\n\n")
+	if len(result.Details) == 0 {
+		b.WriteString(paragraph.Render("  No mismatches. All expectations matched."))
+	} else {
+		for _, detail := range result.Details {
+			b.WriteString(paragraph.Render("  - " + detail))
+			b.WriteString("\n")
+		}
+	}
+	b.WriteString("\n")
+
+	b.WriteString(m.renderHelpBar("esc: back • l: load checklist • r: rerun checklist • H: home"))
+	return b.String()
+}
+
 func (m Model) renderInspectorSeveritySelector() string {
 	parts := make([]string, 0, len(inspectorSeverityFilters))
 	for idx, severity := range inspectorSeverityFilters {
@@ -437,6 +998,16 @@ func inspectorFindingResource(finding inspector.SecurityFinding) string {
 	return "-"
 }
 
+func checklistResultResource(result inspector.ChecklistResult) string {
+	if result.ResourceContext != "" {
+		return result.ResourceContext
+	}
+	if result.Resource != "" {
+		return result.Resource
+	}
+	return "-"
+}
+
 func renderInspectorSeverity(severity inspector.RuleSeverity) string {
 	switch severity {
 	case inspector.RuleSeverityCritical:
@@ -452,7 +1023,14 @@ func renderInspectorSeverity(severity inspector.RuleSeverity) string {
 	}
 }
 
-func padInspectorSeverity(value string, width int) string {
+func renderChecklistStatus(passed bool) string {
+	if passed {
+		return inspectorChecklistPassStyle.Render("PASS")
+	}
+	return inspectorChecklistFailStyle.Render("FAIL")
+}
+
+func padInspectorText(value string, width int) string {
 	plainWidth := lipgloss.Width(value)
 	if plainWidth >= width {
 		return value

--- a/internal/app/screen_inspector.go
+++ b/internal/app/screen_inspector.go
@@ -192,7 +192,7 @@ func (m *Model) loadChecklistPickerEntries(dir string) error {
 	return nil
 }
 
-func (m Model) openChecklistPicker() (tea.Model, tea.Cmd) {
+func (m Model) openChecklistPicker() (Model, tea.Cmd) {
 	if err := m.loadChecklistPickerEntries(m.initialChecklistPickerDir()); err != nil {
 		m.errMsg = err.Error()
 		m.screen = screenError

--- a/internal/app/styles.go
+++ b/internal/app/styles.go
@@ -55,7 +55,7 @@ var (
 
 func (m Model) inspectorModeActive() bool {
 	switch m.screen {
-	case screenInspectorHome, screenInspectorWorkflowPlaceholder, screenInspectorScanning, screenInspectorResults, screenInspectorFindingDetail:
+	case screenInspectorHome, screenInspectorWorkflowPlaceholder, screenInspectorChecklistPicker, screenInspectorScanning, screenInspectorResults, screenInspectorFindingDetail, screenInspectorChecklistResults, screenInspectorChecklistDetail:
 		return true
 	default:
 		return false

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -8,9 +8,10 @@ var (
 	// Version is set via ldflags at build time.
 	Version = "dev"
 
-	profile string
-	region  string
-	verbose bool
+	profile   string
+	region    string
+	verbose   bool
+	checklist string
 )
 
 func NewRootCmd() *cobra.Command {
@@ -24,6 +25,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&profile, "profile", "p", "", "AWS profile to use")
 	cmd.PersistentFlags().StringVar(&region, "region", "", "AWS region to use")
 	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose debug logging")
+	cmd.PersistentFlags().StringVar(&checklist, "checklist", "", "Path to a checklist YAML file for Checklist Inspector")
 
 	cmd.AddCommand(newInitCmd())
 	cmd.AddCommand(newContextCmd())
@@ -52,4 +54,9 @@ func Region() *string {
 // Verbose returns true if --verbose was passed.
 func Verbose() bool {
 	return verbose
+}
+
+// Checklist returns the CLI checklist path, or an empty string if not set.
+func Checklist() string {
+	return checklist
 }

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -28,6 +28,10 @@ func TestRootCmdHasFlags(t *testing.T) {
 	if vf == nil {
 		t.Error("expected --verbose flag")
 	}
+	cf := cmd.PersistentFlags().Lookup("checklist")
+	if cf == nil {
+		t.Error("expected --checklist flag")
+	}
 	if vf != nil && vf.Shorthand != "v" {
 		t.Errorf("expected --verbose shorthand 'v', got '%s'", vf.Shorthand)
 	}

--- a/internal/inspector/checklist.go
+++ b/internal/inspector/checklist.go
@@ -1,0 +1,590 @@
+package inspector
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+type ChecklistCheckType string
+
+const (
+	ChecklistCheckRDS           ChecklistCheckType = "rds"
+	ChecklistCheckSecurityGroup ChecklistCheckType = "security_group"
+	ChecklistCheckSecret        ChecklistCheckType = "secret"
+)
+
+type Checklist struct {
+	Name        string           `yaml:"name,omitempty"`
+	Description string           `yaml:"description,omitempty"`
+	Checks      []ChecklistCheck `yaml:"checks"`
+	SourcePath  string           `yaml:"-"`
+}
+
+func (c Checklist) DisplayName() string {
+	if strings.TrimSpace(c.Name) != "" {
+		return c.Name
+	}
+	if strings.TrimSpace(c.SourcePath) != "" {
+		return filepath.Base(c.SourcePath)
+	}
+	return "Checklist"
+}
+
+type ChecklistCheck struct {
+	ID       string                `yaml:"id,omitempty"`
+	Title    string                `yaml:"title,omitempty"`
+	Type     ChecklistCheckType    `yaml:"type"`
+	Resource string                `yaml:"resource"`
+	Expect   ChecklistExpectations `yaml:"expect"`
+}
+
+func (c ChecklistCheck) DisplayTitle() string {
+	if strings.TrimSpace(c.Title) != "" {
+		return c.Title
+	}
+	if strings.TrimSpace(c.ID) != "" {
+		return c.ID
+	}
+	return fmt.Sprintf("%s %s", c.Type, c.Resource)
+}
+
+func (c ChecklistCheck) DisplayID() string {
+	if strings.TrimSpace(c.ID) != "" {
+		return c.ID
+	}
+	return fmt.Sprintf("%s:%s", c.Type, c.Resource)
+}
+
+type ChecklistExpectations struct {
+	Status              *string                      `yaml:"status,omitempty"`
+	Engine              *string                      `yaml:"engine,omitempty"`
+	EngineVersion       *string                      `yaml:"engine_version,omitempty"`
+	InstanceClass       *string                      `yaml:"instance_class,omitempty"`
+	MultiAZ             *bool                        `yaml:"multi_az,omitempty"`
+	StorageEncrypted    *bool                        `yaml:"storage_encrypted,omitempty"`
+	PubliclyAccessible  *bool                        `yaml:"publicly_accessible,omitempty"`
+	BackupRetentionDays *int                         `yaml:"backup_retention_days,omitempty"`
+	KMSKeyID            *string                      `yaml:"kms_key_id,omitempty"`
+	RotationEnabled     *bool                        `yaml:"rotation_enabled,omitempty"`
+	ValueKeys           []string                     `yaml:"value_keys,omitempty"`
+	IngressPresent      []ChecklistSecurityGroupRule `yaml:"ingress_present,omitempty"`
+	IngressAbsent       []ChecklistSecurityGroupRule `yaml:"ingress_absent,omitempty"`
+	EgressPresent       []ChecklistSecurityGroupRule `yaml:"egress_present,omitempty"`
+	EgressAbsent        []ChecklistSecurityGroupRule `yaml:"egress_absent,omitempty"`
+}
+
+func (e ChecklistExpectations) HasExpectationsFor(checkType ChecklistCheckType) bool {
+	switch checkType {
+	case ChecklistCheckRDS:
+		return e.Status != nil ||
+			e.Engine != nil ||
+			e.EngineVersion != nil ||
+			e.InstanceClass != nil ||
+			e.MultiAZ != nil ||
+			e.StorageEncrypted != nil ||
+			e.PubliclyAccessible != nil ||
+			e.BackupRetentionDays != nil
+	case ChecklistCheckSecurityGroup:
+		return len(e.IngressPresent) > 0 ||
+			len(e.IngressAbsent) > 0 ||
+			len(e.EgressPresent) > 0 ||
+			len(e.EgressAbsent) > 0
+	case ChecklistCheckSecret:
+		return e.KMSKeyID != nil ||
+			e.RotationEnabled != nil ||
+			len(e.ValueKeys) > 0
+	default:
+		return false
+	}
+}
+
+type ChecklistSecurityGroupRule struct {
+	Protocol       string `yaml:"protocol,omitempty"`
+	FromPort       *int   `yaml:"from_port,omitempty"`
+	ToPort         *int   `yaml:"to_port,omitempty"`
+	CIDR           string `yaml:"cidr,omitempty"`
+	CIDRv6         string `yaml:"cidr_v6,omitempty"`
+	ReferencedSGID string `yaml:"referenced_sg_id,omitempty"`
+}
+
+func (r ChecklistSecurityGroupRule) Valid() bool {
+	return strings.TrimSpace(r.Protocol) != "" ||
+		r.FromPort != nil ||
+		r.ToPort != nil ||
+		strings.TrimSpace(r.CIDR) != "" ||
+		strings.TrimSpace(r.CIDRv6) != "" ||
+		strings.TrimSpace(r.ReferencedSGID) != ""
+}
+
+func (r ChecklistSecurityGroupRule) Matches(actual SecurityGroupRule) bool {
+	if r.Protocol != "" && !strings.EqualFold(strings.TrimSpace(r.Protocol), strings.TrimSpace(actual.Protocol)) {
+		return false
+	}
+	if r.FromPort != nil && int32(*r.FromPort) != actual.FromPort {
+		return false
+	}
+	if r.ToPort != nil && int32(*r.ToPort) != actual.ToPort {
+		return false
+	}
+	if r.CIDR != "" && strings.TrimSpace(r.CIDR) != strings.TrimSpace(actual.CIDRV4) {
+		return false
+	}
+	if r.CIDRv6 != "" && strings.TrimSpace(r.CIDRv6) != strings.TrimSpace(actual.CIDRV6) {
+		return false
+	}
+	if r.ReferencedSGID != "" && strings.TrimSpace(r.ReferencedSGID) != strings.TrimSpace(actual.ReferencedSGID) {
+		return false
+	}
+	return true
+}
+
+func (r ChecklistSecurityGroupRule) DisplayTitle() string {
+	protocol := r.Protocol
+	if strings.TrimSpace(protocol) == "" {
+		protocol = "any"
+	}
+
+	portRange := "all ports"
+	switch {
+	case r.FromPort != nil && r.ToPort != nil && *r.FromPort == *r.ToPort:
+		portRange = fmt.Sprintf("port %d", *r.FromPort)
+	case r.FromPort != nil && r.ToPort != nil:
+		portRange = fmt.Sprintf("ports %d-%d", *r.FromPort, *r.ToPort)
+	case r.FromPort != nil:
+		portRange = fmt.Sprintf("from port %d", *r.FromPort)
+	case r.ToPort != nil:
+		portRange = fmt.Sprintf("to port %d", *r.ToPort)
+	}
+
+	target := "any target"
+	switch {
+	case strings.TrimSpace(r.CIDR) != "":
+		target = r.CIDR
+	case strings.TrimSpace(r.CIDRv6) != "":
+		target = r.CIDRv6
+	case strings.TrimSpace(r.ReferencedSGID) != "":
+		target = r.ReferencedSGID
+	}
+
+	return fmt.Sprintf("%s %s %s", protocol, portRange, target)
+}
+
+type ChecklistResult struct {
+	CheckID         string
+	Title           string
+	Type            ChecklistCheckType
+	Resource        string
+	ResourceContext string
+	Passed          bool
+	Summary         string
+	Details         []string
+}
+
+func (r ChecklistResult) StatusLabel() string {
+	if r.Passed {
+		return "PASS"
+	}
+	return "FAIL"
+}
+
+type ChecklistReport struct {
+	ChecklistName string
+	SourcePath    string
+	Results       []ChecklistResult
+	PassedCount   int
+	FailedCount   int
+	ScannedAt     time.Time
+}
+
+func LoadChecklist(path string) (*Checklist, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, fmt.Errorf("checklist path is required")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read checklist %s: %w", path, err)
+	}
+
+	var checklist Checklist
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&checklist); err != nil {
+		return nil, fmt.Errorf("failed to parse checklist %s: %w", path, err)
+	}
+
+	checklist.SourcePath = path
+	if err := checklist.validate(); err != nil {
+		return nil, err
+	}
+
+	return &checklist, nil
+}
+
+func (c Checklist) validate() error {
+	if len(c.Checks) == 0 {
+		return fmt.Errorf("checklist %s does not define any checks", c.DisplayName())
+	}
+
+	for idx, check := range c.Checks {
+		if strings.TrimSpace(check.Resource) == "" {
+			return fmt.Errorf("check %d is missing resource", idx+1)
+		}
+
+		switch check.Type {
+		case ChecklistCheckRDS, ChecklistCheckSecurityGroup, ChecklistCheckSecret:
+		default:
+			return fmt.Errorf("check %d has unsupported type %q", idx+1, check.Type)
+		}
+
+		if !check.Expect.HasExpectationsFor(check.Type) {
+			return fmt.Errorf("check %d (%s) does not define any expectations", idx+1, check.DisplayID())
+		}
+
+		for _, ruleSet := range [][]ChecklistSecurityGroupRule{
+			check.Expect.IngressPresent,
+			check.Expect.IngressAbsent,
+			check.Expect.EgressPresent,
+			check.Expect.EgressAbsent,
+		} {
+			for _, rule := range ruleSet {
+				if !rule.Valid() {
+					return fmt.Errorf("check %d (%s) contains an empty security group rule matcher", idx+1, check.DisplayID())
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+type checklistRunner struct {
+	repo *AwsRepository
+
+	rdsLoaded bool
+	rdsErr    error
+	rdsByID   map[string]RDSInstance
+
+	securityGroupsLoaded bool
+	securityGroupsErr    error
+	securityGroupsByID   map[string]SecurityGroup
+	securityGroupsByName map[string][]SecurityGroup
+
+	secretsLoaded bool
+	secretsErr    error
+	secretsByName map[string]Secret
+	secretsByARN  map[string]Secret
+	secretDetails map[string]*SecretDetail
+}
+
+func RunChecklist(ctx context.Context, repo *AwsRepository, checklist *Checklist) (*ChecklistReport, error) {
+	if checklist == nil {
+		return nil, fmt.Errorf("checklist is required")
+	}
+
+	runner := &checklistRunner{
+		repo:          repo,
+		secretDetails: make(map[string]*SecretDetail),
+	}
+	report := &ChecklistReport{
+		ChecklistName: checklist.DisplayName(),
+		SourcePath:    checklist.SourcePath,
+		ScannedAt:     time.Now().UTC(),
+	}
+
+	for _, check := range checklist.Checks {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		result := runner.runCheck(ctx, check)
+		report.Results = append(report.Results, result)
+		if result.Passed {
+			report.PassedCount++
+		} else {
+			report.FailedCount++
+		}
+	}
+
+	return report, nil
+}
+
+func (r *checklistRunner) runCheck(ctx context.Context, check ChecklistCheck) ChecklistResult {
+	switch check.Type {
+	case ChecklistCheckRDS:
+		return r.runRDSCheck(ctx, check)
+	case ChecklistCheckSecurityGroup:
+		return r.runSecurityGroupCheck(ctx, check)
+	case ChecklistCheckSecret:
+		return r.runSecretCheck(ctx, check)
+	default:
+		return failedChecklistResult(check, "", "Unsupported checklist type.", []string{
+			fmt.Sprintf("type %q is not supported", check.Type),
+		})
+	}
+}
+
+func (r *checklistRunner) runRDSCheck(ctx context.Context, check ChecklistCheck) ChecklistResult {
+	instance, err := r.findRDSInstance(ctx, check.Resource)
+	if err != nil {
+		return failedChecklistResult(check, "", "Target RDS instance could not be resolved.", []string{err.Error()})
+	}
+
+	var mismatches []string
+	expect := check.Expect
+	if expect.Status != nil && *expect.Status != instance.Status {
+		mismatches = append(mismatches, formatChecklistMismatch("status", *expect.Status, instance.Status))
+	}
+	if expect.Engine != nil && *expect.Engine != instance.Engine {
+		mismatches = append(mismatches, formatChecklistMismatch("engine", *expect.Engine, instance.Engine))
+	}
+	if expect.EngineVersion != nil && *expect.EngineVersion != instance.EngineVersion {
+		mismatches = append(mismatches, formatChecklistMismatch("engine_version", *expect.EngineVersion, instance.EngineVersion))
+	}
+	if expect.InstanceClass != nil && *expect.InstanceClass != instance.InstanceClass {
+		mismatches = append(mismatches, formatChecklistMismatch("instance_class", *expect.InstanceClass, instance.InstanceClass))
+	}
+	if expect.MultiAZ != nil && *expect.MultiAZ != instance.MultiAZ {
+		mismatches = append(mismatches, formatChecklistMismatch("multi_az", *expect.MultiAZ, instance.MultiAZ))
+	}
+	if expect.StorageEncrypted != nil && *expect.StorageEncrypted != instance.StorageEncrypted {
+		mismatches = append(mismatches, formatChecklistMismatch("storage_encrypted", *expect.StorageEncrypted, instance.StorageEncrypted))
+	}
+	if expect.PubliclyAccessible != nil && *expect.PubliclyAccessible != instance.PubliclyAccessible {
+		mismatches = append(mismatches, formatChecklistMismatch("publicly_accessible", *expect.PubliclyAccessible, instance.PubliclyAccessible))
+	}
+	if expect.BackupRetentionDays != nil && int32(*expect.BackupRetentionDays) != instance.BackupRetentionPeriod {
+		mismatches = append(mismatches, formatChecklistMismatch("backup_retention_days", *expect.BackupRetentionDays, instance.BackupRetentionPeriod))
+	}
+
+	return finalizeChecklistResult(check, instance.DBInstanceID, mismatches)
+}
+
+func (r *checklistRunner) runSecurityGroupCheck(ctx context.Context, check ChecklistCheck) ChecklistResult {
+	group, err := r.findSecurityGroup(ctx, check.Resource)
+	if err != nil {
+		return failedChecklistResult(check, "", "Target security group could not be resolved.", []string{err.Error()})
+	}
+
+	var mismatches []string
+	for _, expected := range check.Expect.IngressPresent {
+		if !checklistRuleExists(group.IngressRules, expected) {
+			mismatches = append(mismatches, fmt.Sprintf("missing ingress rule: %s", expected.DisplayTitle()))
+		}
+	}
+	for _, expected := range check.Expect.IngressAbsent {
+		if checklistRuleExists(group.IngressRules, expected) {
+			mismatches = append(mismatches, fmt.Sprintf("unexpected ingress rule present: %s", expected.DisplayTitle()))
+		}
+	}
+	for _, expected := range check.Expect.EgressPresent {
+		if !checklistRuleExists(group.EgressRules, expected) {
+			mismatches = append(mismatches, fmt.Sprintf("missing egress rule: %s", expected.DisplayTitle()))
+		}
+	}
+	for _, expected := range check.Expect.EgressAbsent {
+		if checklistRuleExists(group.EgressRules, expected) {
+			mismatches = append(mismatches, fmt.Sprintf("unexpected egress rule present: %s", expected.DisplayTitle()))
+		}
+	}
+
+	context := group.GroupID
+	if group.Name != "" {
+		context = fmt.Sprintf("%s (%s)", group.Name, group.GroupID)
+	}
+	return finalizeChecklistResult(check, context, mismatches)
+}
+
+func (r *checklistRunner) runSecretCheck(ctx context.Context, check ChecklistCheck) ChecklistResult {
+	secret, err := r.findSecret(ctx, check.Resource)
+	if err != nil {
+		return failedChecklistResult(check, "", "Target secret could not be resolved.", []string{err.Error()})
+	}
+
+	var mismatches []string
+	if check.Expect.KMSKeyID != nil && *check.Expect.KMSKeyID != secret.KMSKeyID {
+		mismatches = append(mismatches, formatChecklistMismatch("kms_key_id", *check.Expect.KMSKeyID, secret.KMSKeyID))
+	}
+	if check.Expect.RotationEnabled != nil && *check.Expect.RotationEnabled != secret.RotationEnabled {
+		mismatches = append(mismatches, formatChecklistMismatch("rotation_enabled", *check.Expect.RotationEnabled, secret.RotationEnabled))
+	}
+	if len(check.Expect.ValueKeys) > 0 {
+		detail, err := r.getSecretDetail(ctx, secret.Name)
+		if err != nil {
+			mismatches = append(mismatches, fmt.Sprintf("failed to load secret value: %v", err))
+		} else if len(detail.Values) == 0 {
+			mismatches = append(mismatches, "secret value is not a JSON object, so value_keys could not be verified")
+		} else {
+			for _, key := range check.Expect.ValueKeys {
+				if _, ok := detail.Values[key]; !ok {
+					mismatches = append(mismatches, fmt.Sprintf("missing value key %q", key))
+				}
+			}
+		}
+	}
+
+	return finalizeChecklistResult(check, secret.Name, mismatches)
+}
+
+func (r *checklistRunner) findRDSInstance(ctx context.Context, resource string) (*RDSInstance, error) {
+	if !r.rdsLoaded {
+		r.rdsLoaded = true
+		instances, err := r.repo.ListDBInstances(ctx)
+		if err != nil {
+			r.rdsErr = fmt.Errorf("failed to list RDS instances: %w", err)
+		} else {
+			r.rdsByID = make(map[string]RDSInstance, len(instances))
+			for _, instance := range instances {
+				r.rdsByID[normalizedChecklistKey(instance.DBInstanceID)] = instance
+			}
+		}
+	}
+	if r.rdsErr != nil {
+		return nil, r.rdsErr
+	}
+
+	instance, ok := r.rdsByID[normalizedChecklistKey(resource)]
+	if !ok {
+		return nil, fmt.Errorf("RDS instance %q was not found", resource)
+	}
+	return &instance, nil
+}
+
+func (r *checklistRunner) findSecurityGroup(ctx context.Context, resource string) (*SecurityGroup, error) {
+	if !r.securityGroupsLoaded {
+		r.securityGroupsLoaded = true
+		groups, err := r.repo.ListSecurityGroups(ctx)
+		if err != nil {
+			r.securityGroupsErr = fmt.Errorf("failed to list security groups: %w", err)
+		} else {
+			r.securityGroupsByID = make(map[string]SecurityGroup, len(groups))
+			r.securityGroupsByName = make(map[string][]SecurityGroup)
+			for _, group := range groups {
+				r.securityGroupsByID[normalizedChecklistKey(group.GroupID)] = group
+				key := normalizedChecklistKey(group.Name)
+				r.securityGroupsByName[key] = append(r.securityGroupsByName[key], group)
+			}
+		}
+	}
+	if r.securityGroupsErr != nil {
+		return nil, r.securityGroupsErr
+	}
+
+	if group, ok := r.securityGroupsByID[normalizedChecklistKey(resource)]; ok {
+		return &group, nil
+	}
+	nameMatches := r.securityGroupsByName[normalizedChecklistKey(resource)]
+	if len(nameMatches) == 1 {
+		return &nameMatches[0], nil
+	}
+	if len(nameMatches) > 1 {
+		var ids []string
+		for _, group := range nameMatches {
+			ids = append(ids, group.GroupID)
+		}
+		return nil, fmt.Errorf("security group name %q is ambiguous; use a group ID (%s)", resource, strings.Join(ids, ", "))
+	}
+	return nil, fmt.Errorf("security group %q was not found", resource)
+}
+
+func (r *checklistRunner) findSecret(ctx context.Context, resource string) (*Secret, error) {
+	if !r.secretsLoaded {
+		r.secretsLoaded = true
+		secrets, err := r.repo.ListSecrets(ctx)
+		if err != nil {
+			r.secretsErr = fmt.Errorf("failed to list secrets: %w", err)
+		} else {
+			r.secretsByName = make(map[string]Secret, len(secrets))
+			r.secretsByARN = make(map[string]Secret, len(secrets))
+			for _, secret := range secrets {
+				r.secretsByName[normalizedChecklistKey(secret.Name)] = secret
+				r.secretsByARN[normalizedChecklistKey(secret.ARN)] = secret
+			}
+		}
+	}
+	if r.secretsErr != nil {
+		return nil, r.secretsErr
+	}
+
+	if secret, ok := r.secretsByName[normalizedChecklistKey(resource)]; ok {
+		return &secret, nil
+	}
+	if secret, ok := r.secretsByARN[normalizedChecklistKey(resource)]; ok {
+		return &secret, nil
+	}
+	return nil, fmt.Errorf("secret %q was not found", resource)
+}
+
+func (r *checklistRunner) getSecretDetail(ctx context.Context, secretName string) (*SecretDetail, error) {
+	key := normalizedChecklistKey(secretName)
+	if detail, ok := r.secretDetails[key]; ok {
+		return detail, nil
+	}
+
+	detail, err := r.repo.GetSecretDetail(ctx, secretName)
+	if err != nil {
+		return nil, err
+	}
+	r.secretDetails[key] = detail
+	return detail, nil
+}
+
+func checklistRuleExists(actual []SecurityGroupRule, expected ChecklistSecurityGroupRule) bool {
+	for _, rule := range actual {
+		if expected.Matches(rule) {
+			return true
+		}
+	}
+	return false
+}
+
+func finalizeChecklistResult(check ChecklistCheck, resourceContext string, mismatches []string) ChecklistResult {
+	if len(mismatches) == 0 {
+		return ChecklistResult{
+			CheckID:         check.DisplayID(),
+			Title:           check.DisplayTitle(),
+			Type:            check.Type,
+			Resource:        check.Resource,
+			ResourceContext: resourceContext,
+			Passed:          true,
+			Summary:         "All expectations matched.",
+		}
+	}
+
+	return failedChecklistResult(
+		check,
+		resourceContext,
+		fmt.Sprintf("%d expectation(s) did not match.", len(mismatches)),
+		mismatches,
+	)
+}
+
+func failedChecklistResult(check ChecklistCheck, resourceContext, summary string, details []string) ChecklistResult {
+	return ChecklistResult{
+		CheckID:         check.DisplayID(),
+		Title:           check.DisplayTitle(),
+		Type:            check.Type,
+		Resource:        check.Resource,
+		ResourceContext: resourceContext,
+		Passed:          false,
+		Summary:         summary,
+		Details:         append([]string(nil), details...),
+	}
+}
+
+func formatChecklistMismatch(field string, expected, actual any) string {
+	return fmt.Sprintf("%s expected %v, got %v", field, expected, actual)
+}
+
+func normalizedChecklistKey(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}

--- a/internal/inspector/checklist_test.go
+++ b/internal/inspector/checklist_test.go
@@ -1,0 +1,163 @@
+package inspector
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+)
+
+func TestLoadChecklistParsesSampleFile(t *testing.T) {
+	path := filepath.Join("testdata", "checklists", "readiness.yaml")
+
+	checklist, err := LoadChecklist(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if checklist.SourcePath != path {
+		t.Fatalf("expected source path %q, got %q", path, checklist.SourcePath)
+	}
+	if checklist.DisplayName() != "Production Readiness" {
+		t.Fatalf("unexpected checklist name: %q", checklist.DisplayName())
+	}
+	if len(checklist.Checks) != 3 {
+		t.Fatalf("expected 3 checks, got %d", len(checklist.Checks))
+	}
+	if checklist.Checks[0].Type != ChecklistCheckRDS {
+		t.Fatalf("expected first check to be RDS, got %s", checklist.Checks[0].Type)
+	}
+	if checklist.Checks[1].Type != ChecklistCheckSecurityGroup {
+		t.Fatalf("expected second check to be security_group, got %s", checklist.Checks[1].Type)
+	}
+	if checklist.Checks[2].Expect.RotationEnabled == nil || !*checklist.Checks[2].Expect.RotationEnabled {
+		t.Fatalf("expected secret rotation expectation to be true, got %+v", checklist.Checks[2].Expect)
+	}
+}
+
+func TestLoadChecklistRejectsUnknownFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "invalid.yaml")
+	content := strings.Join([]string{
+		"name: Invalid",
+		"checks:",
+		"  - type: rds",
+		"    resource: prod-db",
+		"    unexpected: true",
+		"    expect:",
+		"      publicly_accessible: false",
+	}, "\n")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write checklist: %v", err)
+	}
+
+	_, err := LoadChecklist(path)
+	if err == nil {
+		t.Fatal("expected unknown field error")
+	}
+	if !strings.Contains(err.Error(), "unexpected") {
+		t.Fatalf("expected unknown field mention, got %v", err)
+	}
+}
+
+func TestRunChecklistReportsPassAndFailPerCheck(t *testing.T) {
+	checklist, err := LoadChecklist(filepath.Join("testdata", "checklists", "readiness.yaml"))
+	if err != nil {
+		t.Fatalf("unexpected error loading checklist: %v", err)
+	}
+
+	repo := &AwsRepository{
+		RDSClient: &mockRDSClient{
+			describeDBInstancesFunc: func(context.Context, *rds.DescribeDBInstancesInput, ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error) {
+				return &rds.DescribeDBInstancesOutput{
+					DBInstances: []rdstypes.DBInstance{
+						{
+							DBInstanceIdentifier:  awssdk.String("prod-db"),
+							DBInstanceStatus:      awssdk.String("available"),
+							Engine:                awssdk.String("postgres"),
+							EngineVersion:         awssdk.String("16.2"),
+							DBInstanceClass:       awssdk.String("db.t4g.medium"),
+							MultiAZ:               awssdk.Bool(true),
+							StorageEncrypted:      awssdk.Bool(true),
+							PubliclyAccessible:    awssdk.Bool(false),
+							BackupRetentionPeriod: awssdk.Int32(7),
+						},
+					},
+				}, nil
+			},
+		},
+		EC2Client: &mockEC2Client{
+			describeSecurityGroupsFunc: func(context.Context, *ec2.DescribeSecurityGroupsInput, ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error) {
+				return &ec2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []ec2types.SecurityGroup{
+						{
+							GroupId:   awssdk.String("sg-web"),
+							GroupName: awssdk.String("web"),
+							VpcId:     awssdk.String("vpc-123"),
+							IpPermissions: []ec2types.IpPermission{
+								{
+									IpProtocol: awssdk.String("tcp"),
+									FromPort:   awssdk.Int32(443),
+									ToPort:     awssdk.Int32(443),
+									UserIdGroupPairs: []ec2types.UserIdGroupPair{
+										{GroupId: awssdk.String("sg-alb")},
+									},
+								},
+							},
+						},
+					},
+				}, nil
+			},
+		},
+		SecretsManagerClient: &inspectorSecretsMockClient{
+			listSecretsFunc: func(context.Context, *secretsmanager.ListSecretsInput, ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error) {
+				return &secretsmanager.ListSecretsOutput{
+					SecretList: []smtypes.SecretListEntry{
+						{
+							Name:            awssdk.String("prod/app"),
+							ARN:             awssdk.String("arn:aws:secretsmanager:ap-northeast-2:123456789012:secret:prod/app"),
+							KmsKeyId:        awssdk.String("alias/prod-secrets"),
+							RotationEnabled: awssdk.Bool(true),
+						},
+					},
+				}, nil
+			},
+			getSecretValueFunc: func(context.Context, *secretsmanager.GetSecretValueInput, ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+				return &secretsmanager.GetSecretValueOutput{
+					Name:         awssdk.String("prod/app"),
+					SecretString: awssdk.String(`{"username":"app-user"}`),
+				}, nil
+			},
+		},
+	}
+
+	report, err := RunChecklist(context.Background(), repo, checklist)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.PassedCount != 2 || report.FailedCount != 1 {
+		t.Fatalf("expected 2 pass / 1 fail, got %d pass / %d fail", report.PassedCount, report.FailedCount)
+	}
+	if len(report.Results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(report.Results))
+	}
+	if !report.Results[0].Passed {
+		t.Fatalf("expected RDS check to pass, got %+v", report.Results[0])
+	}
+	if !report.Results[1].Passed {
+		t.Fatalf("expected security group check to pass, got %+v", report.Results[1])
+	}
+	if report.Results[2].Passed {
+		t.Fatalf("expected secret check to fail, got %+v", report.Results[2])
+	}
+	if !strings.Contains(report.Results[2].Details[0], "password") {
+		t.Fatalf("expected missing password detail, got %+v", report.Results[2].Details)
+	}
+}

--- a/internal/inspector/inspector_model.go
+++ b/internal/inspector/inspector_model.go
@@ -20,9 +20,18 @@ type Workflow struct {
 	Title       string
 	Description string
 	Available   bool
+	Status      string
 }
 
-func Workflows() []Workflow {
+func Workflows(checklistPath string) []Workflow {
+	checklistAvailable := strings.TrimSpace(checklistPath) != ""
+	checklistStatus := "ADD FILE"
+	checklistDescription := "Pass --checklist <path> to load a YAML checklist for readiness checks across RDS, security groups, and Secrets Manager."
+	if checklistAvailable {
+		checklistStatus = ""
+		checklistDescription = "Run a user-supplied YAML checklist to verify infrastructure readiness across RDS, security groups, and Secrets Manager."
+	}
+
 	return []Workflow{
 		{
 			Kind:        WorkflowSecurity,
@@ -33,8 +42,9 @@ func Workflows() []Workflow {
 		{
 			Kind:        WorkflowChecklist,
 			Title:       "Checklist Inspector",
-			Description: "Planned guided readiness and rollout checks for infrastructure workflows that span multiple AWS services.",
-			Available:   false,
+			Description: checklistDescription,
+			Available:   checklistAvailable,
+			Status:      checklistStatus,
 		},
 	}
 }
@@ -42,6 +52,9 @@ func Workflows() []Workflow {
 func (w Workflow) StatusLabel() string {
 	if w.Available {
 		return "READY"
+	}
+	if w.Status != "" {
+		return w.Status
 	}
 	return "PLANNED"
 }
@@ -57,6 +70,7 @@ type IAMClientAPI = awsservice.IAMClientAPI
 type RDSClientAPI = awsservice.RDSClientAPI
 type S3Bucket = awsservice.S3Bucket
 type Secret = awsservice.Secret
+type SecretDetail = awsservice.SecretDetail
 type SecurityGroup = awsservice.SecurityGroup
 type SecurityGroupRule = awsservice.SecurityGroupRule
 type SecretsManagerClientAPI = awsservice.SecretsManagerClientAPI

--- a/internal/inspector/inspector_rules_identity_secrets_test.go
+++ b/internal/inspector/inspector_rules_identity_secrets_test.go
@@ -84,7 +84,8 @@ func (m *inspectorIAMMockClient) DeleteAccessKey(context.Context, *iam.DeleteAcc
 }
 
 type inspectorSecretsMockClient struct {
-	listSecretsFunc func(ctx context.Context, params *secretsmanager.ListSecretsInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error)
+	listSecretsFunc    func(ctx context.Context, params *secretsmanager.ListSecretsInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error)
+	getSecretValueFunc func(ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
 }
 
 func (m *inspectorSecretsMockClient) ListSecrets(ctx context.Context, params *secretsmanager.ListSecretsInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error) {
@@ -94,7 +95,10 @@ func (m *inspectorSecretsMockClient) ListSecrets(ctx context.Context, params *se
 	return &secretsmanager.ListSecretsOutput{}, nil
 }
 
-func (m *inspectorSecretsMockClient) GetSecretValue(context.Context, *secretsmanager.GetSecretValueInput, ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+func (m *inspectorSecretsMockClient) GetSecretValue(ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+	if m.getSecretValueFunc != nil {
+		return m.getSecretValueFunc(ctx, params, optFns...)
+	}
 	return &secretsmanager.GetSecretValueOutput{}, nil
 }
 

--- a/internal/inspector/testdata/checklists/readiness.yaml
+++ b/internal/inspector/testdata/checklists/readiness.yaml
@@ -1,0 +1,43 @@
+name: Production Readiness
+description: Baseline readiness checks for the primary production stack.
+checks:
+  - id: prod-db-baseline
+    title: Production database baseline
+    type: rds
+    resource: prod-db
+    expect:
+      status: available
+      engine: postgres
+      engine_version: "16.2"
+      instance_class: db.t4g.medium
+      multi_az: true
+      storage_encrypted: true
+      publicly_accessible: false
+      backup_retention_days: 7
+
+  - id: web-sg-locked-down
+    title: Web security group exposure
+    type: security_group
+    resource: sg-web
+    expect:
+      ingress_present:
+        - protocol: tcp
+          from_port: 443
+          to_port: 443
+          referenced_sg_id: sg-alb
+      ingress_absent:
+        - protocol: tcp
+          from_port: 22
+          to_port: 22
+          cidr: 0.0.0.0/0
+
+  - id: app-secret-ready
+    title: App secret rotation and keys
+    type: secret
+    resource: prod/app
+    expect:
+      kms_key_id: alias/prod-secrets
+      rotation_enabled: true
+      value_keys:
+        - username
+        - password


### PR DESCRIPTION
### Summary

- add Checklist Inspector v1 with YAML-driven readiness checks for RDS, security groups, and Secrets Manager
- add in-TUI checklist loading, results, and detail flows while keeping `--checklist <path>` as an optional preload path
- refresh README and architecture/project overview docs for the new Inspector behavior

### Related Issues

Closes #60

### Validation

- `make test`
- `make build`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed
- [x] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [ ] Breaking changes documented
