### PR TITLE
feat: Add CloudWatch metric presets and chart controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ checks:
 | RDS | `s` start, `x` stop, `f` failover, `r` refresh |
 | Route53 | `c` create, `e` edit, `d` delete |
 | IAM Key Rotation | `r` rotate, `c` copy exports, `a` apply and verify, `d` deactivate old key, `x` delete old key |
-| CloudWatch Metrics | single-series metric list/detail flow, `/` filter, `r` refresh, fixed `Average` stat over the last hour with in-terminal block-chart rendering |
+| CloudWatch Metrics | preset-driven metric list/detail flow, `/` filter, `g` preset cycle, `t/p/s` range-period-stat controls, `r` refresh, in-terminal single-series charts |
 | CloudWatch Logs | log groups/streams load 10 at a time, `n` load more, `1`-`6` time presets, `t` live tail, `f` filter pattern, `w` wrap toggle, `h/l` horizontal scroll |
 | ECS Exec | `r` refresh, `Enter` drill down / exec |
 | ECS Rollout / Exec | cluster/service lists support refresh and drill-down, service detail shows deployments/task definition images/events, `Enter` continues into tasks and exec |

--- a/docs/project-overview.en.md
+++ b/docs/project-overview.en.md
@@ -23,7 +23,7 @@ Implemented service areas currently include:
 - Lambda
 - Inspector mode
 
-The application already includes interactive mutation flows, polling-based status flows, context helpers, and per-service drill-down screens.
+The application already includes interactive mutation flows, polling-based status flows, context helpers, and per-service drill-down screens. CloudWatch Metrics now includes resource-centric preset groups plus time-range, period, and statistic controls for faster terminal triage.
 Inspector mode now includes built-in security scans plus checklist-driven readiness checks for RDS, security groups, secrets, Route53, VPCs/subnets, CloudWatch Logs, and baseline posture wrappers.
 
 ## Primary User Flows

--- a/docs/project-overview.ko.md
+++ b/docs/project-overview.ko.md
@@ -23,7 +23,7 @@ UNIC은 다음 세 가지를 결합한 Go 기반 AWS 터미널 콘솔이다.
 - Lambda
 - Inspector mode
 
-애플리케이션은 이미 상호작용형 변경 작업 플로우, polling 기반 상태 확인, context helper, 서비스별 drill-down 화면을 포함한다.
+애플리케이션은 이미 상호작용형 변경 작업 플로우, polling 기반 상태 확인, context helper, 서비스별 drill-down 화면을 포함한다. CloudWatch Metrics는 이제 resource-centric preset 그룹과 time-range / period / statistic control을 제공해 터미널에서 더 빠르게 triage할 수 있다.
 Inspector mode는 이제 built-in security scan과 함께 RDS, security group, secret, Route53, VPC/subnet, CloudWatch Logs, baseline posture wrapper를 다루는 checklist 기반 readiness check도 포함한다.
 
 ## 주요 사용자 흐름

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -331,11 +331,22 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 			{"q / esc", "Return to the access key list"},
 		}
 	case screenCWMetricList:
-		return listScreenShortcuts("open the selected metric series", "go back to the feature list", true, true)
+		shortcuts := listScreenShortcuts("open the selected metric series", "go back to the feature list", true, true)
+		shortcuts = append(shortcuts[:3],
+			append([]helpShortcut{
+				{"g", "Cycle the preset metric group"},
+				{"t", "Cycle the chart time range"},
+				{"p", "Cycle the datapoint period"},
+				{"s", "Cycle the statistic"},
+			}, shortcuts[3:]...)...)
+		return shortcuts
 	case screenCWMetricDetail:
 		return []helpShortcut{
 			{"↑/↓, j/k", "Scroll the metric detail"},
 			{"pgup / pgdn", "Scroll by one page"},
+			{"t", "Cycle the chart time range"},
+			{"p", "Cycle the datapoint period"},
+			{"s", "Cycle the statistic"},
 			{"r", "Refresh the selected metric series"},
 			{"q / esc", "Go back to the metric list"},
 		}

--- a/internal/app/screen_cloudwatchmetrics.go
+++ b/internal/app/screen_cloudwatchmetrics.go
@@ -12,13 +12,85 @@ import (
 	awsservice "unic/internal/services/aws"
 )
 
-const (
-	cwMetricDefaultLookback = time.Hour
-	cwMetricDefaultPeriod   = time.Minute
-	cwMetricDefaultStat     = "Average"
-)
-
 var cwMetricSparklineBlocks = []rune("▁▂▃▄▅▆▇█")
+
+type cwMetricRangeOption struct {
+	label    string
+	duration time.Duration
+}
+
+type cwMetricPeriodOption struct {
+	label    string
+	duration time.Duration
+}
+
+type cwMetricPresetRule struct {
+	namespace   string
+	metricNames []string
+}
+
+type cwMetricPreset struct {
+	label       string
+	description string
+	rules       []cwMetricPresetRule
+}
+
+var cwMetricRangeOptions = []cwMetricRangeOption{
+	{label: "15m", duration: 15 * time.Minute},
+	{label: "1h", duration: time.Hour},
+	{label: "6h", duration: 6 * time.Hour},
+	{label: "24h", duration: 24 * time.Hour},
+	{label: "7d", duration: 7 * 24 * time.Hour},
+}
+
+var cwMetricPeriodOptions = []cwMetricPeriodOption{
+	{label: "1m", duration: time.Minute},
+	{label: "5m", duration: 5 * time.Minute},
+	{label: "15m", duration: 15 * time.Minute},
+	{label: "1h", duration: time.Hour},
+}
+
+var cwMetricStatOptions = []string{
+	"Average",
+	"Maximum",
+	"Minimum",
+	"Sum",
+}
+
+var cwMetricPresets = []cwMetricPreset{
+	{
+		label:       "All Metrics",
+		description: "Show every discovered CloudWatch metric series in the current region.",
+	},
+	{
+		label:       "EC2 CPU / Network",
+		description: "Focus on instance CPU, traffic, and status-check signals for EC2 triage.",
+		rules: []cwMetricPresetRule{
+			{namespace: "AWS/EC2", metricNames: []string{"CPUUtilization", "NetworkIn", "NetworkOut", "StatusCheckFailed", "StatusCheckFailed_Instance", "StatusCheckFailed_System"}},
+		},
+	},
+	{
+		label:       "RDS Connections / Storage",
+		description: "Show connection pressure and storage headroom metrics for DB instances.",
+		rules: []cwMetricPresetRule{
+			{namespace: "AWS/RDS", metricNames: []string{"DatabaseConnections", "FreeStorageSpace", "FreeableMemory", "ReadIOPS", "WriteIOPS", "CPUUtilization"}},
+		},
+	},
+	{
+		label:       "ECS Service",
+		description: "Show service-level utilization metrics from the standard AWS/ECS namespace.",
+		rules: []cwMetricPresetRule{
+			{namespace: "AWS/ECS", metricNames: []string{"CPUUtilization", "MemoryUtilization", "CPUReservation", "MemoryReservation"}},
+		},
+	},
+	{
+		label:       "ECS Task",
+		description: "Show task/container-level metrics where Container Insights publishes them cleanly.",
+		rules: []cwMetricPresetRule{
+			{namespace: "ECS/ContainerInsights", metricNames: []string{"CpuUtilized", "CpuReserved", "MemoryUtilized", "MemoryReserved", "RunningTaskCount", "PendingTaskCount", "RestartCount"}},
+		},
+	},
+}
 
 type cloudWatchMetricsModel struct {
 	metrics           []awsservice.CloudWatchMetric
@@ -27,10 +99,19 @@ type cloudWatchMetricsModel struct {
 	selectedMetric    *awsservice.CloudWatchMetric
 	selectedSeries    *awsservice.CloudWatchMetricSeriesData
 	detailScroll      int
+	presetIdx         int
+	timeRangeIdx      int
+	periodIdx         int
+	statIdx           int
 }
 
 func newCloudWatchMetricsModel() cloudWatchMetricsModel {
-	return cloudWatchMetricsModel{}
+	return cloudWatchMetricsModel{
+		presetIdx:    0,
+		timeRangeIdx: 1,
+		periodIdx:    0,
+		statIdx:      0,
+	}
 }
 
 func (cw *cloudWatchMetricsModel) Start(m *Model) (tea.Model, tea.Cmd) {
@@ -41,7 +122,7 @@ func (cw *cloudWatchMetricsModel) Start(m *Model) (tea.Model, tea.Cmd) {
 		"Loading CloudWatch metrics...",
 		[]string{
 			"Fetching metric definitions from the current account and region.",
-			"This first-pass viewer opens one metric series at a time with a fixed 1h / Average view.",
+			cw.controlsSummary(),
 		},
 		cw.loadMetrics(*m),
 	)
@@ -51,8 +132,7 @@ func (cw *cloudWatchMetricsModel) HandleMessage(m *Model, msg tea.Msg) (tea.Mode
 	switch msg := msg.(type) {
 	case cwMetricsLoadedMsg:
 		cw.metrics = msg.metrics
-		cw.filteredCWMetrics = applyFilter(cw.metrics, m.filterValue(filterCWMetrics))
-		cw.metricIdx = 0
+		cw.applyMetricFilters(m)
 		m.screen = screenCWMetricList
 		return *m, nil, true
 	case cwMetricDataLoadedMsg:
@@ -95,8 +175,7 @@ func (cw *cloudWatchMetricsModel) ApplyFilter(m *Model, target filterTarget) boo
 	if target != filterCWMetrics {
 		return false
 	}
-	cw.filteredCWMetrics = applyFilter(cw.metrics, m.filterValue(target))
-	cw.metricIdx = 0
+	cw.applyMetricFilters(m)
 	return true
 }
 
@@ -121,6 +200,15 @@ func (cw *cloudWatchMetricsModel) updateMetricList(m *Model, msg tea.KeyMsg) (te
 		return *m, m.activateFilter(filterCWMetrics)
 	case "r":
 		return m.startLoading(cw.loadMetrics(*m))
+	case "g":
+		cw.presetIdx = (cw.presetIdx + 1) % len(cwMetricPresets)
+		cw.applyMetricFilters(m)
+	case "t":
+		cw.timeRangeIdx = (cw.timeRangeIdx + 1) % len(cwMetricRangeOptions)
+	case "p":
+		cw.periodIdx = (cw.periodIdx + 1) % len(cwMetricPeriodOptions)
+	case "s":
+		cw.statIdx = (cw.statIdx + 1) % len(cwMetricStatOptions)
 	case "enter":
 		if len(cw.filteredCWMetrics) == 0 || cw.metricIdx >= len(cw.filteredCWMetrics) {
 			return *m, nil
@@ -130,7 +218,7 @@ func (cw *cloudWatchMetricsModel) updateMetricList(m *Model, msg tea.KeyMsg) (te
 			"Loading CloudWatch metric series...",
 			[]string{
 				fmt.Sprintf("Metric: %s / %s", selected.Namespace, selected.MetricName),
-				fmt.Sprintf("Stat: %s  Range: last %s  Period: %s", cwMetricDefaultStat, cwMetricDefaultLookback, cwMetricDefaultPeriod),
+				cw.controlsSummary(),
 			},
 			cw.loadSeries(*m, selected),
 		)
@@ -171,7 +259,37 @@ func (cw *cloudWatchMetricsModel) updateMetricDetail(m *Model, msg tea.KeyMsg) (
 		}
 		return m.startLoadingWithMessage(
 			"Refreshing CloudWatch metric series...",
-			[]string{fmt.Sprintf("Metric: %s / %s", cw.selectedMetric.Namespace, cw.selectedMetric.MetricName)},
+			[]string{fmt.Sprintf("Metric: %s / %s", cw.selectedMetric.Namespace, cw.selectedMetric.MetricName), cw.controlsSummary()},
+			cw.loadSeries(*m, *cw.selectedMetric),
+		)
+	case "t":
+		cw.timeRangeIdx = (cw.timeRangeIdx + 1) % len(cwMetricRangeOptions)
+		if cw.selectedMetric == nil {
+			return *m, nil
+		}
+		return m.startLoadingWithMessage(
+			"Refreshing CloudWatch metric series...",
+			[]string{fmt.Sprintf("Metric: %s / %s", cw.selectedMetric.Namespace, cw.selectedMetric.MetricName), cw.controlsSummary()},
+			cw.loadSeries(*m, *cw.selectedMetric),
+		)
+	case "p":
+		cw.periodIdx = (cw.periodIdx + 1) % len(cwMetricPeriodOptions)
+		if cw.selectedMetric == nil {
+			return *m, nil
+		}
+		return m.startLoadingWithMessage(
+			"Refreshing CloudWatch metric series...",
+			[]string{fmt.Sprintf("Metric: %s / %s", cw.selectedMetric.Namespace, cw.selectedMetric.MetricName), cw.controlsSummary()},
+			cw.loadSeries(*m, *cw.selectedMetric),
+		)
+	case "s":
+		cw.statIdx = (cw.statIdx + 1) % len(cwMetricStatOptions)
+		if cw.selectedMetric == nil {
+			return *m, nil
+		}
+		return m.startLoadingWithMessage(
+			"Refreshing CloudWatch metric series...",
+			[]string{fmt.Sprintf("Metric: %s / %s", cw.selectedMetric.Namespace, cw.selectedMetric.MetricName), cw.controlsSummary()},
 			cw.loadSeries(*m, *cw.selectedMetric),
 		)
 	}
@@ -185,14 +303,29 @@ func (cw cloudWatchMetricsModel) viewMetricList(m Model) string {
 	b.WriteString(m.renderStatusBar())
 	b.WriteString(titleStyle.Render("CloudWatch Metrics"))
 	b.WriteString("\n")
-	b.WriteString(dimStyle.Render("Single-series viewer v1. Use / to filter, then Enter to open one metric series."))
+	b.WriteString(dimStyle.Render(cw.controlsSummary()))
+	b.WriteString("\n")
+	b.WriteString(dimStyle.Render(cw.selectedPreset().description))
 	b.WriteString("\n\n")
 
 	b.WriteString(m.renderFilterValue(filterCWMetrics))
 	b.WriteString("\n\n")
 
 	if len(cw.filteredCWMetrics) == 0 {
-		panel.WriteString(dimStyle.Render("  No matching metrics"))
+		switch {
+		case len(cw.metrics) == 0:
+			panel.WriteString(dimStyle.Render("  No CloudWatch metrics were found in this account/region."))
+			panel.WriteString("\n")
+			panel.WriteString(dimStyle.Render("  Verify that the current region has emitted metrics and press r to refresh."))
+		case m.filterValue(filterCWMetrics) != "":
+			panel.WriteString(dimStyle.Render("  No metrics matched the current preset and filter query."))
+			panel.WriteString("\n")
+			panel.WriteString(dimStyle.Render("  Press g to switch presets or clear the filter with esc."))
+		default:
+			panel.WriteString(dimStyle.Render("  No metrics matched the current preset."))
+			panel.WriteString("\n")
+			panel.WriteString(dimStyle.Render("  Press g to cycle to another preset group."))
+		}
 		panel.WriteString("\n")
 	} else {
 		visibleLines := max(m.height-11, 5)
@@ -220,7 +353,7 @@ func (cw cloudWatchMetricsModel) viewMetricList(m Model) string {
 
 	b.WriteString(m.renderListPanel(panel.String()))
 	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • r: refresh • enter: chart • esc: back • H: home"))
+	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • g: preset • t: range • p: period • s: stat • r: refresh • enter: chart • esc: back • H: home"))
 	return b.String()
 }
 
@@ -231,6 +364,12 @@ func (cw cloudWatchMetricsModel) viewMetricDetail(m Model) string {
 	b.WriteString(m.renderStatusBar())
 	b.WriteString(titleStyle.Render("CloudWatch Metric Detail"))
 	b.WriteString("\n\n")
+	b.WriteString(dimStyle.Render(cw.controlsSummary()))
+	b.WriteString("\n")
+	if description := cw.selectedPreset().description; description != "" {
+		b.WriteString(dimStyle.Render(description))
+		b.WriteString("\n\n")
+	}
 
 	lines := cw.detailLines(m.width)
 	visibleLines := max(m.height-10, 5)
@@ -253,7 +392,7 @@ func (cw cloudWatchMetricsModel) viewMetricDetail(m Model) string {
 
 	b.WriteString(m.renderListPanel(panel.String()))
 	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("↑/↓: scroll • pgup/pgdn: page • r: refresh • esc: back • H: home"))
+	b.WriteString(m.renderHelpBar("↑/↓: scroll • pgup/pgdn: page • t: range • p: period • s: stat • r: refresh • esc: back • H: home"))
 	return b.String()
 }
 
@@ -290,9 +429,10 @@ func (cw cloudWatchMetricsModel) detailLines(width int) []string {
 	}
 
 	lines = append(lines,
+		renderDetailLine("Preset", normalStyle.Render(cw.selectedPreset().label)),
 		renderDetailLine("Stat", normalStyle.Render(series.Stat)),
 		renderDetailLine("Range", normalStyle.Render(fmt.Sprintf("%s to %s", series.StartTime.Local().Format("2006-01-02 15:04"), series.EndTime.Local().Format("2006-01-02 15:04")))),
-		renderDetailLine("Period", normalStyle.Render(series.Period.String())),
+		renderDetailLine("Period", normalStyle.Render(cw.selectedPeriod().label)),
 		renderDetailLine("Points", normalStyle.Render(fmt.Sprintf("%d", len(series.Datapoints)))),
 	)
 
@@ -311,6 +451,7 @@ func (cw cloudWatchMetricsModel) detailLines(width int) []string {
 	lines = append(lines, "", titleStyle.Render("Series"))
 	if len(series.Datapoints) == 0 {
 		lines = append(lines, dimStyle.Render("  No datapoints returned for the selected time window."))
+		lines = append(lines, dimStyle.Render("  Try t to widen the range, p to change the period, or s to switch the statistic."))
 	} else {
 		chartWidth := max(width-8, 16)
 		lines = append(lines, selectedStyle.Render("  "+renderMetricSparkline(series.Datapoints, chartWidth)))
@@ -457,9 +598,6 @@ func (cw cloudWatchMetricsModel) loadMetrics(m Model) tea.Cmd {
 		if err != nil {
 			return errMsg{err: err}
 		}
-		if len(metrics) == 0 {
-			return errMsg{err: fmt.Errorf("no CloudWatch metrics found")}
-		}
 		return cwMetricsLoadedMsg{metrics: metrics}
 	}
 }
@@ -473,11 +611,84 @@ func (cw cloudWatchMetricsModel) loadSeries(m Model, metric awsservice.CloudWatc
 		}
 
 		endTime := time.Now()
-		startTime := endTime.Add(-cwMetricDefaultLookback)
-		series, err := repo.GetMetricData(ctx, metric, startTime, endTime, cwMetricDefaultPeriod, cwMetricDefaultStat)
+		startTime := endTime.Add(-cw.selectedTimeRange().duration)
+		series, err := repo.GetMetricData(ctx, metric, startTime, endTime, cw.selectedPeriod().duration, cw.selectedStat())
 		if err != nil {
 			return errMsg{err: err}
 		}
 		return cwMetricDataLoadedMsg{metric: metric, series: series}
 	}
+}
+
+func (cw *cloudWatchMetricsModel) applyMetricFilters(m *Model) {
+	base := cw.presetMetrics()
+	cw.filteredCWMetrics = applyFilter(base, m.filterValue(filterCWMetrics))
+	if len(cw.filteredCWMetrics) == 0 {
+		cw.metricIdx = 0
+		return
+	}
+	if cw.metricIdx >= len(cw.filteredCWMetrics) {
+		cw.metricIdx = len(cw.filteredCWMetrics) - 1
+	}
+}
+
+func (cw cloudWatchMetricsModel) presetMetrics() []awsservice.CloudWatchMetric {
+	preset := cw.selectedPreset()
+	if len(preset.rules) == 0 {
+		return cw.metrics
+	}
+
+	filtered := make([]awsservice.CloudWatchMetric, 0, len(cw.metrics))
+	for _, metric := range cw.metrics {
+		if preset.matches(metric) {
+			filtered = append(filtered, metric)
+		}
+	}
+	return filtered
+}
+
+func (cw cloudWatchMetricsModel) selectedPreset() cwMetricPreset {
+	if cw.presetIdx < 0 || cw.presetIdx >= len(cwMetricPresets) {
+		return cwMetricPresets[0]
+	}
+	return cwMetricPresets[cw.presetIdx]
+}
+
+func (cw cloudWatchMetricsModel) selectedTimeRange() cwMetricRangeOption {
+	if cw.timeRangeIdx < 0 || cw.timeRangeIdx >= len(cwMetricRangeOptions) {
+		return cwMetricRangeOptions[0]
+	}
+	return cwMetricRangeOptions[cw.timeRangeIdx]
+}
+
+func (cw cloudWatchMetricsModel) selectedPeriod() cwMetricPeriodOption {
+	if cw.periodIdx < 0 || cw.periodIdx >= len(cwMetricPeriodOptions) {
+		return cwMetricPeriodOptions[0]
+	}
+	return cwMetricPeriodOptions[cw.periodIdx]
+}
+
+func (cw cloudWatchMetricsModel) selectedStat() string {
+	if cw.statIdx < 0 || cw.statIdx >= len(cwMetricStatOptions) {
+		return cwMetricStatOptions[0]
+	}
+	return cwMetricStatOptions[cw.statIdx]
+}
+
+func (cw cloudWatchMetricsModel) controlsSummary() string {
+	return fmt.Sprintf("Preset: %s  Range: %s  Period: %s  Stat: %s", cw.selectedPreset().label, cw.selectedTimeRange().label, cw.selectedPeriod().label, cw.selectedStat())
+}
+
+func (p cwMetricPreset) matches(metric awsservice.CloudWatchMetric) bool {
+	for _, rule := range p.rules {
+		if !strings.EqualFold(rule.namespace, metric.Namespace) {
+			continue
+		}
+		for _, metricName := range rule.metricNames {
+			if strings.EqualFold(metricName, metric.MetricName) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/app/screen_cloudwatchmetrics_test.go
+++ b/internal/app/screen_cloudwatchmetrics_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	awsservice "unic/internal/services/aws"
 )
 
@@ -78,6 +79,52 @@ func TestCloudWatchMetricsApplyFilter(t *testing.T) {
 	}
 }
 
+func TestCloudWatchMetricsPresetFiltersResourceGroups(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.cwMetrics.metrics = []awsservice.CloudWatchMetric{
+		{Namespace: "AWS/EC2", MetricName: "CPUUtilization"},
+		{Namespace: "AWS/EC2", MetricName: "NetworkIn"},
+		{Namespace: "AWS/RDS", MetricName: "DatabaseConnections"},
+		{Namespace: "AWS/ECS", MetricName: "CPUUtilization"},
+		{Namespace: "ECS/ContainerInsights", MetricName: "RunningTaskCount"},
+	}
+
+	m.cwMetrics.presetIdx = 1
+	m.applyFilterTarget(filterCWMetrics)
+
+	if len(m.cwMetrics.filteredCWMetrics) != 2 {
+		t.Fatalf("expected 2 EC2 preset metrics, got %d", len(m.cwMetrics.filteredCWMetrics))
+	}
+	for _, metric := range m.cwMetrics.filteredCWMetrics {
+		if metric.Namespace != "AWS/EC2" {
+			t.Fatalf("expected only AWS/EC2 metrics, got %+v", metric)
+		}
+	}
+}
+
+func TestCloudWatchMetricListCyclePreset(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenCWMetricList
+	m.cwMetrics.metrics = []awsservice.CloudWatchMetric{
+		{Namespace: "AWS/EC2", MetricName: "CPUUtilization"},
+		{Namespace: "AWS/RDS", MetricName: "DatabaseConnections"},
+	}
+	m.cwMetrics.filteredCWMetrics = m.cwMetrics.metrics
+
+	updated, _ := m.cwMetrics.updateMetricList(&m, keyMsg("g"))
+	model := updated.(Model)
+
+	if model.cwMetrics.presetIdx != 1 {
+		t.Fatalf("expected preset index 1, got %d", model.cwMetrics.presetIdx)
+	}
+	if len(model.cwMetrics.filteredCWMetrics) != 1 {
+		t.Fatalf("expected preset-filtered metrics to shrink to 1, got %d", len(model.cwMetrics.filteredCWMetrics))
+	}
+	if got := model.cwMetrics.filteredCWMetrics[0].Namespace; got != "AWS/EC2" {
+		t.Fatalf("expected EC2 metric after preset cycle, got %q", got)
+	}
+}
+
 func TestCloudWatchMetricDetailViewShowsNoDataMessage(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.width = 90
@@ -101,4 +148,50 @@ func TestCloudWatchMetricDetailViewShowsNoDataMessage(t *testing.T) {
 	if !strings.Contains(view, "No datapoints returned for the selected time window.") {
 		t.Fatalf("expected no-data message, got %q", view)
 	}
+	if !strings.Contains(view, "Try t to widen the range, p to change the period, or s to switch the statistic.") {
+		t.Fatalf("expected no-data controls hint, got %q", view)
+	}
+}
+
+func TestCloudWatchMetricDetailControlChangeStartsReload(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenCWMetricDetail
+	metric := awsservice.CloudWatchMetric{
+		Namespace:  "AWS/EC2",
+		MetricName: "CPUUtilization",
+	}
+	m.cwMetrics.selectedMetric = &metric
+	m.cwMetrics.selectedSeries = &awsservice.CloudWatchMetricSeriesData{Metric: metric, Stat: "Average"}
+
+	updated, cmd := m.cwMetrics.updateMetricDetail(&m, keyMsg("s"))
+	model := updated.(Model)
+
+	if model.screen != screenLoading {
+		t.Fatalf("expected screenLoading after statistic change, got %v", model.screen)
+	}
+	if model.cwMetrics.statIdx != 1 {
+		t.Fatalf("expected stat index to advance to 1, got %d", model.cwMetrics.statIdx)
+	}
+	if model.loadingTitle != "Refreshing CloudWatch metric series..." {
+		t.Fatalf("unexpected loading title %q", model.loadingTitle)
+	}
+	if cmd == nil {
+		t.Fatal("expected reload command after statistic change")
+	}
+}
+
+func TestCloudWatchMetricListViewShowsGlobalEmptyState(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.width = 90
+	m.height = 24
+	m.screen = screenCWMetricList
+
+	view := m.cwMetrics.viewMetricList(m)
+	if !strings.Contains(view, "No CloudWatch metrics were found in this account/region.") {
+		t.Fatalf("expected global empty-state copy, got %q", view)
+	}
+}
+
+func keyMsg(value string) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(value), Alt: false}
 }

--- a/internal/domain/catalog.go
+++ b/internal/domain/catalog.go
@@ -61,7 +61,7 @@ func Catalog() []Service {
 			Features: []Feature{
 				{
 					Kind:        FeatureCloudWatchMetrics,
-					Description: "Browse CloudWatch metric series and view a single-series chart",
+					Description: "Browse CloudWatch metric series with presets, controls, and a single-series chart",
 				},
 			},
 		},


### PR DESCRIPTION
### Summary

Build on the initial CloudWatch metrics viewer with practical triage controls instead of a fixed single-view chart.

- add preset metric groups for EC2 CPU/network, RDS connections/storage, ECS service, and ECS task signals
- add `g/t/p/s` controls for preset, time range, period, and statistic selection
- improve CloudWatch Metrics empty, loading, and no-data states so the flow stays usable in-terminal
- update help text, README, and overview docs to reflect the expanded CloudWatch Metrics behavior
- no breaking changes

### Related Issues

Closes #126

### Validation

- `make test`
- `make build`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed
- [x] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented
