### PR TITLE
feat: Add Lambda browser with invoke and integrated log viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Context ordering:
 | CloudWatch Logs | Logs Browser |
 | ECS | ECS Exec Sessions |
 | S3 | S3 Browser |
+| Lambda | Lambda Browser |
 | IAM | IAM User Browser |
 | IAM | ListAccessKeys |
 | IAM | RotateAccessKey |
@@ -313,12 +314,13 @@ checks:
 | IAM Key Rotation | `r` rotate, `c` copy exports, `a` apply and verify, `d` deactivate old key, `x` delete old key |
 | CloudWatch Logs | log groups/streams load 10 at a time, `n` load more, `1`-`6` time presets, `t` live tail, `f` filter pattern, `w` wrap toggle, `h/l` horizontal scroll |
 | ECS Exec | `r` refresh, `Enter` drill down / exec |
+| Lambda | `Enter` invoke, `d` detail, `l` view CloudWatch Logs, `/` filter, `r` refresh |
 | Inspector Mode | `i` open mode from the service list, `Enter` open the selected workflow, `l` open the checklist file picker |
 | Security Inspector | `r` run/rescan, `1`-`5` severity filter, `Enter` finding detail |
 | Checklist Inspector | `l` load or switch checklist files, `r` run/rerun the loaded checklist, `Enter` result detail |
 | Context Picker | `a` add context, type or `/` filter, `s` setup selected context and quit, `y` copy selected exports and quit, `u` clear shell context and quit with a final confirmation message |
 
-Shared list filters now use fuzzy matching with inline match highlighting. While filter mode stays active, `↑`/`↓` continue to move through the filtered results without requiring an extra Enter first. Filtering is currently available on EC2 instances, IAM users, VPCs, subnets, RDS instances, Route53 zones/records, CloudWatch log groups/streams, Secrets Manager resources, ECS clusters/services, S3 buckets/objects, and the context picker.
+Shared list filters now use fuzzy matching with inline match highlighting. While filter mode stays active, `↑`/`↓` continue to move through the filtered results without requiring an extra Enter first. Filtering is currently available on EC2 instances, IAM users, VPCs, subnets, RDS instances, Route53 zones/records, CloudWatch log groups/streams, Secrets Manager resources, ECS clusters/services, S3 buckets/objects, Lambda functions, and the context picker.
 
 Reachability Analyzer starts with a region selection step, defaults to the current context region, and now surfaces the AWS-documented source and destination resource types that unic supports: EC2 instances, Internet gateways, Network interfaces, Transit gateways, Transit gateway attachments, Virtual private gateways, VPC endpoint services, VPC endpoints, VPC peering connections, plus IP addresses as destinations. The source and destination pickers support type tabs, keyword filtering, IPv4 destination validation, and automatic cleanup of temporary Network Insights resources after each analysis. During analysis, the loading screen shows a vertical source-to-destination flow and intent summary, and the result view renders path hops and findings in a more readable layout.
 

--- a/docs/project-overview.en.md
+++ b/docs/project-overview.en.md
@@ -19,6 +19,7 @@ Implemented service areas currently include:
 - CloudWatch Logs
 - ECS
 - S3
+- Lambda
 - Inspector mode
 
 The application already includes interactive mutation flows, polling-based status flows, context helpers, and per-service drill-down screens.

--- a/docs/project-overview.ko.md
+++ b/docs/project-overview.ko.md
@@ -19,6 +19,7 @@ UNIC은 다음 세 가지를 결합한 Go 기반 AWS 터미널 콘솔이다.
 - CloudWatch Logs
 - ECS
 - S3
+- Lambda
 - Inspector mode
 
 애플리케이션은 이미 상호작용형 변경 작업 플로우, polling 기반 상태 확인, context helper, 서비스별 drill-down 화면을 포함한다.

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/lambda v1.89.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.17 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 h1:c31//R3x
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21/go.mod h1:r6+pf23ouCB718FUxaqzZdbpYFyDtehyZcmP5KL9FkA=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 h1:ZlvrNcHSFFWURB8avufQq9gFsheUgjVD9536obIknfM=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21/go.mod h1:cv3TNhVrssKR0O/xxLJVRfd2oazSnZnkUeTf6ctUwfQ=
+github.com/aws/aws-sdk-go-v2/service/lambda v1.89.0 h1:e4NAllPs/ygQ7W4dTlAuP5N7QpCT+rTij3S8UOv2DD4=
+github.com/aws/aws-sdk-go-v2/service/lambda v1.89.0/go.mod h1:6HBXRyFFqOw+ALkJ6YGHfrr20/YXYv6X9pcZErXRvCA=
 github.com/aws/aws-sdk-go-v2/service/rds v1.116.3 h1:H/ZYZ6QR4EXJAYElI5xkIM/yCz+A4uHIvWpzl+IfJks=
 github.com/aws/aws-sdk-go-v2/service/rds v1.116.3/go.mod h1:QbXW4coAMakHQhf1qhE0eVVCen9gwB/Kvn+HHHKhpGY=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.62.4 h1:64aYPyHg3RjLvnMMSYQSg7aP+r1WRCPIS9SP9KfHjWg=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -62,6 +62,10 @@ const (
 	screenS3BucketList
 	screenS3ObjectList
 	screenS3ObjectDetail
+	screenLambdaFunctionList
+	screenLambdaFunctionDetail
+	screenLambdaInvokeInput
+	screenLambdaInvokeResult
 	screenInspectorHome
 	screenInspectorWorkflowPlaceholder
 	screenInspectorChecklistPicker
@@ -244,6 +248,17 @@ type Model struct {
 	s3CurrentPrefix   string
 	s3PrefixStack     []string
 	selectedS3Object  *awsservice.S3ObjectDetail
+
+	// Lambda browser state
+	lambdaFunctions         []awsservice.LambdaFunction
+	filteredLambdaFunctions []awsservice.LambdaFunction
+	lambdaFunctionIdx       int
+	selectedLambdaFunction  *awsservice.LambdaFunction
+	lambdaInvokePayload     string
+	lambdaInvokeAsync       bool
+	lambdaInvokeResult      *awsservice.LambdaInvokeResult
+	lambdaPayloadSource     lambdaPayloadSource
+	lambdaInvokeStep        int // 0=source select, 1=text input
 
 	// Inspector browser state
 	inspectorWorkflows        []inspector.Workflow
@@ -440,6 +455,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.handleSecretMsg,
 		m.handleECSMsg,
 		m.handleS3Msg,
+		m.handleLambdaMsg,
 		m.handleInspectorMsg,
 		m.handleContextMsg,
 	} {
@@ -477,14 +493,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// Global home — return to service list from any screen (skip text-input screens)
 		if msg.String() == "H" && m.screen != screenServiceList && m.screen != screenContextPicker &&
-			m.screen != screenSecurityGroupAddRule && m.screen != screenSecurityGroupDeleteConfirm {
+			m.screen != screenSecurityGroupAddRule && m.screen != screenSecurityGroupDeleteConfirm &&
+			m.screen != screenLambdaInvokeInput {
 			m.deactivateFilter()
 			m.screen = screenServiceList
 			return m, nil
 		}
 		// Global context switch — C key opens context picker (skip text-input screens)
 		if msg.String() == "C" && m.screen != screenContextPicker &&
-			m.screen != screenSecurityGroupAddRule && m.screen != screenSecurityGroupDeleteConfirm {
+			m.screen != screenSecurityGroupAddRule && m.screen != screenSecurityGroupDeleteConfirm &&
+			m.screen != screenLambdaInvokeInput {
 			m.deactivateFilter()
 			m.ctxPrevScreen = m.screen
 			return m, m.loadContexts()
@@ -547,6 +565,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateS3ObjectList(msg)
 		case screenS3ObjectDetail:
 			return m.updateS3ObjectDetail(msg)
+		case screenLambdaFunctionList:
+			return m.updateLambdaFunctionList(msg)
+		case screenLambdaFunctionDetail:
+			return m.updateLambdaFunctionDetail(msg)
+		case screenLambdaInvokeInput:
+			return m.updateLambdaInvokeInput(msg)
+		case screenLambdaInvokeResult:
+			return m.updateLambdaInvokeResult(msg)
 		case screenInspectorHome:
 			return m.updateInspectorHome(msg)
 		case screenInspectorWorkflowPlaceholder:
@@ -718,6 +744,8 @@ func (m Model) updateFeatureList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m.startLoading(m.loadIAMKeys())
 			case domain.FeatureECSExec:
 				return m.startLoading(m.loadECSClusters())
+			case domain.FeatureLambdaBrowser:
+				return m.startLoading(m.loadLambdaFunctions())
 			}
 		}
 	}
@@ -802,6 +830,14 @@ func (m Model) View() string {
 		v = m.viewS3ObjectList()
 	case screenS3ObjectDetail:
 		v = m.viewS3ObjectDetail()
+	case screenLambdaFunctionList:
+		v = m.viewLambdaFunctionList()
+	case screenLambdaFunctionDetail:
+		v = m.viewLambdaFunctionDetail()
+	case screenLambdaInvokeInput:
+		v = m.viewLambdaInvokeInput()
+	case screenLambdaInvokeResult:
+		v = m.viewLambdaInvokeResult()
 	case screenInspectorHome:
 		v = m.viewInspectorHome()
 	case screenInspectorWorkflowPlaceholder:

--- a/internal/app/filter.go
+++ b/internal/app/filter.go
@@ -28,6 +28,7 @@ const (
 	filterVPCs
 	filterSubnets
 	filterInspectorChecklistFiles
+	filterLambdaFunctions
 )
 
 // Filterable is implemented by any type that supports text-based filtering.
@@ -200,6 +201,9 @@ func (m *Model) applyFilterTarget(target filterTarget) {
 	case filterInspectorChecklistFiles:
 		m.filteredChecklistFiles = applyFilter(m.inspectorChecklistFiles, m.filterValue(target))
 		m.inspectorChecklistFileIdx = 0
+	case filterLambdaFunctions:
+		m.filteredLambdaFunctions = applyFilter(m.lambdaFunctions, m.filterValue(target))
+		m.lambdaFunctionIdx = 0
 	}
 }
 

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -67,11 +67,13 @@ func (m Model) helpSections() []helpSection {
 func (m Model) globalHelpShortcuts() []helpShortcut {
 	var shortcuts []helpShortcut
 	if m.screen != screenServiceList && m.screen != screenContextPicker &&
-		m.screen != screenSecurityGroupAddRule && m.screen != screenSecurityGroupDeleteConfirm {
+		m.screen != screenSecurityGroupAddRule && m.screen != screenSecurityGroupDeleteConfirm &&
+		m.screen != screenLambdaInvokeInput {
 		shortcuts = append(shortcuts, helpShortcut{"H", "Jump to the service list"})
 	}
 	if m.screen != screenContextPicker &&
-		m.screen != screenSecurityGroupAddRule && m.screen != screenSecurityGroupDeleteConfirm {
+		m.screen != screenSecurityGroupAddRule && m.screen != screenSecurityGroupDeleteConfirm &&
+		m.screen != screenLambdaInvokeInput {
 		shortcuts = append(shortcuts, helpShortcut{"C", "Open the context picker"})
 	}
 	return shortcuts
@@ -379,6 +381,42 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 			{"esc", "Go back to the object list"},
 			{"q", "Go back to the feature list"},
 		}
+	case screenLambdaFunctionList:
+		return []helpShortcut{
+			{"↑/↓, j/k", "Move between functions"},
+			{"/", "Start filtering functions"},
+			{"r", "Refresh the function list"},
+			{"enter", "Invoke the selected function"},
+			{"d", "View function detail"},
+			{"l", "View CloudWatch Logs for the selected function"},
+			{"q / esc", "Go back to the feature list"},
+		}
+	case screenLambdaFunctionDetail:
+		return []helpShortcut{
+			{"i", "Invoke the selected function"},
+			{"l", "View CloudWatch Logs for this function"},
+			{"q / esc", "Go back to the function list"},
+		}
+	case screenLambdaInvokeInput:
+		if m.lambdaInvokeStep == 0 {
+			return []helpShortcut{
+				{"↑/↓, j/k", "Select payload source"},
+				{"enter", "Confirm the selected source"},
+				{"esc", "Go back to the function list"},
+			}
+		}
+		return []helpShortcut{
+			{"type", "Edit the payload or file path"},
+			{"backspace", "Delete the previous character"},
+			{"enter", "Invoke the function"},
+			{"esc", "Go back to source selection"},
+		}
+	case screenLambdaInvokeResult:
+		return []helpShortcut{
+			{"i", "Invoke the function again"},
+			{"l", "View CloudWatch Logs for this function"},
+			{"q / esc", "Go back to the function list"},
+		}
 	case screenInspectorHome:
 		return []helpShortcut{
 			{"↑/↓, j/k", "Move between inspector workflows"},
@@ -638,6 +676,14 @@ func (m Model) helpScreenTitle() string {
 		return "S3 Objects"
 	case screenS3ObjectDetail:
 		return "S3 Object Detail"
+	case screenLambdaFunctionList:
+		return "Lambda Functions"
+	case screenLambdaFunctionDetail:
+		return "Lambda Function Detail"
+	case screenLambdaInvokeInput:
+		return "Lambda Invoke"
+	case screenLambdaInvokeResult:
+		return "Lambda Invoke Result"
 	case screenInspectorHome:
 		return "Inspector Mode"
 	case screenInspectorWorkflowPlaceholder:

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -207,3 +207,11 @@ type inspectorScanLoadedMsg struct {
 type inspectorChecklistLoadedMsg struct {
 	report *inspector.ChecklistReport
 }
+
+type lambdaFunctionsLoadedMsg struct {
+	functions []awsservice.LambdaFunction
+}
+
+type lambdaInvokeResultMsg struct {
+	result *awsservice.LambdaInvokeResult
+}

--- a/internal/app/screen_cloudwatchlogs.go
+++ b/internal/app/screen_cloudwatchlogs.go
@@ -52,6 +52,7 @@ type cloudWatchLogsModel struct {
 	tailToken        *string
 	wrap             bool
 	horizontalOffset int
+	lambdaSource     bool // true when entered from Lambda browser
 }
 
 func newCloudWatchLogsModel() cloudWatchLogsModel {
@@ -70,7 +71,23 @@ func (cw *cloudWatchLogsModel) Start(m *Model) (tea.Model, tea.Cmd) {
 	cw.tailToken = nil
 	cw.tailing = false
 	cw.streamNextToken = nil
+	cw.lambdaSource = false
 	return m.startLoading(cw.loadGroups(*m, false))
+}
+
+// StartFromLambda enters the CW logs flow scoped to a Lambda function's log group.
+func (cw *cloudWatchLogsModel) StartFromLambda(m *Model, functionName string) (tea.Model, tea.Cmd) {
+	logGroupName := "/aws/lambda/" + functionName
+	cw.selectedGroup = &awsservice.LogGroup{Name: logGroupName}
+	cw.selectedStream = nil
+	cw.events = nil
+	cw.scrollOffset = 0
+	cw.nextToken = nil
+	cw.tailToken = nil
+	cw.tailing = false
+	cw.streamNextToken = nil
+	cw.lambdaSource = true
+	return m.startLoading(cw.loadStreams(*m, logGroupName, false))
 }
 
 func (cw *cloudWatchLogsModel) HandleMessage(m *Model, msg tea.Msg) (tea.Model, tea.Cmd, bool) {
@@ -346,7 +363,12 @@ func (cw *cloudWatchLogsModel) updateStreamList(m *Model, msg tea.KeyMsg) (tea.M
 
 	switch key {
 	case "q", "esc":
-		m.screen = screenCWLogGroupList
+		if cw.lambdaSource {
+			cw.lambdaSource = false
+			m.screen = screenLambdaFunctionList
+		} else {
+			m.screen = screenCWLogGroupList
+		}
 		m.resetFilter(filterCWLogStreams)
 	case "up", "k":
 		if cw.streamIdx > 0 {

--- a/internal/app/screen_lambda.go
+++ b/internal/app/screen_lambda.go
@@ -1,0 +1,424 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	awsservice "unic/internal/services/aws"
+)
+
+const lambdaAPITimeout = 30 * time.Second
+
+// lambdaPayloadSource indicates how the invoke payload is provided.
+type lambdaPayloadSource int
+
+const (
+	lambdaPayloadManual lambdaPayloadSource = iota
+	lambdaPayloadFile
+)
+
+// handleLambdaMsg routes Lambda messages to the correct screen.
+func (m Model) handleLambdaMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
+	switch msg := msg.(type) {
+	case lambdaFunctionsLoadedMsg:
+		m.lambdaFunctions = msg.functions
+		m.filteredLambdaFunctions = msg.functions
+		m.lambdaFunctionIdx = 0
+		m.resetFilter(filterLambdaFunctions)
+		m.screen = screenLambdaFunctionList
+		return m, nil, true
+	case lambdaInvokeResultMsg:
+		m.lambdaInvokeResult = msg.result
+		m.screen = screenLambdaInvokeResult
+		return m, nil, true
+	}
+	return m, nil, false
+}
+
+// --- Function List ---
+
+func (m Model) updateLambdaFunctionList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if cmd, handled := m.updateSharedFilter(msg, filterLambdaFunctions); handled {
+		return m, cmd
+	}
+
+	switch msg.String() {
+	case "q", "esc":
+		m.screen = screenFeatureList
+	case "up", "k":
+		if m.lambdaFunctionIdx > 0 {
+			m.lambdaFunctionIdx--
+		}
+	case "down", "j":
+		if m.lambdaFunctionIdx < len(m.filteredLambdaFunctions)-1 {
+			m.lambdaFunctionIdx++
+		}
+	case "/":
+		return m, m.activateFilter(filterLambdaFunctions)
+	case "r":
+		return m.startLoading(m.loadLambdaFunctions())
+	case "d":
+		if len(m.filteredLambdaFunctions) > 0 && m.lambdaFunctionIdx < len(m.filteredLambdaFunctions) {
+			fn := m.filteredLambdaFunctions[m.lambdaFunctionIdx]
+			m.selectedLambdaFunction = &fn
+			m.screen = screenLambdaFunctionDetail
+		}
+	case "l":
+		if len(m.filteredLambdaFunctions) > 0 && m.lambdaFunctionIdx < len(m.filteredLambdaFunctions) {
+			fn := m.filteredLambdaFunctions[m.lambdaFunctionIdx]
+			m.selectedLambdaFunction = &fn
+			return m.cwLogs.StartFromLambda(&m, fn.Name)
+		}
+	case "enter":
+		if len(m.filteredLambdaFunctions) > 0 && m.lambdaFunctionIdx < len(m.filteredLambdaFunctions) {
+			fn := m.filteredLambdaFunctions[m.lambdaFunctionIdx]
+			m.selectedLambdaFunction = &fn
+			m.lambdaInvokePayload = ""
+			m.lambdaPayloadSource = lambdaPayloadManual
+			m.lambdaInvokeStep = 0
+			m.screen = screenLambdaInvokeInput
+		}
+	}
+	return m, nil
+}
+
+func (m Model) viewLambdaFunctionList() string {
+	var b strings.Builder
+	var panel strings.Builder
+	b.WriteString(m.renderStatusBar())
+	b.WriteString(titleStyle.Render("Lambda Functions"))
+	b.WriteString("\n")
+	b.WriteString(m.renderFilterValue(filterLambdaFunctions))
+	b.WriteString("\n\n")
+
+	if len(m.filteredLambdaFunctions) == 0 {
+		panel.WriteString(dimStyle.Render("  No functions found"))
+		panel.WriteString("\n")
+	} else {
+		visibleLines := max(m.height-10, 5)
+		start := 0
+		if m.lambdaFunctionIdx >= visibleLines {
+			start = m.lambdaFunctionIdx - visibleLines + 1
+		}
+		end := min(start+visibleLines, len(m.filteredLambdaFunctions))
+
+		for i := start; i < end; i++ {
+			fn := m.filteredLambdaFunctions[i]
+			cursor := "  "
+			style := normalStyle
+			if i == m.lambdaFunctionIdx {
+				cursor = "> "
+				style = selectedStyle
+			}
+			panel.WriteString(style.Render(cursor + m.renderHighlightedValue(filterLambdaFunctions, fn.DisplayTitle())))
+			panel.WriteString("\n")
+		}
+		panel.WriteString("\n")
+		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d functions", len(m.filteredLambdaFunctions), len(m.lambdaFunctions))))
+	}
+
+	b.WriteString(m.renderListPanel(panel.String()))
+	b.WriteString("\n\n")
+	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • r: refresh • enter: invoke • d: detail • l: logs • esc: back"))
+	return b.String()
+}
+
+// --- Function Detail ---
+
+func (m Model) updateLambdaFunctionDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "esc":
+		m.screen = screenLambdaFunctionList
+	case "i":
+		m.lambdaInvokePayload = ""
+		m.lambdaPayloadSource = lambdaPayloadManual
+		m.lambdaInvokeStep = 0
+		m.screen = screenLambdaInvokeInput
+	case "l":
+		if m.selectedLambdaFunction != nil {
+			return m.cwLogs.StartFromLambda(&m, m.selectedLambdaFunction.Name)
+		}
+	}
+	return m, nil
+}
+
+func (m Model) viewLambdaFunctionDetail() string {
+	var b strings.Builder
+	b.WriteString(m.renderStatusBar())
+
+	fn := m.selectedLambdaFunction
+	if fn == nil {
+		return b.String()
+	}
+
+	b.WriteString(titleStyle.Render(fmt.Sprintf("Lambda — %s", fn.Name)))
+	b.WriteString("\n\n")
+
+	b.WriteString(renderDetailLine("Runtime", fn.Runtime))
+	b.WriteString(renderDetailLine("Handler", fn.Handler))
+	b.WriteString(renderDetailLine("Memory", fmt.Sprintf("%d MB", fn.MemoryMB)))
+	b.WriteString(renderDetailLine("Timeout", fmt.Sprintf("%d seconds", fn.TimeoutSec)))
+	b.WriteString(renderDetailLine("Code Size", formatBytes(fn.CodeSize)))
+	b.WriteString(renderDetailLine("Last Modified", fn.LastModified))
+	b.WriteString(renderDetailLine("ARN", fn.ARN))
+	b.WriteString(renderDetailLine("Role", fn.Role))
+
+	if fn.Description != "" {
+		b.WriteString(renderDetailLine("Description", fn.Description))
+	}
+	if len(fn.Layers) > 0 {
+		b.WriteString(renderDetailLine("Layers", fmt.Sprintf("%d layer(s)", len(fn.Layers))))
+		for _, l := range fn.Layers {
+			b.WriteString(dimStyle.Render(fmt.Sprintf("                    %s", l)))
+			b.WriteString("\n")
+		}
+	}
+	if len(fn.VPCSubnets) > 0 {
+		b.WriteString(renderDetailLine("VPC Subnets", strings.Join(fn.VPCSubnets, ", ")))
+	}
+	if len(fn.VPCSGs) > 0 {
+		b.WriteString(renderDetailLine("VPC SGs", strings.Join(fn.VPCSGs, ", ")))
+	}
+
+	b.WriteString("\n")
+	b.WriteString(m.renderHelpBar("i: invoke • l: logs • esc: back • H: home"))
+	return b.String()
+}
+
+// --- Invoke Input ---
+// Step 0: select payload source (manual / file)
+// Step 1: type payload or file path, then invoke
+
+func (m Model) updateLambdaInvokeInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	key := msg.String()
+
+	// Step 0: source selection
+	if m.lambdaInvokeStep == 0 {
+		switch key {
+		case "esc":
+			m.screen = screenLambdaFunctionList
+		case "up", "k":
+			m.lambdaPayloadSource = lambdaPayloadManual
+		case "down", "j":
+			m.lambdaPayloadSource = lambdaPayloadFile
+		case "enter":
+			m.lambdaInvokeStep = 1
+			m.lambdaInvokePayload = ""
+		}
+		return m, nil
+	}
+
+	// Step 1: text input
+	switch key {
+	case "esc":
+		m.lambdaInvokeStep = 0
+	case "enter":
+		if m.selectedLambdaFunction != nil {
+			return m.startLoading(m.invokeLambdaFunction())
+		}
+	case "backspace":
+		if len(m.lambdaInvokePayload) > 0 {
+			m.lambdaInvokePayload = m.lambdaInvokePayload[:len(m.lambdaInvokePayload)-1]
+		}
+	default:
+		if len(key) == 1 || key == " " {
+			m.lambdaInvokePayload += key
+		}
+	}
+	return m, nil
+}
+
+func (m Model) viewLambdaInvokeInput() string {
+	var b strings.Builder
+	b.WriteString(m.renderStatusBar())
+
+	fnName := ""
+	if m.selectedLambdaFunction != nil {
+		fnName = m.selectedLambdaFunction.Name
+	}
+	b.WriteString(titleStyle.Render(fmt.Sprintf("Invoke — %s", fnName)))
+	b.WriteString("\n\n")
+
+	if m.lambdaInvokeStep == 0 {
+		b.WriteString(normalStyle.Render("  Select payload source:"))
+		b.WriteString("\n\n")
+		sources := []struct {
+			src   lambdaPayloadSource
+			label string
+		}{
+			{lambdaPayloadManual, "Manual input (type JSON directly)"},
+			{lambdaPayloadFile, "File path (load JSON from local file)"},
+		}
+		for _, s := range sources {
+			cursor := "  "
+			style := normalStyle
+			if m.lambdaPayloadSource == s.src {
+				cursor = "> "
+				style = selectedStyle
+			}
+			b.WriteString(style.Render(cursor + s.label))
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+		b.WriteString(m.renderHelpBar("↑/↓: select source • enter: confirm • esc: back"))
+	} else {
+		label := "Payload (JSON):"
+		hint := "(empty — press enter to invoke with no payload)"
+		if m.lambdaPayloadSource == lambdaPayloadFile {
+			label = "File path:"
+			hint = "(enter path to a local JSON file)"
+		}
+		b.WriteString(normalStyle.Render("  " + label))
+		b.WriteString("\n")
+		payload := m.lambdaInvokePayload
+		if payload == "" {
+			payload = dimStyle.Render(hint)
+		}
+		b.WriteString(normalStyle.Render("  " + payload))
+		b.WriteString("\n\n")
+		b.WriteString(m.renderHelpBar("type: edit • enter: invoke • esc: back to source"))
+	}
+
+	return b.String()
+}
+
+// --- Invoke Result ---
+
+func (m Model) updateLambdaInvokeResult(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "esc":
+		m.screen = screenLambdaFunctionList
+	case "i":
+		m.lambdaInvokePayload = ""
+		m.lambdaPayloadSource = lambdaPayloadManual
+		m.lambdaInvokeStep = 0
+		m.screen = screenLambdaInvokeInput
+	case "l":
+		if m.selectedLambdaFunction != nil {
+			return m.cwLogs.StartFromLambda(&m, m.selectedLambdaFunction.Name)
+		}
+	}
+	return m, nil
+}
+
+func (m Model) viewLambdaInvokeResult() string {
+	var b strings.Builder
+	b.WriteString(m.renderStatusBar())
+
+	fnName := ""
+	if m.selectedLambdaFunction != nil {
+		fnName = m.selectedLambdaFunction.Name
+	}
+	b.WriteString(titleStyle.Render(fmt.Sprintf("Invoke Result — %s", fnName)))
+	b.WriteString("\n\n")
+
+	r := m.lambdaInvokeResult
+	if r == nil {
+		return b.String()
+	}
+
+	b.WriteString(renderDetailLine("Status Code", fmt.Sprintf("%d", r.StatusCode)))
+	if r.FunctionError != "" {
+		b.WriteString(renderDetailLine("Error", r.FunctionError))
+	}
+	b.WriteString("\n")
+
+	b.WriteString(normalStyle.Render("  Response:"))
+	b.WriteString("\n")
+	if r.Payload != "" {
+		for _, line := range strings.Split(r.Payload, "\n") {
+			b.WriteString(normalStyle.Render("  " + line))
+			b.WriteString("\n")
+		}
+	} else {
+		b.WriteString(dimStyle.Render("  (empty)"))
+		b.WriteString("\n")
+	}
+
+	if r.LogResult != "" {
+		b.WriteString("\n")
+		b.WriteString(normalStyle.Render("  Execution Log:"))
+		b.WriteString("\n")
+		for _, line := range strings.Split(r.LogResult, "\n") {
+			b.WriteString(dimStyle.Render("  " + line))
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString("\n")
+	b.WriteString(m.renderHelpBar("i: invoke again • l: logs • esc: back to list • H: home"))
+	return b.String()
+}
+
+// --- Load Commands ---
+
+func (m Model) loadLambdaFunctions() tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), lambdaAPITimeout)
+		defer cancel()
+		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		functions, err := repo.ListFunctions(ctx)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		if len(functions) == 0 {
+			return errMsg{err: fmt.Errorf("no Lambda functions found in region %s", m.cfg.Region)}
+		}
+		return lambdaFunctionsLoadedMsg{functions: functions}
+	}
+}
+
+func (m Model) invokeLambdaFunction() tea.Cmd {
+	payloadSource := m.lambdaPayloadSource
+	payloadInput := m.lambdaInvokePayload
+	fnName := m.selectedLambdaFunction.Name
+
+	return func() tea.Msg {
+		payload := payloadInput
+		if payloadSource == lambdaPayloadFile && payloadInput != "" {
+			path := strings.TrimSpace(payloadInput)
+			if strings.HasPrefix(path, "~/") {
+				if home, err := os.UserHomeDir(); err == nil {
+					path = home + path[1:]
+				}
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return errMsg{err: fmt.Errorf("failed to read payload file: %w", err)}
+			}
+			payload = string(data)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), lambdaAPITimeout)
+		defer cancel()
+		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		result, err := repo.InvokeFunction(ctx, fnName, payload, false)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		return lambdaInvokeResultMsg{result: result}
+	}
+}
+
+// formatBytes formats a byte count into a human-readable string.
+func formatBytes(b int64) string {
+	switch {
+	case b >= 1<<20:
+		return fmt.Sprintf("%.1f MB", float64(b)/float64(1<<20))
+	case b >= 1<<10:
+		return fmt.Sprintf("%.1f KB", float64(b)/float64(1<<10))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}

--- a/internal/app/screen_lambda.go
+++ b/internal/app/screen_lambda.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"

--- a/internal/app/screen_lambda.go
+++ b/internal/app/screen_lambda.go
@@ -403,6 +403,14 @@ func (m Model) invokeLambdaFunction() tea.Cmd {
 			payload = string(data)
 		}
 
+		// Validate JSON format if payload is provided
+		if payload != "" {
+			var jsonCheck interface{}
+			if err := json.Unmarshal([]byte(payload), &jsonCheck); err != nil {
+				return errMsg{err: fmt.Errorf("invalid JSON payload: %w", err)}
+			}
+		}
+
 		ctx, cancel := context.WithTimeout(context.Background(), lambdaAPITimeout)
 		defer cancel()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)

--- a/internal/app/screen_lambda.go
+++ b/internal/app/screen_lambda.go
@@ -377,6 +377,11 @@ func (m Model) loadLambdaFunctions() tea.Cmd {
 }
 
 func (m Model) invokeLambdaFunction() tea.Cmd {
+	if m.selectedLambdaFunction == nil {
+		return func() tea.Msg {
+			return errMsg{err: fmt.Errorf("no function selected")}
+		}
+	}
 	payloadSource := m.lambdaPayloadSource
 	payloadInput := m.lambdaInvokePayload
 	fnName := m.selectedLambdaFunction.Name

--- a/internal/domain/catalog.go
+++ b/internal/domain/catalog.go
@@ -84,6 +84,15 @@ func Catalog() []Service {
 			},
 		},
 		{
+			Name: ServiceLambda,
+			Features: []Feature{
+				{
+					Kind:        FeatureLambdaBrowser,
+					Description: "Browse Lambda functions, view config, and invoke with payload",
+				},
+			},
+		},
+		{
 			Name: ServiceIAM,
 			Features: []Feature{
 				{

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -13,6 +13,7 @@ const (
 	ServiceCloudWatchLogs AwsService = "CloudWatch Logs"
 	ServiceECS            AwsService = "ECS"
 	ServiceS3             AwsService = "S3"
+	ServiceLambda         AwsService = "Lambda"
 )
 
 // FeatureKind represents a specific feature within a service.
@@ -32,6 +33,7 @@ const (
 	FeatureCloudWatchLogsBrowser FeatureKind = "CloudWatch Logs Browser"
 	FeatureECSExec               FeatureKind = "ECS Exec Sessions"
 	FeatureS3Browser             FeatureKind = "S3 Browser"
+	FeatureLambdaBrowser         FeatureKind = "Lambda Browser"
 )
 
 // Feature describes a selectable feature under an AWS service.

--- a/internal/services/aws/lambda.go
+++ b/internal/services/aws/lambda.go
@@ -1,0 +1,94 @@
+package aws
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+
+	uniclog "unic/internal/log"
+)
+
+// ListFunctions returns Lambda functions in the current account/region.
+func (r *AwsRepository) ListFunctions(ctx context.Context) ([]LambdaFunction, error) {
+	uniclog.Debug("aws", "ListFunctions called")
+
+	var functions []LambdaFunction
+	var marker *string
+	for {
+		out, err := r.LambdaClient.ListFunctions(ctx, &lambda.ListFunctionsInput{
+			Marker:   marker,
+			MaxItems: awssdk.Int32(50),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list Lambda functions: %w", err)
+		}
+		for _, f := range out.Functions {
+			fn := LambdaFunction{
+				Name:         awssdk.ToString(f.FunctionName),
+				ARN:          awssdk.ToString(f.FunctionArn),
+				Runtime:      string(f.Runtime),
+				Handler:      awssdk.ToString(f.Handler),
+				MemoryMB:     awssdk.ToInt32(f.MemorySize),
+				TimeoutSec:   awssdk.ToInt32(f.Timeout),
+				CodeSize:     f.CodeSize,
+				LastModified: awssdk.ToString(f.LastModified),
+				Description:  awssdk.ToString(f.Description),
+				Role:         awssdk.ToString(f.Role),
+			}
+			for _, l := range f.Layers {
+				fn.Layers = append(fn.Layers, awssdk.ToString(l.Arn))
+			}
+			if f.VpcConfig != nil {
+				fn.VPCSubnets = f.VpcConfig.SubnetIds
+				fn.VPCSGs = f.VpcConfig.SecurityGroupIds
+			}
+			functions = append(functions, fn)
+		}
+		if out.NextMarker == nil {
+			break
+		}
+		marker = out.NextMarker
+	}
+	return functions, nil
+}
+
+// InvokeFunction invokes a Lambda function with the given payload.
+func (r *AwsRepository) InvokeFunction(ctx context.Context, functionName, payload string, async bool) (*LambdaInvokeResult, error) {
+	uniclog.Debug("aws", "InvokeFunction called", "function", functionName, "async", async)
+
+	invocationType := lambdatypes.InvocationTypeRequestResponse
+	if async {
+		invocationType = lambdatypes.InvocationTypeEvent
+	}
+
+	input := &lambda.InvokeInput{
+		FunctionName:   awssdk.String(functionName),
+		InvocationType: invocationType,
+		LogType:        lambdatypes.LogTypeTail,
+	}
+	if payload != "" {
+		input.Payload = []byte(payload)
+	}
+
+	out, err := r.LambdaClient.Invoke(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to invoke Lambda function: %w", err)
+	}
+
+	result := &LambdaInvokeResult{
+		StatusCode:    out.StatusCode,
+		Payload:       string(out.Payload),
+		FunctionError: awssdk.ToString(out.FunctionError),
+	}
+	if out.LogResult != nil {
+		decoded, err := base64.StdEncoding.DecodeString(awssdk.ToString(out.LogResult))
+		if err == nil {
+			result.LogResult = string(decoded)
+		}
+	}
+	return result, nil
+}

--- a/internal/services/aws/lambda.go
+++ b/internal/services/aws/lambda.go
@@ -86,7 +86,9 @@ func (r *AwsRepository) InvokeFunction(ctx context.Context, functionName, payloa
 	}
 	if out.LogResult != nil {
 		decoded, err := base64.StdEncoding.DecodeString(awssdk.ToString(out.LogResult))
-		if err == nil {
+		if err != nil {
+			result.LogResult = fmt.Sprintf("Error decoding log result: %v", err)
+		} else {
 			result.LogResult = string(decoded)
 		}
 	}

--- a/internal/services/aws/lambda_model.go
+++ b/internal/services/aws/lambda_model.go
@@ -1,0 +1,47 @@
+package aws
+
+import (
+	"fmt"
+	"time"
+)
+
+// LambdaFunction represents an AWS Lambda function.
+type LambdaFunction struct {
+	Name         string
+	ARN          string
+	Runtime      string
+	Handler      string
+	MemoryMB     int32
+	TimeoutSec   int32
+	CodeSize     int64
+	LastModified string
+	Description  string
+	Role         string
+	Layers       []string
+	VPCSubnets   []string
+	VPCSGs       []string
+}
+
+func (f LambdaFunction) DisplayTitle() string {
+	return fmt.Sprintf("%-40s  %-14s  %4dMB  %3ds  %s", f.Name, f.Runtime, f.MemoryMB, f.TimeoutSec, f.shortLastModified())
+}
+
+func (f LambdaFunction) FilterText() string {
+	return f.Name + " " + f.Runtime
+}
+
+func (f LambdaFunction) shortLastModified() string {
+	t, err := time.Parse("2006-01-02T15:04:05.000+0000", f.LastModified)
+	if err != nil {
+		return f.LastModified
+	}
+	return t.Format("2006-01-02 15:04")
+}
+
+// LambdaInvokeResult holds the result of a Lambda invocation.
+type LambdaInvokeResult struct {
+	StatusCode   int32
+	Payload      string
+	FunctionError string
+	LogResult    string
+}

--- a/internal/services/aws/repository.go
+++ b/internal/services/aws/repository.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	"github.com/aws/aws-sdk-go-v2/service/guardduty"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -67,6 +68,9 @@ var _ ElastiCacheClientAPI = (*elasticache.Client)(nil)
 
 // Verify *s3.Client satisfies S3ClientAPI at compile time.
 var _ S3ClientAPI = (*s3.Client)(nil)
+
+// Verify *lambda.Client satisfies LambdaClientAPI at compile time.
+var _ LambdaClientAPI = (*lambda.Client)(nil)
 
 // SSMClientAPI is the interface for SSM operations used by AwsRepository.
 type SSMClientAPI interface {
@@ -176,6 +180,13 @@ type ElastiCacheClientAPI interface {
 	DescribeReplicationGroups(ctx context.Context, params *elasticache.DescribeReplicationGroupsInput, optFns ...func(*elasticache.Options)) (*elasticache.DescribeReplicationGroupsOutput, error)
 }
 
+// LambdaClientAPI is the interface for Lambda operations used by AwsRepository.
+type LambdaClientAPI interface {
+	ListFunctions(ctx context.Context, params *lambda.ListFunctionsInput, optFns ...func(*lambda.Options)) (*lambda.ListFunctionsOutput, error)
+	GetFunction(ctx context.Context, params *lambda.GetFunctionInput, optFns ...func(*lambda.Options)) (*lambda.GetFunctionOutput, error)
+	Invoke(ctx context.Context, params *lambda.InvokeInput, optFns ...func(*lambda.Options)) (*lambda.InvokeOutput, error)
+}
+
 // EC2ClientAPI is the interface for EC2 operations used by AwsRepository.
 type EC2ClientAPI interface {
 	ec2.DescribeInstancesAPIClient
@@ -226,6 +237,7 @@ type AwsRepository struct {
 	ECSClient            ECSClientAPI
 	ElastiCacheClient    ElastiCacheClientAPI
 	S3Client             S3ClientAPI
+	LambdaClient         LambdaClientAPI
 	Region               string
 	Profile              string
 	awsCfg               aws.Config
@@ -290,6 +302,7 @@ func NewAwsRepository(ctx context.Context, cfg *config.Config) (*AwsRepository, 
 		ECSClient:            ecs.NewFromConfig(awsCfg),
 		ElastiCacheClient:    elasticache.NewFromConfig(awsCfg),
 		S3Client:             s3.NewFromConfig(awsCfg),
+		LambdaClient:         lambda.NewFromConfig(awsCfg),
 		Region:               cfg.Region,
 		Profile:              cfg.Profile,
 		awsCfg:               awsCfg,


### PR DESCRIPTION
### Summary

Add Lambda as a new AWS service in unic. Users can browse Lambda functions, invoke them with a JSON payload (typed manually or loaded from a local file), and view the invocation result including response payload and execution log. An integrated CloudWatch Logs viewer lets users jump directly to the function's log streams from any Lambda screen via the `l` key.

### Related Issues

Closes #145
Closes #146

### Validation

- `go test ./...` — all tests pass
- `go build ./cmd/unic` — binary compiles
- Manual testing: list functions, view detail, invoke with manual payload, invoke with file payload (`~/` path expansion verified), view logs from function list / detail / invoke result, back navigation returns to Lambda screens

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed
- [x] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [ ] Breaking changes documented