### PR TITLE
feat: expand Checklist Inspector static coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It combines a Bubble Tea application, Cobra-based CLI commands, and AWS SDK v2 c
 - Open a context-aware keyboard shortcut help screen with `?`
 - Show animated loading indicators while async AWS data is being fetched
 - Perform operational workflows such as SSM sessions, RDS control, Route53 record changes, ECS exec, and IAM access key rotation
-- Press `i` from the service picker to enter Inspector mode, then run either the Security Inspector workflow for built-in findings or the Checklist Inspector workflow for YAML-driven readiness checks across RDS, security groups, and secrets. Checklist files can be loaded from the in-TUI picker or preloaded with `--checklist <path>`
+- Press `i` from the service picker to enter Inspector mode, then run either the Security Inspector workflow for built-in findings or the Checklist Inspector workflow for YAML-driven readiness checks across databases, network resources, DNS, logging, secrets, and baseline posture. Checklist files can be loaded from the in-TUI picker or preloaded with `--checklist <path>`
 
 ## Documentation Map
 
@@ -221,11 +221,17 @@ Context ordering:
 
 Security Inspector ships built-in rule packs for Security Group exposure, RDS encryption/public access/backups and public snapshot sharing, IAM access key age/root-account hardening/wildcard policies, Secrets Manager rotation age, S3 public access/Block Public Access/versioning, CloudTrail baseline coverage, GuardDuty and AWS Config baseline controls, and ElastiCache for Valkey encryption/backup/access-control checks.
 
-Checklist Inspector can load a YAML file either from the Inspector-mode file picker or from `--checklist` at startup, and currently supports three check types:
+Checklist Inspector can load a YAML file either from the Inspector-mode file picker or from `--checklist` at startup, and currently supports:
 
 - `rds` for expected DB instance state such as status, engine, class, Multi-AZ, encryption, public access, and backup retention
 - `security_group` for required or forbidden ingress/egress rule matchers
 - `secret` for rotation state, KMS key ID, and required JSON value keys
+- `hosted_zone` for hosted zone existence and private/public scope checks
+- `route53_record` for DNS record existence, type, TTL, values, and alias target checks within `expect.zone`
+- `vpc` for VPC existence, CIDR, default-VPC posture, and subnet-count checks
+- `subnet` for subnet existence, optional `expect.vpc` scoping, CIDR, availability zone, and minimum available-IP checks
+- `cloudwatch_log_group` for log-group existence and retention-days checks
+- `cloudtrail_baseline`, `guardduty_baseline`, `config_baseline`, and `elasticache_valkey_baseline` for checklist-driven pass/fail wrappers around the built-in baseline security scanners
 
 Minimal checklist example:
 
@@ -255,6 +261,27 @@ checks:
       value_keys:
         - username
         - password
+
+  - type: route53_record
+    resource: api.example.internal
+    expect:
+      zone: example.internal
+      record_type: A
+      alias_target: internal-alb-123.ap-northeast-2.elb.amazonaws.com
+
+  - type: vpc
+    resource: main-vpc
+    expect:
+      cidr: 10.0.0.0/16
+      subnet_count: 2
+
+  - type: cloudwatch_log_group
+    resource: /aws/ecs/app
+    expect:
+      retention_days: 30
+
+  - type: cloudtrail_baseline
+    resource: cloudtrail
 ```
 
 ## TUI Navigation

--- a/docs/project-overview.en.md
+++ b/docs/project-overview.en.md
@@ -22,6 +22,7 @@ Implemented service areas currently include:
 - Inspector mode
 
 The application already includes interactive mutation flows, polling-based status flows, context helpers, and per-service drill-down screens.
+Inspector mode now includes built-in security scans plus checklist-driven readiness checks for RDS, security groups, secrets, Route53, VPCs/subnets, CloudWatch Logs, and baseline posture wrappers.
 
 ## Primary User Flows
 

--- a/docs/project-overview.ko.md
+++ b/docs/project-overview.ko.md
@@ -22,6 +22,7 @@ UNIC은 다음 세 가지를 결합한 Go 기반 AWS 터미널 콘솔이다.
 - Inspector mode
 
 애플리케이션은 이미 상호작용형 변경 작업 플로우, polling 기반 상태 확인, context helper, 서비스별 drill-down 화면을 포함한다.
+Inspector mode는 이제 built-in security scan과 함께 RDS, security group, secret, Route53, VPC/subnet, CloudWatch Logs, baseline posture wrapper를 다루는 checklist 기반 readiness check도 포함한다.
 
 ## 주요 사용자 흐름
 

--- a/internal/app/screen_inspector.go
+++ b/internal/app/screen_inspector.go
@@ -597,7 +597,7 @@ func (m Model) viewInspectorWorkflowPlaceholder() string {
 	if workflow.Kind == inspector.WorkflowChecklist {
 		b.WriteString(normalStyle.Render("  Checklist Inspector needs a checklist file before it can run."))
 		b.WriteString("\n")
-		b.WriteString(dimStyle.Render("  Press enter or l to open the file picker and load a YAML checklist for RDS, security groups, and secrets."))
+		b.WriteString(dimStyle.Render("  Press enter or l to open the file picker and load a YAML checklist for resource readiness and baseline posture checks."))
 		b.WriteString("\n\n")
 		b.WriteString(renderDetailLine("Status", inspectorPlannedStyle.Render(workflow.StatusLabel())))
 		b.WriteString("\n")

--- a/internal/inspector/checklist.go
+++ b/internal/inspector/checklist.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -15,9 +16,18 @@ import (
 type ChecklistCheckType string
 
 const (
-	ChecklistCheckRDS           ChecklistCheckType = "rds"
-	ChecklistCheckSecurityGroup ChecklistCheckType = "security_group"
-	ChecklistCheckSecret        ChecklistCheckType = "secret"
+	ChecklistCheckRDS                       ChecklistCheckType = "rds"
+	ChecklistCheckSecurityGroup             ChecklistCheckType = "security_group"
+	ChecklistCheckSecret                    ChecklistCheckType = "secret"
+	ChecklistCheckHostedZone                ChecklistCheckType = "hosted_zone"
+	ChecklistCheckRoute53Record             ChecklistCheckType = "route53_record"
+	ChecklistCheckVPC                       ChecklistCheckType = "vpc"
+	ChecklistCheckSubnet                    ChecklistCheckType = "subnet"
+	ChecklistCheckCloudWatchLogGroup        ChecklistCheckType = "cloudwatch_log_group"
+	ChecklistCheckCloudTrailBaseline        ChecklistCheckType = "cloudtrail_baseline"
+	ChecklistCheckGuardDutyBaseline         ChecklistCheckType = "guardduty_baseline"
+	ChecklistCheckConfigBaseline            ChecklistCheckType = "config_baseline"
+	ChecklistCheckElastiCacheValkeyBaseline ChecklistCheckType = "elasticache_valkey_baseline"
 )
 
 type Checklist struct {
@@ -74,6 +84,20 @@ type ChecklistExpectations struct {
 	KMSKeyID            *string                      `yaml:"kms_key_id,omitempty"`
 	RotationEnabled     *bool                        `yaml:"rotation_enabled,omitempty"`
 	ValueKeys           []string                     `yaml:"value_keys,omitempty"`
+	Zone                string                       `yaml:"zone,omitempty"`
+	PrivateZone         *bool                        `yaml:"private_zone,omitempty"`
+	RecordType          *string                      `yaml:"record_type,omitempty"`
+	TTL                 *int                         `yaml:"ttl,omitempty"`
+	Values              []string                     `yaml:"values,omitempty"`
+	AliasTarget         *string                      `yaml:"alias_target,omitempty"`
+	AliasHostedZoneID   *string                      `yaml:"alias_hosted_zone_id,omitempty"`
+	CIDR                *string                      `yaml:"cidr,omitempty"`
+	DefaultVPC          *bool                        `yaml:"default_vpc,omitempty"`
+	SubnetCount         *int                         `yaml:"subnet_count,omitempty"`
+	VPC                 string                       `yaml:"vpc,omitempty"`
+	AvailabilityZone    *string                      `yaml:"availability_zone,omitempty"`
+	AvailableIPCountMin *int                         `yaml:"available_ip_count_min,omitempty"`
+	RetentionDays       *int                         `yaml:"retention_days,omitempty"`
 	IngressPresent      []ChecklistSecurityGroupRule `yaml:"ingress_present,omitempty"`
 	IngressAbsent       []ChecklistSecurityGroupRule `yaml:"ingress_absent,omitempty"`
 	EgressPresent       []ChecklistSecurityGroupRule `yaml:"egress_present,omitempty"`
@@ -100,6 +124,22 @@ func (e ChecklistExpectations) HasExpectationsFor(checkType ChecklistCheckType) 
 		return e.KMSKeyID != nil ||
 			e.RotationEnabled != nil ||
 			len(e.ValueKeys) > 0
+	case ChecklistCheckHostedZone,
+		ChecklistCheckVPC,
+		ChecklistCheckSubnet,
+		ChecklistCheckCloudWatchLogGroup,
+		ChecklistCheckCloudTrailBaseline,
+		ChecklistCheckGuardDutyBaseline,
+		ChecklistCheckConfigBaseline,
+		ChecklistCheckElastiCacheValkeyBaseline:
+		return true
+	case ChecklistCheckRoute53Record:
+		return strings.TrimSpace(e.Zone) != "" ||
+			e.RecordType != nil ||
+			e.TTL != nil ||
+			len(e.Values) > 0 ||
+			e.AliasTarget != nil ||
+			e.AliasHostedZoneID != nil
 	default:
 		return false
 	}
@@ -239,9 +279,24 @@ func (c Checklist) validate() error {
 		}
 
 		switch check.Type {
-		case ChecklistCheckRDS, ChecklistCheckSecurityGroup, ChecklistCheckSecret:
+		case ChecklistCheckRDS,
+			ChecklistCheckSecurityGroup,
+			ChecklistCheckSecret,
+			ChecklistCheckHostedZone,
+			ChecklistCheckRoute53Record,
+			ChecklistCheckVPC,
+			ChecklistCheckSubnet,
+			ChecklistCheckCloudWatchLogGroup,
+			ChecklistCheckCloudTrailBaseline,
+			ChecklistCheckGuardDutyBaseline,
+			ChecklistCheckConfigBaseline,
+			ChecklistCheckElastiCacheValkeyBaseline:
 		default:
 			return fmt.Errorf("check %d has unsupported type %q", idx+1, check.Type)
+		}
+
+		if check.Type == ChecklistCheckRoute53Record && strings.TrimSpace(check.Expect.Zone) == "" {
+			return fmt.Errorf("check %d (%s) must define expect.zone for route53_record checks", idx+1, check.DisplayID())
 		}
 
 		if !check.Expect.HasExpectationsFor(check.Type) {
@@ -272,6 +327,28 @@ type checklistRunner struct {
 	rdsErr    error
 	rdsByID   map[string]RDSInstance
 
+	hostedZonesLoaded bool
+	hostedZonesErr    error
+	hostedZonesByID   map[string]HostedZone
+	hostedZonesByName map[string][]HostedZone
+	zoneRecords       map[string][]DNSRecord
+
+	vpcsLoaded bool
+	vpcsErr    error
+	vpcsByID   map[string]VPC
+	vpcsByName map[string][]VPC
+
+	subnetsLoaded bool
+	subnetsErr    error
+	subnetsByID   map[string]Subnet
+	subnetsByName map[string][]Subnet
+	subnetsByVPC  map[string][]Subnet
+
+	logGroupsLoaded bool
+	logGroupsErr    error
+	logGroupsByName map[string]LogGroup
+	logGroupsByARN  map[string]LogGroup
+
 	securityGroupsLoaded bool
 	securityGroupsErr    error
 	securityGroupsByID   map[string]SecurityGroup
@@ -292,6 +369,7 @@ func RunChecklist(ctx context.Context, repo *AwsRepository, checklist *Checklist
 	runner := &checklistRunner{
 		repo:          repo,
 		secretDetails: make(map[string]*SecretDetail),
+		zoneRecords:   make(map[string][]DNSRecord),
 	}
 	report := &ChecklistReport{
 		ChecklistName: checklist.DisplayName(),
@@ -326,6 +404,28 @@ func (r *checklistRunner) runCheck(ctx context.Context, check ChecklistCheck) Ch
 		return r.runSecurityGroupCheck(ctx, check)
 	case ChecklistCheckSecret:
 		return r.runSecretCheck(ctx, check)
+	case ChecklistCheckHostedZone:
+		return r.runHostedZoneCheck(ctx, check)
+	case ChecklistCheckRoute53Record:
+		return r.runRoute53RecordCheck(ctx, check)
+	case ChecklistCheckVPC:
+		return r.runVPCCheck(ctx, check)
+	case ChecklistCheckSubnet:
+		return r.runSubnetCheck(ctx, check)
+	case ChecklistCheckCloudWatchLogGroup:
+		return r.runCloudWatchLogGroupCheck(ctx, check)
+	case ChecklistCheckCloudTrailBaseline:
+		return r.runBaselineCheck(ctx, check, "CloudTrail baseline", runCloudTrailBaselineScan)
+	case ChecklistCheckGuardDutyBaseline:
+		return r.runBaselineCheck(ctx, check, "GuardDuty baseline", func(ctx context.Context, repo *AwsRepository) ([]SecurityFinding, error) {
+			return inspectGuardDutyBaseline(ctx, repo.GuardDutyClient)
+		})
+	case ChecklistCheckConfigBaseline:
+		return r.runBaselineCheck(ctx, check, "AWS Config baseline", func(ctx context.Context, repo *AwsRepository) ([]SecurityFinding, error) {
+			return inspectConfigBaseline(ctx, repo.ConfigServiceClient)
+		})
+	case ChecklistCheckElastiCacheValkeyBaseline:
+		return r.runBaselineCheck(ctx, check, "ElastiCache for Valkey baseline", runElastiCacheValkeySecurityScan)
 	default:
 		return failedChecklistResult(check, "", "Unsupported checklist type.", []string{
 			fmt.Sprintf("type %q is not supported", check.Type),
@@ -433,6 +533,407 @@ func (r *checklistRunner) runSecretCheck(ctx context.Context, check ChecklistChe
 	}
 
 	return finalizeChecklistResult(check, secret.Name, mismatches)
+}
+
+func (r *checklistRunner) runHostedZoneCheck(ctx context.Context, check ChecklistCheck) ChecklistResult {
+	zone, err := r.findHostedZone(ctx, check.Resource)
+	if err != nil {
+		return failedChecklistResult(check, "", "Target hosted zone could not be resolved.", []string{err.Error()})
+	}
+
+	var mismatches []string
+	if check.Expect.PrivateZone != nil && *check.Expect.PrivateZone != zone.IsPrivate {
+		mismatches = append(mismatches, formatChecklistMismatch("private_zone", *check.Expect.PrivateZone, zone.IsPrivate))
+	}
+
+	return finalizeChecklistResult(check, formatHostedZoneContext(zone), mismatches)
+}
+
+func (r *checklistRunner) runRoute53RecordCheck(ctx context.Context, check ChecklistCheck) ChecklistResult {
+	recordTypeHint := check.Expect.RecordType
+	zone, record, err := r.findRoute53Record(ctx, check.Expect.Zone, check.Resource, recordTypeHint)
+	if err != nil {
+		return failedChecklistResult(check, "", "Target Route53 record could not be resolved.", []string{err.Error()})
+	}
+
+	var mismatches []string
+	if check.Expect.RecordType != nil && !strings.EqualFold(strings.TrimSpace(*check.Expect.RecordType), strings.TrimSpace(record.Type)) {
+		mismatches = append(mismatches, formatChecklistMismatch("record_type", *check.Expect.RecordType, record.Type))
+	}
+	if check.Expect.TTL != nil && int64(*check.Expect.TTL) != record.TTL {
+		mismatches = append(mismatches, formatChecklistMismatch("ttl", *check.Expect.TTL, record.TTL))
+	}
+	if len(check.Expect.Values) > 0 && !equalChecklistStringSets(check.Expect.Values, record.Values) {
+		mismatches = append(mismatches, formatChecklistMismatch("values", check.Expect.Values, record.Values))
+	}
+	if check.Expect.AliasTarget != nil && normalizedDNSNameKey(*check.Expect.AliasTarget) != normalizedDNSNameKey(record.AliasTarget) {
+		mismatches = append(mismatches, formatChecklistMismatch("alias_target", *check.Expect.AliasTarget, record.AliasTarget))
+	}
+	if check.Expect.AliasHostedZoneID != nil && normalizedHostedZoneIDKey(*check.Expect.AliasHostedZoneID) != normalizedHostedZoneIDKey(record.AliasHostedZoneId) {
+		mismatches = append(mismatches, formatChecklistMismatch("alias_hosted_zone_id", *check.Expect.AliasHostedZoneID, record.AliasHostedZoneId))
+	}
+
+	return finalizeChecklistResult(check, formatRoute53RecordContext(zone, record), mismatches)
+}
+
+func (r *checklistRunner) runVPCCheck(ctx context.Context, check ChecklistCheck) ChecklistResult {
+	vpc, err := r.findVPC(ctx, check.Resource)
+	if err != nil {
+		return failedChecklistResult(check, "", "Target VPC could not be resolved.", []string{err.Error()})
+	}
+
+	var mismatches []string
+	if check.Expect.CIDR != nil && strings.TrimSpace(*check.Expect.CIDR) != strings.TrimSpace(vpc.CIDR) {
+		mismatches = append(mismatches, formatChecklistMismatch("cidr", *check.Expect.CIDR, vpc.CIDR))
+	}
+	if check.Expect.DefaultVPC != nil && *check.Expect.DefaultVPC != vpc.IsDefault {
+		mismatches = append(mismatches, formatChecklistMismatch("default_vpc", *check.Expect.DefaultVPC, vpc.IsDefault))
+	}
+	if check.Expect.SubnetCount != nil {
+		subnets, err := r.subnetsForVPC(ctx, vpc.VPCID)
+		if err != nil {
+			mismatches = append(mismatches, fmt.Sprintf("failed to load VPC subnets: %v", err))
+		} else if *check.Expect.SubnetCount != len(subnets) {
+			mismatches = append(mismatches, formatChecklistMismatch("subnet_count", *check.Expect.SubnetCount, len(subnets)))
+		}
+	}
+
+	return finalizeChecklistResult(check, formatVPCContext(vpc), mismatches)
+}
+
+func (r *checklistRunner) runSubnetCheck(ctx context.Context, check ChecklistCheck) ChecklistResult {
+	subnet, err := r.findSubnet(ctx, check.Resource, check.Expect.VPC)
+	if err != nil {
+		return failedChecklistResult(check, "", "Target subnet could not be resolved.", []string{err.Error()})
+	}
+
+	var mismatches []string
+	if check.Expect.CIDR != nil && strings.TrimSpace(*check.Expect.CIDR) != strings.TrimSpace(subnet.CIDR) {
+		mismatches = append(mismatches, formatChecklistMismatch("cidr", *check.Expect.CIDR, subnet.CIDR))
+	}
+	if check.Expect.AvailabilityZone != nil && strings.TrimSpace(*check.Expect.AvailabilityZone) != strings.TrimSpace(subnet.AvailabilityZone) {
+		mismatches = append(mismatches, formatChecklistMismatch("availability_zone", *check.Expect.AvailabilityZone, subnet.AvailabilityZone))
+	}
+	if check.Expect.AvailableIPCountMin != nil && subnet.AvailableIPCount < int32(*check.Expect.AvailableIPCountMin) {
+		mismatches = append(mismatches, fmt.Sprintf("available_ip_count expected at least %d, got %d", *check.Expect.AvailableIPCountMin, subnet.AvailableIPCount))
+	}
+
+	return finalizeChecklistResult(check, formatSubnetContext(subnet), mismatches)
+}
+
+func (r *checklistRunner) runCloudWatchLogGroupCheck(ctx context.Context, check ChecklistCheck) ChecklistResult {
+	group, err := r.findLogGroup(ctx, check.Resource)
+	if err != nil {
+		return failedChecklistResult(check, "", "Target CloudWatch log group could not be resolved.", []string{err.Error()})
+	}
+
+	var mismatches []string
+	if check.Expect.RetentionDays != nil && int32(*check.Expect.RetentionDays) != group.RetentionDays {
+		mismatches = append(mismatches, formatChecklistMismatch("retention_days", *check.Expect.RetentionDays, group.RetentionDays))
+	}
+
+	return finalizeChecklistResult(check, group.Name, mismatches)
+}
+
+func (r *checklistRunner) runBaselineCheck(
+	ctx context.Context,
+	check ChecklistCheck,
+	label string,
+	run func(context.Context, *AwsRepository) ([]SecurityFinding, error),
+) ChecklistResult {
+	findings, err := run(ctx, r.repo)
+	if err != nil {
+		return failedChecklistResult(check, label, "Baseline scan could not be completed.", []string{err.Error()})
+	}
+	if len(findings) == 0 {
+		return ChecklistResult{
+			CheckID:         check.DisplayID(),
+			Title:           check.DisplayTitle(),
+			Type:            check.Type,
+			Resource:        check.Resource,
+			ResourceContext: label,
+			Passed:          true,
+			Summary:         "Baseline scanner reported no findings.",
+		}
+	}
+
+	return failedChecklistResult(
+		check,
+		label,
+		fmt.Sprintf("%d baseline finding(s) detected.", len(findings)),
+		formatChecklistFindings(findings),
+	)
+}
+
+func (r *checklistRunner) findHostedZone(ctx context.Context, resource string) (*HostedZone, error) {
+	if !r.hostedZonesLoaded {
+		r.hostedZonesLoaded = true
+		zones, err := r.repo.ListHostedZones(ctx)
+		if err != nil {
+			r.hostedZonesErr = fmt.Errorf("failed to list hosted zones: %w", err)
+		} else {
+			r.hostedZonesByID = make(map[string]HostedZone, len(zones))
+			r.hostedZonesByName = make(map[string][]HostedZone)
+			for _, zone := range zones {
+				r.hostedZonesByID[normalizedHostedZoneIDKey(zone.ID)] = zone
+				key := normalizedDNSNameKey(zone.Name)
+				r.hostedZonesByName[key] = append(r.hostedZonesByName[key], zone)
+			}
+		}
+	}
+	if r.hostedZonesErr != nil {
+		return nil, r.hostedZonesErr
+	}
+
+	if zone, ok := r.hostedZonesByID[normalizedHostedZoneIDKey(resource)]; ok {
+		return &zone, nil
+	}
+	nameMatches := r.hostedZonesByName[normalizedDNSNameKey(resource)]
+	if len(nameMatches) == 1 {
+		return &nameMatches[0], nil
+	}
+	if len(nameMatches) > 1 {
+		var ids []string
+		for _, zone := range nameMatches {
+			ids = append(ids, zone.ID)
+		}
+		return nil, fmt.Errorf("hosted zone name %q is ambiguous; use a zone ID (%s)", resource, strings.Join(ids, ", "))
+	}
+	return nil, fmt.Errorf("hosted zone %q was not found", resource)
+}
+
+func (r *checklistRunner) hostedZoneRecords(ctx context.Context, zoneID string) ([]DNSRecord, error) {
+	key := normalizedHostedZoneIDKey(zoneID)
+	if records, ok := r.zoneRecords[key]; ok {
+		return records, nil
+	}
+
+	records, err := r.repo.ListResourceRecordSets(ctx, zoneID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Route53 records for zone %s: %w", zoneID, err)
+	}
+	r.zoneRecords[key] = records
+	return records, nil
+}
+
+func (r *checklistRunner) findRoute53Record(ctx context.Context, zoneResource, recordName string, recordType *string) (*HostedZone, *DNSRecord, error) {
+	zone, err := r.findHostedZone(ctx, zoneResource)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	records, err := r.hostedZoneRecords(ctx, zone.ID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	typeHint := ""
+	if recordType != nil {
+		typeHint = normalizedChecklistKey(*recordType)
+	}
+
+	nameKey := normalizedDNSNameKey(recordName)
+	nameMatches := make([]DNSRecord, 0, 2)
+	for _, record := range records {
+		if normalizedDNSNameKey(record.Name) != nameKey {
+			continue
+		}
+		nameMatches = append(nameMatches, record)
+	}
+
+	if len(nameMatches) == 0 {
+		if typeHint != "" {
+			return nil, nil, fmt.Errorf("Route53 record %q with type %q was not found in zone %q", recordName, *recordType, zoneResource)
+		}
+		return nil, nil, fmt.Errorf("Route53 record %q was not found in zone %q", recordName, zoneResource)
+	}
+
+	if typeHint == "" {
+		if len(nameMatches) == 1 {
+			return zone, &nameMatches[0], nil
+		}
+		var recordTypes []string
+		for _, record := range nameMatches {
+			recordTypes = append(recordTypes, record.Type)
+		}
+		return nil, nil, fmt.Errorf("Route53 record %q in zone %q is ambiguous; set expect.record_type (%s)", recordName, zoneResource, strings.Join(recordTypes, ", "))
+	}
+
+	for _, record := range nameMatches {
+		if normalizedChecklistKey(record.Type) == typeHint {
+			return zone, &record, nil
+		}
+	}
+
+	if len(nameMatches) == 1 {
+		return zone, &nameMatches[0], nil
+	}
+
+	{
+		var recordTypes []string
+		for _, record := range nameMatches {
+			recordTypes = append(recordTypes, record.Type)
+		}
+		return nil, nil, fmt.Errorf("Route53 record %q in zone %q did not match expected type %q; available types: %s", recordName, zoneResource, *recordType, strings.Join(recordTypes, ", "))
+	}
+}
+
+func (r *checklistRunner) loadVPCs(ctx context.Context) error {
+	if r.vpcsLoaded {
+		return r.vpcsErr
+	}
+	r.vpcsLoaded = true
+
+	vpcs, err := r.repo.ListVPCs(ctx)
+	if err != nil {
+		r.vpcsErr = fmt.Errorf("failed to list VPCs: %w", err)
+		return r.vpcsErr
+	}
+
+	r.vpcsByID = make(map[string]VPC, len(vpcs))
+	r.vpcsByName = make(map[string][]VPC)
+	for _, vpc := range vpcs {
+		r.vpcsByID[normalizedChecklistKey(vpc.VPCID)] = vpc
+		key := normalizedChecklistKey(vpc.Name)
+		r.vpcsByName[key] = append(r.vpcsByName[key], vpc)
+	}
+
+	return nil
+}
+
+func (r *checklistRunner) findVPC(ctx context.Context, resource string) (*VPC, error) {
+	if err := r.loadVPCs(ctx); err != nil {
+		return nil, err
+	}
+
+	if vpc, ok := r.vpcsByID[normalizedChecklistKey(resource)]; ok {
+		return &vpc, nil
+	}
+	nameMatches := r.vpcsByName[normalizedChecklistKey(resource)]
+	if len(nameMatches) == 1 {
+		return &nameMatches[0], nil
+	}
+	if len(nameMatches) > 1 {
+		var ids []string
+		for _, vpc := range nameMatches {
+			ids = append(ids, vpc.VPCID)
+		}
+		return nil, fmt.Errorf("VPC name %q is ambiguous; use a VPC ID (%s)", resource, strings.Join(ids, ", "))
+	}
+	return nil, fmt.Errorf("VPC %q was not found", resource)
+}
+
+func (r *checklistRunner) loadSubnets(ctx context.Context) error {
+	if r.subnetsLoaded {
+		return r.subnetsErr
+	}
+	r.subnetsLoaded = true
+
+	if err := r.loadVPCs(ctx); err != nil {
+		r.subnetsErr = err
+		return r.subnetsErr
+	}
+
+	r.subnetsByID = make(map[string]Subnet)
+	r.subnetsByName = make(map[string][]Subnet)
+	r.subnetsByVPC = make(map[string][]Subnet)
+	for _, vpc := range r.vpcsByID {
+		subnets, err := r.repo.ListSubnets(ctx, vpc.VPCID)
+		if err != nil {
+			r.subnetsErr = fmt.Errorf("failed to list subnets for VPC %s: %w", vpc.VPCID, err)
+			return r.subnetsErr
+		}
+		for _, subnet := range subnets {
+			if subnet.VPCID == "" {
+				subnet.VPCID = vpc.VPCID
+			}
+			r.subnetsByID[normalizedChecklistKey(subnet.SubnetID)] = subnet
+			r.subnetsByName[normalizedChecklistKey(subnet.Name)] = append(r.subnetsByName[normalizedChecklistKey(subnet.Name)], subnet)
+			key := normalizedChecklistKey(subnet.VPCID)
+			r.subnetsByVPC[key] = append(r.subnetsByVPC[key], subnet)
+		}
+	}
+
+	return nil
+}
+
+func (r *checklistRunner) subnetsForVPC(ctx context.Context, vpcID string) ([]Subnet, error) {
+	if err := r.loadSubnets(ctx); err != nil {
+		return nil, err
+	}
+	return append([]Subnet(nil), r.subnetsByVPC[normalizedChecklistKey(vpcID)]...), nil
+}
+
+func (r *checklistRunner) findSubnet(ctx context.Context, resource, vpcResource string) (*Subnet, error) {
+	if err := r.loadSubnets(ctx); err != nil {
+		return nil, err
+	}
+
+	expectedVPCID := ""
+	if strings.TrimSpace(vpcResource) != "" {
+		vpc, err := r.findVPC(ctx, vpcResource)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve subnet VPC %q: %w", vpcResource, err)
+		}
+		expectedVPCID = vpc.VPCID
+	}
+
+	if subnet, ok := r.subnetsByID[normalizedChecklistKey(resource)]; ok {
+		if expectedVPCID != "" && normalizedChecklistKey(subnet.VPCID) != normalizedChecklistKey(expectedVPCID) {
+			return nil, fmt.Errorf("subnet %q is in VPC %s, not %s", resource, subnet.VPCID, expectedVPCID)
+		}
+		return &subnet, nil
+	}
+
+	nameMatches := r.subnetsByName[normalizedChecklistKey(resource)]
+	filtered := make([]Subnet, 0, len(nameMatches))
+	for _, subnet := range nameMatches {
+		if expectedVPCID == "" || normalizedChecklistKey(subnet.VPCID) == normalizedChecklistKey(expectedVPCID) {
+			filtered = append(filtered, subnet)
+		}
+	}
+	if len(filtered) == 1 {
+		return &filtered[0], nil
+	}
+	if len(filtered) > 1 {
+		var ids []string
+		for _, subnet := range filtered {
+			ids = append(ids, subnet.SubnetID)
+		}
+		return nil, fmt.Errorf("subnet name %q is ambiguous; use a subnet ID (%s)", resource, strings.Join(ids, ", "))
+	}
+	if expectedVPCID != "" {
+		return nil, fmt.Errorf("subnet %q was not found in VPC %q", resource, vpcResource)
+	}
+	return nil, fmt.Errorf("subnet %q was not found", resource)
+}
+
+func (r *checklistRunner) findLogGroup(ctx context.Context, resource string) (*LogGroup, error) {
+	if !r.logGroupsLoaded {
+		r.logGroupsLoaded = true
+		groups, err := r.repo.ListLogGroups(ctx)
+		if err != nil {
+			r.logGroupsErr = fmt.Errorf("failed to list CloudWatch log groups: %w", err)
+		} else {
+			r.logGroupsByName = make(map[string]LogGroup, len(groups))
+			r.logGroupsByARN = make(map[string]LogGroup, len(groups))
+			for _, group := range groups {
+				r.logGroupsByName[normalizedChecklistKey(group.Name)] = group
+				r.logGroupsByARN[normalizedChecklistKey(group.ARN)] = group
+			}
+		}
+	}
+	if r.logGroupsErr != nil {
+		return nil, r.logGroupsErr
+	}
+
+	if group, ok := r.logGroupsByName[normalizedChecklistKey(resource)]; ok {
+		return &group, nil
+	}
+	if group, ok := r.logGroupsByARN[normalizedChecklistKey(resource)]; ok {
+		return &group, nil
+	}
+	return nil, fmt.Errorf("CloudWatch log group %q was not found", resource)
 }
 
 func (r *checklistRunner) findRDSInstance(ctx context.Context, resource string) (*RDSInstance, error) {
@@ -583,6 +1084,79 @@ func failedChecklistResult(check ChecklistCheck, resourceContext, summary string
 
 func formatChecklistMismatch(field string, expected, actual any) string {
 	return fmt.Sprintf("%s expected %v, got %v", field, expected, actual)
+}
+
+func formatChecklistFindings(findings []SecurityFinding) []string {
+	details := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		resource := finding.ResourceID
+		if strings.TrimSpace(resource) == "" {
+			resource = finding.ResourceType
+		}
+		details = append(details, fmt.Sprintf("[%s] %s — %s: %s", finding.Severity, resource, finding.RuleName, finding.Summary))
+	}
+	return details
+}
+
+func formatHostedZoneContext(zone *HostedZone) string {
+	name := strings.TrimRight(strings.TrimSpace(zone.Name), ".")
+	if name == "" {
+		return zone.ID
+	}
+	return fmt.Sprintf("%s (%s)", name, zone.ID)
+}
+
+func formatRoute53RecordContext(zone *HostedZone, record *DNSRecord) string {
+	return fmt.Sprintf("%s [%s] in %s", strings.TrimRight(strings.TrimSpace(record.Name), "."), record.Type, formatHostedZoneContext(zone))
+}
+
+func formatVPCContext(vpc *VPC) string {
+	if strings.TrimSpace(vpc.Name) == "" {
+		return vpc.VPCID
+	}
+	return fmt.Sprintf("%s (%s)", vpc.Name, vpc.VPCID)
+}
+
+func formatSubnetContext(subnet *Subnet) string {
+	label := subnet.SubnetID
+	if strings.TrimSpace(subnet.Name) != "" {
+		label = fmt.Sprintf("%s (%s)", subnet.Name, subnet.SubnetID)
+	}
+	if strings.TrimSpace(subnet.VPCID) == "" {
+		return label
+	}
+	return fmt.Sprintf("%s in %s", label, subnet.VPCID)
+}
+
+func equalChecklistStringSets(expected, actual []string) bool {
+	if len(expected) != len(actual) {
+		return false
+	}
+	left := normalizeChecklistStringSet(expected)
+	right := normalizeChecklistStringSet(actual)
+	for idx := range left {
+		if left[idx] != right[idx] {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeChecklistStringSet(values []string) []string {
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		normalized = append(normalized, strings.TrimSpace(value))
+	}
+	slices.Sort(normalized)
+	return normalized
+}
+
+func normalizedHostedZoneIDKey(value string) string {
+	return normalizedChecklistKey(strings.TrimPrefix(strings.TrimSpace(value), "/hostedzone/"))
+}
+
+func normalizedDNSNameKey(value string) string {
+	return strings.ToLower(strings.TrimRight(strings.TrimSpace(value), "."))
 }
 
 func normalizedChecklistKey(value string) string {

--- a/internal/inspector/checklist_support_test.go
+++ b/internal/inspector/checklist_support_test.go
@@ -1,0 +1,70 @@
+package inspector
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+)
+
+type checklistMockRoute53Client struct {
+	listHostedZonesFunc        func(ctx context.Context, params *route53.ListHostedZonesInput, optFns ...func(*route53.Options)) (*route53.ListHostedZonesOutput, error)
+	listResourceRecordSetsFunc func(ctx context.Context, params *route53.ListResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error)
+	changeResourceRecordSets   func(ctx context.Context, params *route53.ChangeResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ChangeResourceRecordSetsOutput, error)
+	getChangeFunc              func(ctx context.Context, params *route53.GetChangeInput, optFns ...func(*route53.Options)) (*route53.GetChangeOutput, error)
+}
+
+func (m *checklistMockRoute53Client) ListHostedZones(ctx context.Context, params *route53.ListHostedZonesInput, optFns ...func(*route53.Options)) (*route53.ListHostedZonesOutput, error) {
+	if m.listHostedZonesFunc != nil {
+		return m.listHostedZonesFunc(ctx, params, optFns...)
+	}
+	return &route53.ListHostedZonesOutput{}, nil
+}
+
+func (m *checklistMockRoute53Client) ListResourceRecordSets(ctx context.Context, params *route53.ListResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error) {
+	if m.listResourceRecordSetsFunc != nil {
+		return m.listResourceRecordSetsFunc(ctx, params, optFns...)
+	}
+	return &route53.ListResourceRecordSetsOutput{}, nil
+}
+
+func (m *checklistMockRoute53Client) ChangeResourceRecordSets(ctx context.Context, params *route53.ChangeResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ChangeResourceRecordSetsOutput, error) {
+	if m.changeResourceRecordSets != nil {
+		return m.changeResourceRecordSets(ctx, params, optFns...)
+	}
+	return &route53.ChangeResourceRecordSetsOutput{}, nil
+}
+
+func (m *checklistMockRoute53Client) GetChange(ctx context.Context, params *route53.GetChangeInput, optFns ...func(*route53.Options)) (*route53.GetChangeOutput, error) {
+	if m.getChangeFunc != nil {
+		return m.getChangeFunc(ctx, params, optFns...)
+	}
+	return &route53.GetChangeOutput{}, nil
+}
+
+type checklistMockCloudWatchLogsClient struct {
+	describeLogGroupsFunc  func(ctx context.Context, params *cloudwatchlogs.DescribeLogGroupsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error)
+	describeLogStreamsFunc func(ctx context.Context, params *cloudwatchlogs.DescribeLogStreamsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogStreamsOutput, error)
+	filterLogEventsFunc    func(ctx context.Context, params *cloudwatchlogs.FilterLogEventsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.FilterLogEventsOutput, error)
+}
+
+func (m *checklistMockCloudWatchLogsClient) DescribeLogGroups(ctx context.Context, params *cloudwatchlogs.DescribeLogGroupsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+	if m.describeLogGroupsFunc != nil {
+		return m.describeLogGroupsFunc(ctx, params, optFns...)
+	}
+	return &cloudwatchlogs.DescribeLogGroupsOutput{}, nil
+}
+
+func (m *checklistMockCloudWatchLogsClient) DescribeLogStreams(ctx context.Context, params *cloudwatchlogs.DescribeLogStreamsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogStreamsOutput, error) {
+	if m.describeLogStreamsFunc != nil {
+		return m.describeLogStreamsFunc(ctx, params, optFns...)
+	}
+	return &cloudwatchlogs.DescribeLogStreamsOutput{}, nil
+}
+
+func (m *checklistMockCloudWatchLogsClient) FilterLogEvents(ctx context.Context, params *cloudwatchlogs.FilterLogEventsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.FilterLogEventsOutput, error) {
+	if m.filterLogEventsFunc != nil {
+		return m.filterLogEventsFunc(ctx, params, optFns...)
+	}
+	return &cloudwatchlogs.FilterLogEventsOutput{}, nil
+}

--- a/internal/inspector/checklist_test.go
+++ b/internal/inspector/checklist_test.go
@@ -8,10 +8,21 @@ import (
 	"testing"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudtrail"
+	cloudtrailtypes "github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cloudwatchlogstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	"github.com/aws/aws-sdk-go-v2/service/configservice"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+	elasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	"github.com/aws/aws-sdk-go-v2/service/guardduty"
+	guarddutytypes "github.com/aws/aws-sdk-go-v2/service/guardduty/types"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 )
@@ -43,6 +54,30 @@ func TestLoadChecklistParsesSampleFile(t *testing.T) {
 	}
 }
 
+func TestLoadChecklistParsesExpandedSampleFile(t *testing.T) {
+	path := filepath.Join("testdata", "checklists", "expanded-readiness.yaml")
+
+	checklist, err := LoadChecklist(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(checklist.Checks) != 9 {
+		t.Fatalf("expected 9 checks, got %d", len(checklist.Checks))
+	}
+	if checklist.Checks[0].Type != ChecklistCheckHostedZone {
+		t.Fatalf("expected first expanded check to be hosted_zone, got %s", checklist.Checks[0].Type)
+	}
+	if checklist.Checks[1].Expect.Zone != "example.internal" {
+		t.Fatalf("expected route53_record zone to parse, got %+v", checklist.Checks[1].Expect)
+	}
+	if checklist.Checks[4].Type != ChecklistCheckCloudWatchLogGroup {
+		t.Fatalf("expected fifth expanded check to be cloudwatch_log_group, got %s", checklist.Checks[4].Type)
+	}
+	if checklist.Checks[8].Type != ChecklistCheckElastiCacheValkeyBaseline {
+		t.Fatalf("expected final expanded check to be elasticache_valkey_baseline, got %s", checklist.Checks[8].Type)
+	}
+}
+
 func TestLoadChecklistRejectsUnknownFields(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "invalid.yaml")
 	content := strings.Join([]string{
@@ -64,6 +99,29 @@ func TestLoadChecklistRejectsUnknownFields(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unexpected") {
 		t.Fatalf("expected unknown field mention, got %v", err)
+	}
+}
+
+func TestLoadChecklistRejectsRoute53RecordWithoutZone(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing-zone.yaml")
+	content := strings.Join([]string{
+		"name: Invalid",
+		"checks:",
+		"  - type: route53_record",
+		"    resource: api.example.internal",
+		"    expect:",
+		"      record_type: A",
+	}, "\n")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write checklist: %v", err)
+	}
+
+	_, err := LoadChecklist(path)
+	if err == nil {
+		t.Fatal("expected route53_record zone validation error")
+	}
+	if !strings.Contains(err.Error(), "expect.zone") {
+		t.Fatalf("expected expect.zone validation error, got %v", err)
 	}
 }
 
@@ -159,5 +217,308 @@ func TestRunChecklistReportsPassAndFailPerCheck(t *testing.T) {
 	}
 	if !strings.Contains(report.Results[2].Details[0], "password") {
 		t.Fatalf("expected missing password detail, got %+v", report.Results[2].Details)
+	}
+}
+
+func TestRunChecklistRoute53Checks(t *testing.T) {
+	checklistPath := filepath.Join(t.TempDir(), "route53.yaml")
+	content := strings.Join([]string{
+		"name: Route53 Readiness",
+		"checks:",
+		"  - id: private-zone",
+		"    type: hosted_zone",
+		"    resource: example.internal",
+		"    expect:",
+		"      private_zone: true",
+		"  - id: api-record",
+		"    type: route53_record",
+		"    resource: api.example.internal",
+		"    expect:",
+		"      zone: example.internal",
+		"      record_type: A",
+		"      alias_target: internal-alb-123.ap-northeast-2.elb.amazonaws.com",
+		"  - id: txt-record-mismatch",
+		"    type: route53_record",
+		"    resource: example.internal",
+		"    expect:",
+		"      zone: example.internal",
+		"      record_type: TXT",
+		"      values:",
+		"        - v=spf1 include:mail.example.internal -all",
+	}, "\n")
+	if err := os.WriteFile(checklistPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write checklist: %v", err)
+	}
+
+	checklist, err := LoadChecklist(checklistPath)
+	if err != nil {
+		t.Fatalf("unexpected error loading checklist: %v", err)
+	}
+
+	repo := &AwsRepository{
+		Route53Client: &checklistMockRoute53Client{
+			listHostedZonesFunc: func(context.Context, *route53.ListHostedZonesInput, ...func(*route53.Options)) (*route53.ListHostedZonesOutput, error) {
+				return &route53.ListHostedZonesOutput{
+					HostedZones: []r53types.HostedZone{
+						{
+							Id:   awssdk.String("/hostedzone/Z123"),
+							Name: awssdk.String("example.internal."),
+							Config: &r53types.HostedZoneConfig{
+								PrivateZone: true,
+							},
+						},
+					},
+				}, nil
+			},
+			listResourceRecordSetsFunc: func(_ context.Context, params *route53.ListResourceRecordSetsInput, _ ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error) {
+				if awssdk.ToString(params.HostedZoneId) != "Z123" {
+					t.Fatalf("unexpected hosted zone id %q", awssdk.ToString(params.HostedZoneId))
+				}
+				return &route53.ListResourceRecordSetsOutput{
+					ResourceRecordSets: []r53types.ResourceRecordSet{
+						{
+							Name: awssdk.String("api.example.internal."),
+							Type: r53types.RRTypeA,
+							AliasTarget: &r53types.AliasTarget{
+								DNSName:      awssdk.String("internal-alb-123.ap-northeast-2.elb.amazonaws.com."),
+								HostedZoneId: awssdk.String("ZELB"),
+							},
+						},
+						{
+							Name: awssdk.String("example.internal."),
+							Type: r53types.RRTypeTxt,
+							TTL:  awssdk.Int64(60),
+							ResourceRecords: []r53types.ResourceRecord{
+								{Value: awssdk.String("v=spf1 include:_spf.example.internal -all")},
+							},
+						},
+					},
+				}, nil
+			},
+		},
+	}
+
+	report, err := RunChecklist(context.Background(), repo, checklist)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.PassedCount != 2 || report.FailedCount != 1 {
+		t.Fatalf("expected 2 pass / 1 fail, got %d pass / %d fail", report.PassedCount, report.FailedCount)
+	}
+	if !report.Results[0].Passed || !report.Results[1].Passed {
+		t.Fatalf("expected hosted zone and alias record checks to pass, got %+v", report.Results)
+	}
+	if report.Results[2].Passed {
+		t.Fatalf("expected TXT record check to fail, got %+v", report.Results[2])
+	}
+	if !strings.Contains(report.Results[2].Details[0], "values") {
+		t.Fatalf("expected values mismatch detail, got %+v", report.Results[2].Details)
+	}
+}
+
+func TestRunChecklistVPCAndSubnetChecks(t *testing.T) {
+	checklistPath := filepath.Join(t.TempDir(), "network.yaml")
+	content := strings.Join([]string{
+		"name: Network Readiness",
+		"checks:",
+		"  - id: main-vpc",
+		"    type: vpc",
+		"    resource: main-vpc",
+		"    expect:",
+		"      cidr: 10.0.0.0/16",
+		"      default_vpc: false",
+		"      subnet_count: 2",
+		"  - id: app-subnet-a",
+		"    type: subnet",
+		"    resource: app-a",
+		"    expect:",
+		"      vpc: main-vpc",
+		"      availability_zone: ap-northeast-2a",
+		"      available_ip_count_min: 10",
+		"  - id: app-subnet-b-low-ips",
+		"    type: subnet",
+		"    resource: app-b",
+		"    expect:",
+		"      vpc: main-vpc",
+		"      available_ip_count_min: 10",
+	}, "\n")
+	if err := os.WriteFile(checklistPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write checklist: %v", err)
+	}
+
+	checklist, err := LoadChecklist(checklistPath)
+	if err != nil {
+		t.Fatalf("unexpected error loading checklist: %v", err)
+	}
+
+	repo := &AwsRepository{
+		EC2Client: &mockEC2Client{
+			describeVpcsFunc: func(context.Context, *ec2.DescribeVpcsInput, ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error) {
+				return &ec2.DescribeVpcsOutput{
+					Vpcs: []ec2types.Vpc{
+						{
+							VpcId:     awssdk.String("vpc-123"),
+							CidrBlock: awssdk.String("10.0.0.0/16"),
+							IsDefault: awssdk.Bool(false),
+							Tags:      []ec2types.Tag{{Key: awssdk.String("Name"), Value: awssdk.String("main-vpc")}},
+						},
+					},
+				}, nil
+			},
+			describeSubnetsFunc: func(_ context.Context, params *ec2.DescribeSubnetsInput, _ ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error) {
+				if len(params.Filters) == 0 || awssdk.ToString(params.Filters[0].Name) != "vpc-id" {
+					t.Fatalf("expected subnet filter by vpc-id, got %+v", params.Filters)
+				}
+				return &ec2.DescribeSubnetsOutput{
+					Subnets: []ec2types.Subnet{
+						{
+							SubnetId:                awssdk.String("subnet-a"),
+							VpcId:                   awssdk.String("vpc-123"),
+							CidrBlock:               awssdk.String("10.0.1.0/24"),
+							AvailabilityZone:        awssdk.String("ap-northeast-2a"),
+							AvailableIpAddressCount: awssdk.Int32(20),
+							Tags:                    []ec2types.Tag{{Key: awssdk.String("Name"), Value: awssdk.String("app-a")}},
+						},
+						{
+							SubnetId:                awssdk.String("subnet-b"),
+							VpcId:                   awssdk.String("vpc-123"),
+							CidrBlock:               awssdk.String("10.0.2.0/24"),
+							AvailabilityZone:        awssdk.String("ap-northeast-2b"),
+							AvailableIpAddressCount: awssdk.Int32(4),
+							Tags:                    []ec2types.Tag{{Key: awssdk.String("Name"), Value: awssdk.String("app-b")}},
+						},
+					},
+				}, nil
+			},
+		},
+	}
+
+	report, err := RunChecklist(context.Background(), repo, checklist)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.PassedCount != 2 || report.FailedCount != 1 {
+		t.Fatalf("expected 2 pass / 1 fail, got %d pass / %d fail", report.PassedCount, report.FailedCount)
+	}
+	if report.Results[2].Passed {
+		t.Fatalf("expected subnet low-IP check to fail, got %+v", report.Results[2])
+	}
+	if !strings.Contains(report.Results[2].Details[0], "available_ip_count") {
+		t.Fatalf("expected available_ip_count detail, got %+v", report.Results[2].Details)
+	}
+}
+
+func TestRunChecklistLogGroupAndBaselineChecks(t *testing.T) {
+	checklistPath := filepath.Join(t.TempDir(), "baselines.yaml")
+	content := strings.Join([]string{
+		"name: Logging and Baselines",
+		"checks:",
+		"  - id: app-log-group",
+		"    type: cloudwatch_log_group",
+		"    resource: /aws/ecs/app",
+		"    expect:",
+		"      retention_days: 30",
+		"  - id: cloudtrail-clean",
+		"    type: cloudtrail_baseline",
+		"    resource: cloudtrail",
+		"  - id: guardduty-clean",
+		"    type: guardduty_baseline",
+		"    resource: guardduty",
+		"  - id: config-clean",
+		"    type: config_baseline",
+		"    resource: config",
+		"  - id: valkey-clean",
+		"    type: elasticache_valkey_baseline",
+		"    resource: valkey",
+	}, "\n")
+	if err := os.WriteFile(checklistPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write checklist: %v", err)
+	}
+
+	checklist, err := LoadChecklist(checklistPath)
+	if err != nil {
+		t.Fatalf("unexpected error loading checklist: %v", err)
+	}
+
+	repo := &AwsRepository{
+		CloudWatchLogsClient: &checklistMockCloudWatchLogsClient{
+			describeLogGroupsFunc: func(context.Context, *cloudwatchlogs.DescribeLogGroupsInput, ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+				return &cloudwatchlogs.DescribeLogGroupsOutput{
+					LogGroups: []cloudwatchlogstypes.LogGroup{
+						{
+							LogGroupName:    awssdk.String("/aws/ecs/app"),
+							Arn:             awssdk.String("arn:aws:logs:ap-northeast-2:123456789012:log-group:/aws/ecs/app"),
+							RetentionInDays: awssdk.Int32(30),
+						},
+					},
+				}, nil
+			},
+		},
+		CloudTrailClient: &mockCloudTrailClient{
+			describeTrailsFunc: func(context.Context, *cloudtrail.DescribeTrailsInput, ...func(*cloudtrail.Options)) (*cloudtrail.DescribeTrailsOutput, error) {
+				return &cloudtrail.DescribeTrailsOutput{
+					TrailList: []cloudtrailtypes.Trail{
+						{
+							Name:                     awssdk.String("org-trail"),
+							TrailARN:                 awssdk.String("arn:aws:cloudtrail:us-east-1:123456789012:trail/org-trail"),
+							IsMultiRegionTrail:       awssdk.Bool(true),
+							LogFileValidationEnabled: awssdk.Bool(true),
+						},
+					},
+				}, nil
+			},
+			getTrailStatusFunc: func(context.Context, *cloudtrail.GetTrailStatusInput, ...func(*cloudtrail.Options)) (*cloudtrail.GetTrailStatusOutput, error) {
+				return &cloudtrail.GetTrailStatusOutput{IsLogging: awssdk.Bool(true)}, nil
+			},
+		},
+		GuardDutyClient: &mockGuardDutyClient{
+			listDetectorsFunc: func(context.Context, *guardduty.ListDetectorsInput, ...func(*guardduty.Options)) (*guardduty.ListDetectorsOutput, error) {
+				return &guardduty.ListDetectorsOutput{DetectorIds: []string{"detector-1"}}, nil
+			},
+			getDetectorFunc: func(context.Context, *guardduty.GetDetectorInput, ...func(*guardduty.Options)) (*guardduty.GetDetectorOutput, error) {
+				return &guardduty.GetDetectorOutput{Status: guarddutytypes.DetectorStatusEnabled}, nil
+			},
+		},
+		ConfigServiceClient: &mockConfigServiceClient{
+			describeRecordersFunc: func(context.Context, *configservice.DescribeConfigurationRecordersInput, ...func(*configservice.Options)) (*configservice.DescribeConfigurationRecordersOutput, error) {
+				return &configservice.DescribeConfigurationRecordersOutput{}, nil
+			},
+			describeStatusFunc: func(context.Context, *configservice.DescribeConfigurationRecorderStatusInput, ...func(*configservice.Options)) (*configservice.DescribeConfigurationRecorderStatusOutput, error) {
+				return &configservice.DescribeConfigurationRecorderStatusOutput{}, nil
+			},
+		},
+		ElastiCacheClient: &mockElastiCacheClient{
+			describeReplicationGroupsFunc: func(context.Context, *elasticache.DescribeReplicationGroupsInput, ...func(*elasticache.Options)) (*elasticache.DescribeReplicationGroupsOutput, error) {
+				return &elasticache.DescribeReplicationGroupsOutput{
+					ReplicationGroups: []elasticachetypes.ReplicationGroup{
+						{
+							ReplicationGroupId:       awssdk.String("valkey-secure"),
+							Engine:                   awssdk.String("valkey"),
+							TransitEncryptionEnabled: awssdk.Bool(true),
+							AtRestEncryptionEnabled:  awssdk.Bool(true),
+							SnapshotRetentionLimit:   awssdk.Int32(inspectorValkeyMinSnapshotRetentionDays),
+							UserGroupIds:             []string{"ug-123"},
+						},
+					},
+				}, nil
+			},
+		},
+	}
+
+	report, err := RunChecklist(context.Background(), repo, checklist)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.PassedCount != 4 || report.FailedCount != 1 {
+		t.Fatalf("expected 4 pass / 1 fail, got %d pass / %d fail", report.PassedCount, report.FailedCount)
+	}
+	if report.Results[3].Passed {
+		t.Fatalf("expected config baseline check to fail, got %+v", report.Results[3])
+	}
+	if !strings.Contains(report.Results[3].Summary, "baseline finding") {
+		t.Fatalf("expected baseline finding summary, got %+v", report.Results[3])
+	}
+	if len(report.Results[3].Details) == 0 || !strings.Contains(report.Results[3].Details[0], "AWS Config") {
+		t.Fatalf("expected baseline finding details, got %+v", report.Results[3].Details)
 	}
 }

--- a/internal/inspector/inspector_model.go
+++ b/internal/inspector/inspector_model.go
@@ -26,10 +26,10 @@ type Workflow struct {
 func Workflows(checklistPath string) []Workflow {
 	checklistAvailable := strings.TrimSpace(checklistPath) != ""
 	checklistStatus := "ADD FILE"
-	checklistDescription := "Pass --checklist <path> to load a YAML checklist for readiness checks across RDS, security groups, and Secrets Manager."
+	checklistDescription := "Pass --checklist <path> to load a YAML checklist for readiness checks across infrastructure resources and baseline posture."
 	if checklistAvailable {
 		checklistStatus = ""
-		checklistDescription = "Run a user-supplied YAML checklist to verify infrastructure readiness across RDS, security groups, and Secrets Manager."
+		checklistDescription = "Run a user-supplied YAML checklist to verify infrastructure readiness across databases, network resources, DNS, logging, secrets, and baseline posture."
 	}
 
 	return []Workflow{
@@ -62,11 +62,15 @@ func (w Workflow) StatusLabel() string {
 type AwsRepository = awsservice.AwsRepository
 type AccessKey = awsservice.AccessKey
 type CloudTrailClientAPI = awsservice.CloudTrailClientAPI
+type CloudWatchLogsClientAPI = awsservice.CloudWatchLogsClientAPI
 type ConfigServiceClientAPI = awsservice.ConfigServiceClientAPI
+type DNSRecord = awsservice.DNSRecord
 type EC2ClientAPI = awsservice.EC2ClientAPI
 type ElastiCacheClientAPI = awsservice.ElastiCacheClientAPI
 type GuardDutyClientAPI = awsservice.GuardDutyClientAPI
+type HostedZone = awsservice.HostedZone
 type IAMClientAPI = awsservice.IAMClientAPI
+type LogGroup = awsservice.LogGroup
 type RDSClientAPI = awsservice.RDSClientAPI
 type S3Bucket = awsservice.S3Bucket
 type Secret = awsservice.Secret
@@ -75,6 +79,9 @@ type SecurityGroup = awsservice.SecurityGroup
 type SecurityGroupRule = awsservice.SecurityGroupRule
 type SecretsManagerClientAPI = awsservice.SecretsManagerClientAPI
 type RDSInstance = awsservice.RDSInstance
+type Route53ClientAPI = awsservice.Route53ClientAPI
+type Subnet = awsservice.Subnet
+type VPC = awsservice.VPC
 
 type RuleSeverity string
 

--- a/internal/inspector/testdata/checklists/expanded-readiness.yaml
+++ b/internal/inspector/testdata/checklists/expanded-readiness.yaml
@@ -1,0 +1,54 @@
+name: Expanded Production Readiness
+description: Covers the extended Checklist Inspector static resource checks.
+checks:
+  - id: private-zone
+    type: hosted_zone
+    resource: example.internal
+    expect:
+      private_zone: true
+
+  - id: api-record
+    type: route53_record
+    resource: api.example.internal
+    expect:
+      zone: example.internal
+      record_type: A
+      alias_target: internal-alb-123.ap-northeast-2.elb.amazonaws.com
+
+  - id: primary-vpc
+    type: vpc
+    resource: main-vpc
+    expect:
+      cidr: 10.0.0.0/16
+      default_vpc: false
+      subnet_count: 2
+
+  - id: app-subnet-a
+    type: subnet
+    resource: app-a
+    expect:
+      vpc: main-vpc
+      availability_zone: ap-northeast-2a
+      available_ip_count_min: 10
+
+  - id: app-log-group
+    type: cloudwatch_log_group
+    resource: /aws/ecs/app
+    expect:
+      retention_days: 30
+
+  - id: cloudtrail-baseline
+    type: cloudtrail_baseline
+    resource: cloudtrail
+
+  - id: guardduty-baseline
+    type: guardduty_baseline
+    resource: guardduty
+
+  - id: config-baseline
+    type: config_baseline
+    resource: config
+
+  - id: valkey-baseline
+    type: elasticache_valkey_baseline
+    resource: valkey

--- a/internal/services/aws/vpc.go
+++ b/internal/services/aws/vpc.go
@@ -70,6 +70,7 @@ func (r *AwsRepository) ListSubnets(ctx context.Context, vpcID string) ([]Subnet
 		subnets = append(subnets, Subnet{
 			SubnetID:         awssdk.ToString(s.SubnetId),
 			Name:             extractNameTag(s.Tags),
+			VPCID:            awssdk.ToString(s.VpcId),
 			CIDR:             awssdk.ToString(s.CidrBlock),
 			AvailabilityZone: awssdk.ToString(s.AvailabilityZone),
 			AvailableIPCount: awssdk.ToInt32(s.AvailableIpAddressCount),

--- a/internal/services/aws/vpc_model.go
+++ b/internal/services/aws/vpc_model.go
@@ -31,6 +31,7 @@ func (v VPC) FilterText() string {
 type Subnet struct {
 	SubnetID         string
 	Name             string
+	VPCID            string
 	CIDR             string
 	AvailabilityZone string
 	AvailableIPCount int32


### PR DESCRIPTION
### Summary

- add Checklist Inspector support for Route53 hosted zones and records, VPCs, subnets, and CloudWatch log groups
- add checklist wrappers for the existing CloudTrail, GuardDuty, AWS Config, and ElastiCache for Valkey baseline scanners
- extend checklist validation, fixtures, tests, and docs for the broader static readiness surface

### Related Issues

Closes #138
Closes #139
Closes #140
Closes #141

### Validation

- `make test`
- `make build`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed
- [x] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [ ] Breaking changes documented
