### PR TITLE
feat: add ECS rollout visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It combines a Bubble Tea application, Cobra-based CLI commands, and AWS SDK v2 c
 - Drill down into resources with filters, detail views, and action screens
 - Open a context-aware keyboard shortcut help screen with `?`
 - Show animated loading indicators while async AWS data is being fetched
-- Perform operational workflows such as SSM sessions, RDS control, Route53 record changes, ECS exec, and IAM access key rotation
+- Perform operational workflows such as SSM sessions, RDS control, Route53 record changes, ECS rollout inspection/exec, and IAM access key rotation
 - Press `i` from the service picker to enter Inspector mode, then run either the Security Inspector workflow for built-in findings or the Checklist Inspector workflow for YAML-driven readiness checks across databases, network resources, DNS, logging, secrets, and baseline posture. Checklist files can be loaded from the in-TUI picker or preloaded with `--checklist <path>`
 
 ## Documentation Map
@@ -206,7 +206,7 @@ Context ordering:
 | Route53 | Route53 Browser |
 | Secrets Manager | Secrets Browser |
 | CloudWatch Logs | Logs Browser |
-| ECS | ECS Exec Sessions |
+| ECS | ECS Browser & Exec |
 | S3 | S3 Browser |
 | IAM | IAM User Browser |
 | IAM | ListAccessKeys |
@@ -312,7 +312,7 @@ checks:
 | Route53 | `c` create, `e` edit, `d` delete |
 | IAM Key Rotation | `r` rotate, `c` copy exports, `a` apply and verify, `d` deactivate old key, `x` delete old key |
 | CloudWatch Logs | log groups/streams load 10 at a time, `n` load more, `1`-`6` time presets, `t` live tail, `f` filter pattern, `w` wrap toggle, `h/l` horizontal scroll |
-| ECS Exec | `r` refresh, `Enter` drill down / exec |
+| ECS Rollout / Exec | cluster/service lists support refresh and drill-down, service detail shows deployments/task definition images/events, `Enter` continues into tasks and exec |
 | Inspector Mode | `i` open mode from the service list, `Enter` open the selected workflow, `l` open the checklist file picker |
 | Security Inspector | `r` run/rescan, `1`-`5` severity filter, `Enter` finding detail |
 | Checklist Inspector | `l` load or switch checklist files, `r` run/rerun the loaded checklist, `Enter` result detail |

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -179,7 +179,7 @@ Current screen families include:
 - Security Group list/detail/edit flows
 - IAM user, key, and key-rotation flows
 - CloudWatch Logs group/stream/viewer flows
-- ECS cluster/service/task/container flows
+- ECS cluster/service/rollout detail/task/container flows
 - S3 bucket/object/detail flows
 - Inspector mode home, checklist setup, security findings/detail, and checklist results/detail flows
 - context picker, context add, and TUI-native context setup/export/unset flows

--- a/docs/architecture.ko.md
+++ b/docs/architecture.ko.md
@@ -179,7 +179,7 @@ UNIC은 현재 세 가지 인증 모드를 지원한다.
 - Security Group list/detail/edit
 - IAM user, key, key rotation
 - CloudWatch Logs group/stream/viewer
-- ECS cluster/service/task/container
+- ECS cluster/service/rollout detail/task/container
 - S3 bucket/object/detail
 - Inspector mode home, checklist setup, security findings/detail, checklist results/detail
 - context picker, context add, TUI-native context setup/export/unset

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -57,6 +57,7 @@ const (
 	screenCWLogViewer
 	screenECSClusterList
 	screenECSServiceList
+	screenECSServiceDetail
 	screenECSTaskList
 	screenECSContainerList
 	screenS3BucketList
@@ -222,6 +223,8 @@ type Model struct {
 	filteredECSServices []awsservice.ECSService
 	ecsServiceIdx       int
 	selectedECSService  *awsservice.ECSService
+	selectedECSDetail   *awsservice.ECSServiceDetail
+	ecsDetailScroll     int
 
 	ecsTasks        []awsservice.ECSTask
 	ecsTaskIdx      int
@@ -585,6 +588,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateECSClusterList(msg)
 		case screenECSServiceList:
 			return m.updateECSServiceList(msg)
+		case screenECSServiceDetail:
+			return m.updateECSServiceDetail(msg)
 		case screenECSTaskList:
 			return m.updateECSTaskList(msg)
 		case screenECSContainerList:
@@ -842,6 +847,8 @@ func (m Model) View() string {
 		v = m.viewECSClusterList()
 	case screenECSServiceList:
 		v = m.viewECSServiceList()
+	case screenECSServiceDetail:
+		v = m.viewECSServiceDetail()
 	case screenECSTaskList:
 		v = m.viewECSTaskList()
 	case screenECSContainerList:

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -351,12 +351,20 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 		return listScreenShortcuts("open the selected ECS cluster", "go back to the feature list", true, true)
 	case screenECSServiceList:
 		return listScreenShortcuts("open the selected ECS service", "go back to the cluster list", true, true)
+	case screenECSServiceDetail:
+		return []helpShortcut{
+			{"↑/↓, j/k", "Scroll the service rollout detail"},
+			{"pgup / pgdn", "Scroll by one page"},
+			{"r", "Refresh the service rollout detail"},
+			{"enter", "Open running tasks for the selected service"},
+			{"q / esc", "Go back to the service list"},
+		}
 	case screenECSTaskList:
 		return []helpShortcut{
 			{"↑/↓, j/k", "Move between tasks"},
 			{"r", "Refresh the task list"},
 			{"enter", "Open the selected task"},
-			{"q / esc", "Go back to the service list"},
+			{"q / esc", "Go back to the service detail"},
 		}
 	case screenECSContainerList:
 		return []helpShortcut{
@@ -628,6 +636,8 @@ func (m Model) helpScreenTitle() string {
 		return "ECS Clusters"
 	case screenECSServiceList:
 		return "ECS Services"
+	case screenECSServiceDetail:
+		return "ECS Service Detail"
 	case screenECSTaskList:
 		return "ECS Tasks"
 	case screenECSContainerList:

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -188,6 +188,10 @@ type ecsServicesLoadedMsg struct {
 	services []awsservice.ECSService
 }
 
+type ecsServiceDetailLoadedMsg struct {
+	detail *awsservice.ECSServiceDetail
+}
+
 type ecsTasksLoadedMsg struct {
 	tasks []awsservice.ECSTask
 }

--- a/internal/app/screen_ecs.go
+++ b/internal/app/screen_ecs.go
@@ -20,6 +20,9 @@ func (m Model) handleECSMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		m.ecsClusters = msg.clusters
 		m.filteredECSClusters = msg.clusters
 		m.ecsClusterIdx = 0
+		m.selectedECSService = nil
+		m.selectedECSDetail = nil
+		m.ecsDetailScroll = 0
 		m.resetFilter(filterECSClusters)
 		m.screen = screenECSClusterList
 		return m, nil, true
@@ -28,8 +31,27 @@ func (m Model) handleECSMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		m.ecsServices = msg.services
 		m.filteredECSServices = msg.services
 		m.ecsServiceIdx = 0
+		m.selectedECSService = nil
+		m.selectedECSDetail = nil
+		m.ecsDetailScroll = 0
 		m.resetFilter(filterECSServices)
 		m.screen = screenECSServiceList
+		return m, nil, true
+
+	case ecsServiceDetailLoadedMsg:
+		m.selectedECSDetail = msg.detail
+		m.ecsDetailScroll = 0
+		if msg.detail != nil {
+			summary := msg.detail.Summary()
+			m.selectedECSService = &summary
+			for i, svc := range m.ecsServices {
+				if svc.ARN == summary.ARN {
+					m.ecsServices[i] = summary
+				}
+			}
+			m.filteredECSServices = applyFilter(m.ecsServices, m.filterValue(filterECSServices))
+		}
+		m.screen = screenECSServiceDetail
 		return m, nil, true
 
 	case ecsTasksLoadedMsg:
@@ -156,7 +178,7 @@ func (m Model) updateECSServiceList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if len(m.filteredECSServices) > 0 && m.ecsServiceIdx < len(m.filteredECSServices) {
 			svc := m.filteredECSServices[m.ecsServiceIdx]
 			m.selectedECSService = &svc
-			return m.startLoading(m.loadECSTasks())
+			return m.startLoading(m.loadECSServiceDetail())
 		}
 	}
 	return m, nil
@@ -205,8 +227,149 @@ func (m Model) viewECSServiceList() string {
 
 	b.WriteString(m.renderListPanel(panel.String()))
 	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • r: refresh • enter: select • esc: back • H: home"))
+	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • r: refresh • enter: detail • esc: back • H: home"))
 	return b.String()
+}
+
+// --- Service Detail ---
+
+func (m Model) updateECSServiceDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	lines := m.ecsServiceDetailLines()
+	visibleLines := max(m.height-9, 5)
+	maxOffset := max(len(lines)-visibleLines, 0)
+
+	switch msg.String() {
+	case "q", "esc":
+		m.screen = screenECSServiceList
+	case "up", "k":
+		if m.ecsDetailScroll > 0 {
+			m.ecsDetailScroll--
+		}
+	case "down", "j":
+		if m.ecsDetailScroll < maxOffset {
+			m.ecsDetailScroll++
+		}
+	case "pgup":
+		m.ecsDetailScroll -= visibleLines
+		if m.ecsDetailScroll < 0 {
+			m.ecsDetailScroll = 0
+		}
+	case "pgdown":
+		m.ecsDetailScroll += visibleLines
+		if m.ecsDetailScroll > maxOffset {
+			m.ecsDetailScroll = maxOffset
+		}
+	case "r":
+		return m.startLoading(m.loadECSServiceDetail())
+	case "enter":
+		return m.startLoading(m.loadECSTasks())
+	}
+	return m, nil
+}
+
+func (m Model) viewECSServiceDetail() string {
+	if m.selectedECSDetail == nil {
+		return ""
+	}
+
+	var b strings.Builder
+	var panel strings.Builder
+	detail := m.selectedECSDetail
+
+	b.WriteString(m.renderStatusBar())
+	b.WriteString(titleStyle.Render(fmt.Sprintf("ECS Service Rollout — %s", detail.Name)))
+	b.WriteString("\n\n")
+
+	lines := m.ecsServiceDetailLines()
+	if len(lines) == 0 {
+		panel.WriteString(dimStyle.Render("  No rollout detail available"))
+		panel.WriteString("\n")
+	} else {
+		visibleLines := max(m.height-9, 5)
+		start := m.ecsDetailScroll
+		maxOffset := max(len(lines)-visibleLines, 0)
+		if start > maxOffset {
+			start = maxOffset
+		}
+		if start < 0 {
+			start = 0
+		}
+		end := min(start+visibleLines, len(lines))
+		for _, line := range lines[start:end] {
+			panel.WriteString(line)
+			panel.WriteString("\n")
+		}
+		panel.WriteString("\n")
+		panel.WriteString(dimStyle.Render(fmt.Sprintf("  lines %d-%d/%d", start+1, end, len(lines))))
+	}
+
+	b.WriteString(m.renderListPanel(panel.String()))
+	b.WriteString("\n\n")
+	b.WriteString(m.renderHelpBar("↑/↓: scroll • pgup/pgdn: page • enter: tasks • r: refresh • esc: back • H: home"))
+	return b.String()
+}
+
+func (m Model) ecsServiceDetailLines() []string {
+	if m.selectedECSDetail == nil {
+		return nil
+	}
+
+	detail := m.selectedECSDetail
+	lines := []string{
+		renderDetailLine("Status", renderECSServiceStatus(detail.Status)),
+		renderDetailLine("Launch", renderECSValue(detail.LaunchType)),
+		renderDetailLine("Tasks", renderECSValue(fmt.Sprintf("running:%d desired:%d pending:%d", detail.RunningCount, detail.DesiredCount, detail.PendingCount))),
+		renderDetailLine("Deploy Ctrl", renderECSValue(zeroFallback(detail.DeploymentControllerType, "-"))),
+		renderDetailLine("Schedule", renderECSValue(zeroFallback(detail.SchedulingStrategy, "-"))),
+		renderDetailLine("Task Def", renderECSValue(detail.TaskDefinitionLabel())),
+		renderDetailLine("Platform", renderECSValue(zeroFallback(detail.PlatformVersion, "-"))),
+		renderDetailLine("Network", renderECSValue(zeroFallback(detail.NetworkMode, "-"))),
+		renderDetailLine("Compat", renderECSValue(detail.CompatibilityLabel())),
+	}
+
+	execStatus := "Disabled"
+	if detail.EnableExecuteCommand {
+		execStatus = "Enabled"
+	}
+	lines = append(lines, renderDetailLine("Exec", renderECSExecStatus(execStatus)))
+
+	lines = append(lines, "")
+	lines = append(lines, titleStyle.Render("Deployments"))
+	if len(detail.Deployments) == 0 {
+		lines = append(lines, dimStyle.Render("  No deployments found"))
+	} else {
+		for _, deployment := range detail.Deployments {
+			lines = append(lines, renderECSDeploymentSummary(deployment))
+			if deployment.RolloutStateReason != "" {
+				lines = append(lines, "    "+dimStyle.Render(deployment.RolloutStateReason))
+			}
+			if !deployment.UpdatedAt.IsZero() {
+				lines = append(lines, "    "+dimStyle.Render("Updated "+deployment.UpdatedAt.Local().Format("2006-01-02 15:04:05")))
+			}
+		}
+	}
+
+	lines = append(lines, "")
+	lines = append(lines, titleStyle.Render("Task Definition Images"))
+	if len(detail.ContainerImages) == 0 {
+		lines = append(lines, dimStyle.Render("  No container images found"))
+	} else {
+		for _, image := range detail.ContainerImages {
+			lines = append(lines, renderDetailLine(image.Name, normalStyle.Render(image.Image)))
+		}
+	}
+
+	lines = append(lines, "")
+	lines = append(lines, titleStyle.Render("Recent Service Events"))
+	if len(detail.Events) == 0 {
+		lines = append(lines, dimStyle.Render("  No recent service events"))
+	} else {
+		for _, event := range detail.Events {
+			lines = append(lines, "  "+normalStyle.Render(event.DisplayTitle()))
+		}
+	}
+
+	return lines
 }
 
 // --- Task List ---
@@ -214,7 +377,7 @@ func (m Model) viewECSServiceList() string {
 func (m Model) updateECSTaskList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "q", "esc":
-		m.screen = screenECSServiceList
+		m.screen = screenECSServiceDetail
 	case "up", "k":
 		if m.ecsTaskIdx > 0 {
 			m.ecsTaskIdx--
@@ -275,7 +438,7 @@ func (m Model) viewECSTaskList() string {
 
 	b.WriteString(m.renderListPanel(panel.String()))
 	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("↑/↓: navigate • r: refresh • enter: select • esc: back • H: home"))
+	b.WriteString(m.renderHelpBar("↑/↓: navigate • r: refresh • enter: select • esc: service detail • H: home"))
 	return b.String()
 }
 
@@ -422,6 +585,25 @@ func (m Model) loadECSTasks() tea.Cmd {
 	}
 }
 
+func (m Model) loadECSServiceDetail() tea.Cmd {
+	return func() tea.Msg {
+		if m.selectedECSCluster == nil || m.selectedECSService == nil {
+			return errMsg{err: fmt.Errorf("no cluster or service selected")}
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), ecsAPITimeout)
+		defer cancel()
+		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		detail, err := repo.DescribeServiceDetail(ctx, m.selectedECSCluster.ARN, m.selectedECSService.ARN)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		return ecsServiceDetailLoadedMsg{detail: detail}
+	}
+}
+
 func (m Model) loadECSContainers() tea.Cmd {
 	return func() tea.Msg {
 		if m.selectedECSCluster == nil || m.selectedECSTask == nil {
@@ -480,4 +662,69 @@ func (m Model) startECSExec(container awsservice.ECSContainer) tea.Cmd {
 		})
 		return execCmd()
 	}
+}
+
+func renderECSValue(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return dimStyle.Render("-")
+	}
+	return normalStyle.Render(value)
+}
+
+func renderECSExecStatus(value string) string {
+	if value == "Enabled" {
+		return successStyle.Render(value)
+	}
+	return dimStyle.Render(value)
+}
+
+func renderECSServiceStatus(status string) string {
+	switch status {
+	case "ACTIVE":
+		return successStyle.Render(status)
+	case "DRAINING":
+		return warningStyle.Render(status)
+	case "INACTIVE":
+		return errorStyle.Render(status)
+	default:
+		return normalStyle.Render(status)
+	}
+}
+
+func renderECSRolloutState(state string) string {
+	switch state {
+	case "COMPLETED":
+		return successStyle.Render(state)
+	case "IN_PROGRESS":
+		return warningStyle.Render(state)
+	case "FAILED":
+		return errorStyle.Render(state)
+	default:
+		return normalStyle.Render(zeroFallback(state, "-"))
+	}
+}
+
+func renderECSDeploymentSummary(deployment awsservice.ECSDeployment) string {
+	prefix := "  "
+	if deployment.Status == "PRIMARY" {
+		prefix = selectedStyle.Render("▸ ")
+	}
+	return prefix +
+		normalStyle.Render(fmt.Sprintf("%-9s rollout:", deployment.Status)) +
+		renderECSRolloutState(deployment.RolloutState) +
+		normalStyle.Render(fmt.Sprintf(
+			"  tasks:%d/%d pending:%d failed:%d  td:%s",
+			deployment.RunningCount,
+			deployment.DesiredCount,
+			deployment.PendingCount,
+			deployment.FailedTasks,
+			zeroFallback(deployment.TaskDefinition, "-"),
+		))
+}
+
+func zeroFallback(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
 }

--- a/internal/app/screen_ecs_test.go
+++ b/internal/app/screen_ecs_test.go
@@ -1,0 +1,148 @@
+package app
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	awsservice "unic/internal/services/aws"
+)
+
+func TestECSServiceListEnterLoadsServiceDetail(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenECSServiceList
+	m.selectedECSCluster = &awsservice.ECSCluster{Name: "prod-cluster", ARN: "arn:aws:ecs:us-east-1:123456789012:cluster/prod-cluster"}
+	m.ecsServices = []awsservice.ECSService{
+		{Name: "api-service", ARN: "arn:aws:ecs:us-east-1:123456789012:service/prod-cluster/api-service", Status: "ACTIVE", RunningCount: 2, DesiredCount: 3, PendingCount: 1, LaunchType: "FARGATE"},
+	}
+	m.filteredECSServices = m.ecsServices
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model := updated.(Model)
+	if cmd == nil {
+		t.Fatal("expected load command for ECS service detail")
+	}
+	if model.screen != screenLoading {
+		t.Fatalf("expected loading screen, got %v", model.screen)
+	}
+	if model.selectedECSService == nil || model.selectedECSService.Name != "api-service" {
+		t.Fatalf("expected selected ECS service api-service, got %+v", model.selectedECSService)
+	}
+}
+
+func TestHandleECSServiceDetailLoadedMsgShowsDetailScreen(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	detail := &awsservice.ECSServiceDetail{
+		Name:                   "api-service",
+		ARN:                    "arn:aws:ecs:us-east-1:123456789012:service/prod-cluster/api-service",
+		Status:                 "ACTIVE",
+		LaunchType:             "FARGATE",
+		DesiredCount:           3,
+		RunningCount:           2,
+		PendingCount:           1,
+		TaskDefinitionFamily:   "api",
+		TaskDefinitionRevision: 42,
+	}
+
+	updated, _, handled := m.handleECSMsg(ecsServiceDetailLoadedMsg{detail: detail})
+	if !handled {
+		t.Fatal("expected detail message to be handled")
+	}
+
+	model := updated.(Model)
+	if model.screen != screenECSServiceDetail {
+		t.Fatalf("expected ECS service detail screen, got %v", model.screen)
+	}
+	if model.selectedECSDetail == nil || model.selectedECSDetail.Name != "api-service" {
+		t.Fatalf("expected selected ECS detail api-service, got %+v", model.selectedECSDetail)
+	}
+	if model.selectedECSService == nil || model.selectedECSService.PendingCount != 1 {
+		t.Fatalf("expected service summary sync, got %+v", model.selectedECSService)
+	}
+}
+
+func TestECSServiceDetailViewShowsRolloutAndImages(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.width = 120
+	m.height = 36
+	m.screen = screenECSServiceDetail
+	m.selectedECSDetail = &awsservice.ECSServiceDetail{
+		Name:                     "api-service",
+		Status:                   "ACTIVE",
+		LaunchType:               "FARGATE",
+		SchedulingStrategy:       "REPLICA",
+		DeploymentControllerType: "ECS",
+		DesiredCount:             3,
+		RunningCount:             2,
+		PendingCount:             1,
+		EnableExecuteCommand:     true,
+		PlatformVersion:          "1.4.0",
+		TaskDefinitionFamily:     "api",
+		TaskDefinitionRevision:   42,
+		NetworkMode:              "awsvpc",
+		RequiresCompatibilities:  []string{"FARGATE"},
+		Deployments: []awsservice.ECSDeployment{
+			{
+				Status:             "PRIMARY",
+				RolloutState:       "IN_PROGRESS",
+				RolloutStateReason: "deployment in progress",
+				TaskDefinition:     "api:42",
+				RunningCount:       2,
+				DesiredCount:       3,
+				PendingCount:       1,
+				FailedTasks:        2,
+				UpdatedAt:          time.Date(2026, 4, 17, 12, 30, 0, 0, time.UTC),
+			},
+		},
+		ContainerImages: []awsservice.ECSContainerImage{
+			{Name: "app", Image: "123456789012.dkr.ecr.us-east-1.amazonaws.com/api:2026-04-17"},
+			{Name: "nginx", Image: "nginx:1.27"},
+		},
+		Events: []awsservice.ECSServiceEvent{
+			{
+				CreatedAt: time.Date(2026, 4, 17, 12, 29, 0, 0, time.UTC),
+				Message:   "(service api-service) has started 1 tasks: task abc123",
+			},
+		},
+	}
+
+	view := stripANSI(m.viewECSServiceDetail())
+	for _, want := range []string{
+		"ECS Service Rollout",
+		"running:2 desired:3 pending:1",
+		"api:42",
+		"deployment in progress",
+		"nginx:1.27",
+		"Recent Service Events",
+		"has started 1 tasks",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected view to contain %q, got %q", want, view)
+		}
+	}
+}
+
+func TestECSServiceDetailEscReturnsToServiceList(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenECSServiceDetail
+	m.selectedECSDetail = &awsservice.ECSServiceDetail{Name: "api-service"}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	model := updated.(Model)
+	if model.screen != screenECSServiceList {
+		t.Fatalf("expected esc to return to service list, got %v", model.screen)
+	}
+}
+
+func TestECSTaskListEscReturnsToServiceDetail(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenECSTaskList
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	model := updated.(Model)
+	if model.screen != screenECSServiceDetail {
+		t.Fatalf("expected esc to return to service detail, got %v", model.screen)
+	}
+}

--- a/internal/domain/catalog.go
+++ b/internal/domain/catalog.go
@@ -70,7 +70,7 @@ func Catalog() []Service {
 			Features: []Feature{
 				{
 					Kind:        FeatureECSExec,
-					Description: "Browse ECS clusters, services, tasks, and launch exec sessions",
+					Description: "Browse ECS clusters, service rollouts, tasks, and launch exec sessions",
 				},
 			},
 		},

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -30,7 +30,7 @@ const (
 	FeatureListAccessKeys        FeatureKind = "ListAccessKeys"
 	FeatureRotateAccessKey       FeatureKind = "RotateAccessKey"
 	FeatureCloudWatchLogsBrowser FeatureKind = "CloudWatch Logs Browser"
-	FeatureECSExec               FeatureKind = "ECS Exec Sessions"
+	FeatureECSExec               FeatureKind = "ECS Browser & Exec"
 	FeatureS3Browser             FeatureKind = "S3 Browser"
 )
 

--- a/internal/services/aws/ecs.go
+++ b/internal/services/aws/ecs.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -100,12 +101,128 @@ func (r *AwsRepository) ListServices(ctx context.Context, clusterARN string) ([]
 				Status:       awssdk.ToString(s.Status),
 				RunningCount: s.RunningCount,
 				DesiredCount: s.DesiredCount,
+				PendingCount: s.PendingCount,
 				LaunchType:   string(s.LaunchType),
 			}
 			services = append(services, svc)
 		}
 	}
 	return services, nil
+}
+
+// DescribeServiceDetail returns rollout, task definition, and recent event detail for one ECS service.
+func (r *AwsRepository) DescribeServiceDetail(ctx context.Context, clusterARN, serviceARN string) (*ECSServiceDetail, error) {
+	uniclog.Debug("aws", "DescribeServiceDetail called", "cluster", clusterARN, "service", serviceARN)
+
+	out, err := r.ECSClient.DescribeServices(ctx, &ecs.DescribeServicesInput{
+		Cluster:  awssdk.String(clusterARN),
+		Services: []string{serviceARN},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe ECS service %s: %w", serviceARN, err)
+	}
+
+	if len(out.Services) == 0 {
+		return nil, fmt.Errorf("ECS service not found: %s", serviceARN)
+	}
+
+	service := out.Services[0]
+	detail := &ECSServiceDetail{
+		Name:                 awssdk.ToString(service.ServiceName),
+		ARN:                  awssdk.ToString(service.ServiceArn),
+		Status:               awssdk.ToString(service.Status),
+		LaunchType:           string(service.LaunchType),
+		SchedulingStrategy:   string(service.SchedulingStrategy),
+		DesiredCount:         service.DesiredCount,
+		RunningCount:         service.RunningCount,
+		PendingCount:         service.PendingCount,
+		EnableExecuteCommand: service.EnableExecuteCommand,
+		PlatformVersion:      awssdk.ToString(service.PlatformVersion),
+		TaskDefinitionARN:    awssdk.ToString(service.TaskDefinition),
+	}
+	if service.DeploymentController != nil {
+		detail.DeploymentControllerType = string(service.DeploymentController.Type)
+	}
+
+	for _, deployment := range service.Deployments {
+		item := ECSDeployment{
+			ID:                 awssdk.ToString(deployment.Id),
+			Status:             awssdk.ToString(deployment.Status),
+			RolloutState:       string(deployment.RolloutState),
+			RolloutStateReason: awssdk.ToString(deployment.RolloutStateReason),
+			TaskDefinition:     shortECSResourceRef(awssdk.ToString(deployment.TaskDefinition)),
+			RunningCount:       deployment.RunningCount,
+			DesiredCount:       deployment.DesiredCount,
+			PendingCount:       deployment.PendingCount,
+			FailedTasks:        deployment.FailedTasks,
+		}
+		if deployment.CreatedAt != nil {
+			item.CreatedAt = *deployment.CreatedAt
+		}
+		if deployment.UpdatedAt != nil {
+			item.UpdatedAt = *deployment.UpdatedAt
+		}
+		detail.Deployments = append(detail.Deployments, item)
+	}
+	sort.SliceStable(detail.Deployments, func(i, j int) bool {
+		left := detail.Deployments[i]
+		right := detail.Deployments[j]
+		if left.Status == "PRIMARY" && right.Status != "PRIMARY" {
+			return true
+		}
+		if left.Status != "PRIMARY" && right.Status == "PRIMARY" {
+			return false
+		}
+		if !left.UpdatedAt.Equal(right.UpdatedAt) {
+			return left.UpdatedAt.After(right.UpdatedAt)
+		}
+		return normalizedSortKey(left.ID, left.TaskDefinition) < normalizedSortKey(right.ID, right.TaskDefinition)
+	})
+
+	for _, event := range service.Events {
+		item := ECSServiceEvent{
+			ID:      awssdk.ToString(event.Id),
+			Message: awssdk.ToString(event.Message),
+		}
+		if event.CreatedAt != nil {
+			item.CreatedAt = *event.CreatedAt
+		}
+		detail.Events = append(detail.Events, item)
+	}
+	sort.SliceStable(detail.Events, func(i, j int) bool {
+		return detail.Events[i].CreatedAt.After(detail.Events[j].CreatedAt)
+	})
+
+	if detail.TaskDefinitionARN != "" {
+		taskDefOut, err := r.ECSClient.DescribeTaskDefinition(ctx, &ecs.DescribeTaskDefinitionInput{
+			TaskDefinition: awssdk.String(detail.TaskDefinitionARN),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to describe ECS task definition %s: %w", detail.TaskDefinitionARN, err)
+		}
+		if taskDefOut.TaskDefinition != nil {
+			taskDef := taskDefOut.TaskDefinition
+			detail.TaskDefinitionFamily = awssdk.ToString(taskDef.Family)
+			detail.TaskDefinitionRevision = taskDef.Revision
+			detail.NetworkMode = string(taskDef.NetworkMode)
+			for _, compatibility := range taskDef.RequiresCompatibilities {
+				detail.RequiresCompatibilities = append(detail.RequiresCompatibilities, string(compatibility))
+			}
+			for _, container := range taskDef.ContainerDefinitions {
+				detail.ContainerImages = append(detail.ContainerImages, ECSContainerImage{
+					Name:  awssdk.ToString(container.Name),
+					Image: awssdk.ToString(container.Image),
+				})
+			}
+			sort.SliceStable(detail.ContainerImages, func(i, j int) bool {
+				left := detail.ContainerImages[i]
+				right := detail.ContainerImages[j]
+				return normalizedSortKey(left.Name, left.Image) < normalizedSortKey(right.Name, right.Image)
+			})
+		}
+	}
+
+	return detail, nil
 }
 
 // ListTasks returns running tasks in the given cluster and service.
@@ -214,4 +331,14 @@ func (r *AwsRepository) describeTasksFromARNs(ctx context.Context, clusterARN st
 		}
 	}
 	return tasks, nil
+}
+
+func shortECSResourceRef(value string) string {
+	if value == "" {
+		return value
+	}
+	if idx := strings.LastIndex(value, "/"); idx >= 0 && idx < len(value)-1 {
+		return value[idx+1:]
+	}
+	return value
 }

--- a/internal/services/aws/ecs_model.go
+++ b/internal/services/aws/ecs_model.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -29,15 +30,106 @@ type ECSService struct {
 	Status       string
 	RunningCount int32
 	DesiredCount int32
+	PendingCount int32
 	LaunchType   string
 }
 
 func (s ECSService) DisplayTitle() string {
-	return fmt.Sprintf("%-40s  %-10s  %-8s  %d/%d", s.Name, s.Status, s.LaunchType, s.RunningCount, s.DesiredCount)
+	return fmt.Sprintf("%-36s  %-10s  %-8s  r:%-3d d:%-3d p:%d", s.Name, s.Status, s.LaunchType, s.RunningCount, s.DesiredCount, s.PendingCount)
 }
 
 func (s ECSService) FilterText() string {
 	return s.Name
+}
+
+// ECSDeployment represents one deployment within an ECS service.
+type ECSDeployment struct {
+	ID                 string
+	Status             string
+	RolloutState       string
+	RolloutStateReason string
+	TaskDefinition     string
+	RunningCount       int32
+	DesiredCount       int32
+	PendingCount       int32
+	FailedTasks        int32
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+}
+
+// ECSServiceEvent represents a recent event attached to an ECS service.
+type ECSServiceEvent struct {
+	ID        string
+	CreatedAt time.Time
+	Message   string
+}
+
+func (e ECSServiceEvent) DisplayTitle() string {
+	if e.CreatedAt.IsZero() {
+		return e.Message
+	}
+	return fmt.Sprintf("%s  %s", e.CreatedAt.Format("2006-01-02 15:04:05"), e.Message)
+}
+
+// ECSContainerImage represents a task definition container/image pair.
+type ECSContainerImage struct {
+	Name  string
+	Image string
+}
+
+// ECSServiceDetail captures rollout, task definition, and event context for a service.
+type ECSServiceDetail struct {
+	Name                     string
+	ARN                      string
+	Status                   string
+	LaunchType               string
+	SchedulingStrategy       string
+	DeploymentControllerType string
+	DesiredCount             int32
+	RunningCount             int32
+	PendingCount             int32
+	EnableExecuteCommand     bool
+	PlatformVersion          string
+	TaskDefinitionARN        string
+	TaskDefinitionFamily     string
+	TaskDefinitionRevision   int32
+	NetworkMode              string
+	RequiresCompatibilities  []string
+	ContainerImages          []ECSContainerImage
+	Deployments              []ECSDeployment
+	Events                   []ECSServiceEvent
+}
+
+func (d ECSServiceDetail) Summary() ECSService {
+	return ECSService{
+		Name:         d.Name,
+		ARN:          d.ARN,
+		Status:       d.Status,
+		RunningCount: d.RunningCount,
+		DesiredCount: d.DesiredCount,
+		PendingCount: d.PendingCount,
+		LaunchType:   d.LaunchType,
+	}
+}
+
+func (d ECSServiceDetail) TaskDefinitionLabel() string {
+	switch {
+	case d.TaskDefinitionFamily != "" && d.TaskDefinitionRevision > 0:
+		return fmt.Sprintf("%s:%d", d.TaskDefinitionFamily, d.TaskDefinitionRevision)
+	case d.TaskDefinitionFamily != "":
+		return d.TaskDefinitionFamily
+	case d.TaskDefinitionARN != "":
+		return d.TaskDefinitionARN
+	default:
+		return "-"
+	}
+}
+
+func (d ECSServiceDetail) CompatibilityLabel() string {
+	if len(d.RequiresCompatibilities) == 0 {
+		return "-"
+	}
+	return strings.Join(d.RequiresCompatibilities, ", ")
 }
 
 // ECSTask represents a running ECS task.

--- a/internal/services/aws/ecs_test.go
+++ b/internal/services/aws/ecs_test.go
@@ -12,12 +12,13 @@ import (
 
 // mockECSClient implements ECSClientAPI for testing.
 type mockECSClient struct {
-	listClustersFunc    func(ctx context.Context, params *ecs.ListClustersInput, optFns ...func(*ecs.Options)) (*ecs.ListClustersOutput, error)
+	listClustersFunc     func(ctx context.Context, params *ecs.ListClustersInput, optFns ...func(*ecs.Options)) (*ecs.ListClustersOutput, error)
 	describeClustersFunc func(ctx context.Context, params *ecs.DescribeClustersInput, optFns ...func(*ecs.Options)) (*ecs.DescribeClustersOutput, error)
-	listServicesFunc    func(ctx context.Context, params *ecs.ListServicesInput, optFns ...func(*ecs.Options)) (*ecs.ListServicesOutput, error)
+	listServicesFunc     func(ctx context.Context, params *ecs.ListServicesInput, optFns ...func(*ecs.Options)) (*ecs.ListServicesOutput, error)
 	describeServicesFunc func(ctx context.Context, params *ecs.DescribeServicesInput, optFns ...func(*ecs.Options)) (*ecs.DescribeServicesOutput, error)
-	listTasksFunc       func(ctx context.Context, params *ecs.ListTasksInput, optFns ...func(*ecs.Options)) (*ecs.ListTasksOutput, error)
-	describeTasksFunc   func(ctx context.Context, params *ecs.DescribeTasksInput, optFns ...func(*ecs.Options)) (*ecs.DescribeTasksOutput, error)
+	describeTaskDefFunc  func(ctx context.Context, params *ecs.DescribeTaskDefinitionInput, optFns ...func(*ecs.Options)) (*ecs.DescribeTaskDefinitionOutput, error)
+	listTasksFunc        func(ctx context.Context, params *ecs.ListTasksInput, optFns ...func(*ecs.Options)) (*ecs.ListTasksOutput, error)
+	describeTasksFunc    func(ctx context.Context, params *ecs.DescribeTasksInput, optFns ...func(*ecs.Options)) (*ecs.DescribeTasksOutput, error)
 }
 
 func (m *mockECSClient) ListClusters(ctx context.Context, params *ecs.ListClustersInput, optFns ...func(*ecs.Options)) (*ecs.ListClustersOutput, error) {
@@ -34,6 +35,10 @@ func (m *mockECSClient) ListServices(ctx context.Context, params *ecs.ListServic
 
 func (m *mockECSClient) DescribeServices(ctx context.Context, params *ecs.DescribeServicesInput, optFns ...func(*ecs.Options)) (*ecs.DescribeServicesOutput, error) {
 	return m.describeServicesFunc(ctx, params, optFns...)
+}
+
+func (m *mockECSClient) DescribeTaskDefinition(ctx context.Context, params *ecs.DescribeTaskDefinitionInput, optFns ...func(*ecs.Options)) (*ecs.DescribeTaskDefinitionOutput, error) {
+	return m.describeTaskDefFunc(ctx, params, optFns...)
 }
 
 func (m *mockECSClient) ListTasks(ctx context.Context, params *ecs.ListTasksInput, optFns ...func(*ecs.Options)) (*ecs.ListTasksOutput, error) {
@@ -150,6 +155,7 @@ func TestListServices_success(t *testing.T) {
 							Status:       awssdk.String("ACTIVE"),
 							RunningCount: 3,
 							DesiredCount: 3,
+							PendingCount: 1,
 							LaunchType:   ecstypes.LaunchTypeFargate,
 						},
 					},
@@ -171,8 +177,135 @@ func TestListServices_success(t *testing.T) {
 	if services[0].RunningCount != 3 {
 		t.Errorf("expected running count 3, got %d", services[0].RunningCount)
 	}
+	if services[0].PendingCount != 1 {
+		t.Errorf("expected pending count 1, got %d", services[0].PendingCount)
+	}
 	if services[0].LaunchType != "FARGATE" {
 		t.Errorf("expected FARGATE, got %s", services[0].LaunchType)
+	}
+}
+
+func TestDescribeServiceDetail_success(t *testing.T) {
+	repo := &AwsRepository{
+		ECSClient: &mockECSClient{
+			describeServicesFunc: func(_ context.Context, params *ecs.DescribeServicesInput, _ ...func(*ecs.Options)) (*ecs.DescribeServicesOutput, error) {
+				if got := awssdk.ToString(params.Cluster); got != "arn:aws:ecs:us-east-1:123456789012:cluster/prod-cluster" {
+					t.Fatalf("unexpected cluster ARN: %s", got)
+				}
+				return &ecs.DescribeServicesOutput{
+					Services: []ecstypes.Service{
+						{
+							ServiceName:          awssdk.String("api-service"),
+							ServiceArn:           awssdk.String("arn:aws:ecs:us-east-1:123456789012:service/prod-cluster/api-service"),
+							Status:               awssdk.String("ACTIVE"),
+							LaunchType:           ecstypes.LaunchTypeFargate,
+							SchedulingStrategy:   ecstypes.SchedulingStrategyReplica,
+							DesiredCount:         3,
+							RunningCount:         2,
+							PendingCount:         1,
+							EnableExecuteCommand: true,
+							PlatformVersion:      awssdk.String("1.4.0"),
+							TaskDefinition:       awssdk.String("arn:aws:ecs:us-east-1:123456789012:task-definition/api:42"),
+							DeploymentController: &ecstypes.DeploymentController{Type: ecstypes.DeploymentControllerTypeEcs},
+							Deployments: []ecstypes.Deployment{
+								{
+									Id:                 awssdk.String("ecs-svc/123"),
+									Status:             awssdk.String("PRIMARY"),
+									RolloutState:       ecstypes.DeploymentRolloutStateInProgress,
+									RolloutStateReason: awssdk.String("deployment in progress"),
+									TaskDefinition:     awssdk.String("arn:aws:ecs:us-east-1:123456789012:task-definition/api:42"),
+									DesiredCount:       3,
+									RunningCount:       2,
+									PendingCount:       1,
+									FailedTasks:        2,
+								},
+							},
+							Events: []ecstypes.ServiceEvent{
+								{
+									Id:      awssdk.String("event-1"),
+									Message: awssdk.String("(service api-service) has started 1 tasks: task abc123"),
+								},
+							},
+						},
+					},
+				}, nil
+			},
+			describeTaskDefFunc: func(_ context.Context, params *ecs.DescribeTaskDefinitionInput, _ ...func(*ecs.Options)) (*ecs.DescribeTaskDefinitionOutput, error) {
+				if got := awssdk.ToString(params.TaskDefinition); got != "arn:aws:ecs:us-east-1:123456789012:task-definition/api:42" {
+					t.Fatalf("unexpected task definition: %s", got)
+				}
+				return &ecs.DescribeTaskDefinitionOutput{
+					TaskDefinition: &ecstypes.TaskDefinition{
+						Family:                  awssdk.String("api"),
+						Revision:                42,
+						NetworkMode:             ecstypes.NetworkModeAwsvpc,
+						RequiresCompatibilities: []ecstypes.Compatibility{ecstypes.CompatibilityFargate},
+						ContainerDefinitions: []ecstypes.ContainerDefinition{
+							{Name: awssdk.String("app"), Image: awssdk.String("123456789012.dkr.ecr.us-east-1.amazonaws.com/api:2026-04-17")},
+							{Name: awssdk.String("nginx"), Image: awssdk.String("nginx:1.27")},
+						},
+					},
+				}, nil
+			},
+		},
+	}
+
+	detail, err := repo.DescribeServiceDetail(context.Background(), "arn:aws:ecs:us-east-1:123456789012:cluster/prod-cluster", "arn:aws:ecs:us-east-1:123456789012:service/prod-cluster/api-service")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if detail.Name != "api-service" {
+		t.Fatalf("expected api-service, got %s", detail.Name)
+	}
+	if detail.TaskDefinitionLabel() != "api:42" {
+		t.Fatalf("expected task definition label api:42, got %q", detail.TaskDefinitionLabel())
+	}
+	if detail.CompatibilityLabel() != "FARGATE" {
+		t.Fatalf("expected FARGATE compatibility, got %q", detail.CompatibilityLabel())
+	}
+	if len(detail.Deployments) != 1 {
+		t.Fatalf("expected 1 deployment, got %d", len(detail.Deployments))
+	}
+	if detail.Deployments[0].TaskDefinition != "api:42" {
+		t.Fatalf("expected short deployment task definition api:42, got %q", detail.Deployments[0].TaskDefinition)
+	}
+	if detail.Deployments[0].FailedTasks != 2 {
+		t.Fatalf("expected failed tasks 2, got %d", detail.Deployments[0].FailedTasks)
+	}
+	if len(detail.ContainerImages) != 2 {
+		t.Fatalf("expected 2 container images, got %d", len(detail.ContainerImages))
+	}
+	if detail.ContainerImages[0].Name != "app" {
+		t.Fatalf("expected app container first after sorting, got %q", detail.ContainerImages[0].Name)
+	}
+	if len(detail.Events) != 1 || detail.Events[0].ID != "event-1" {
+		t.Fatalf("expected 1 service event, got %+v", detail.Events)
+	}
+}
+
+func TestDescribeServiceDetail_taskDefinitionError(t *testing.T) {
+	repo := &AwsRepository{
+		ECSClient: &mockECSClient{
+			describeServicesFunc: func(_ context.Context, _ *ecs.DescribeServicesInput, _ ...func(*ecs.Options)) (*ecs.DescribeServicesOutput, error) {
+				return &ecs.DescribeServicesOutput{
+					Services: []ecstypes.Service{
+						{
+							ServiceName:    awssdk.String("api-service"),
+							ServiceArn:     awssdk.String("arn:aws:ecs:us-east-1:123456789012:service/prod-cluster/api-service"),
+							TaskDefinition: awssdk.String("arn:aws:ecs:us-east-1:123456789012:task-definition/api:42"),
+						},
+					},
+				}, nil
+			},
+			describeTaskDefFunc: func(_ context.Context, _ *ecs.DescribeTaskDefinitionInput, _ ...func(*ecs.Options)) (*ecs.DescribeTaskDefinitionOutput, error) {
+				return nil, fmt.Errorf("AccessDenied")
+			},
+		},
+	}
+
+	_, err := repo.DescribeServiceDetail(context.Background(), "cluster", "service")
+	if err == nil {
+		t.Fatal("expected error, got nil")
 	}
 }
 

--- a/internal/services/aws/repository.go
+++ b/internal/services/aws/repository.go
@@ -155,6 +155,7 @@ type ECSClientAPI interface {
 	DescribeClusters(ctx context.Context, params *ecs.DescribeClustersInput, optFns ...func(*ecs.Options)) (*ecs.DescribeClustersOutput, error)
 	ListServices(ctx context.Context, params *ecs.ListServicesInput, optFns ...func(*ecs.Options)) (*ecs.ListServicesOutput, error)
 	DescribeServices(ctx context.Context, params *ecs.DescribeServicesInput, optFns ...func(*ecs.Options)) (*ecs.DescribeServicesOutput, error)
+	DescribeTaskDefinition(ctx context.Context, params *ecs.DescribeTaskDefinitionInput, optFns ...func(*ecs.Options)) (*ecs.DescribeTaskDefinitionOutput, error)
 	ListTasks(ctx context.Context, params *ecs.ListTasksInput, optFns ...func(*ecs.Options)) (*ecs.ListTasksOutput, error)
 	DescribeTasks(ctx context.Context, params *ecs.DescribeTasksInput, optFns ...func(*ecs.Options)) (*ecs.DescribeTasksOutput, error)
 }


### PR DESCRIPTION
### Summary

- add an ECS service rollout detail screen between the service list and task list
- show deployment state, running/desired/pending counts, failed-task counts, task-definition images, and recent service events
- extend the ECS repository/models plus TUI tests and docs to cover the new rollout inspection flow
- No breaking changes

### Related Issues

Closes #131

### Validation

- `make test`
- `make build`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed
- [x] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented
