### PR TITLE
[codex] Support aws login in unic context setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ contexts:
     role_arn: arn:aws:iam::123456789012:role/Admin
     external_id: optional-external-id
 
+  - name: local-dev
+    profile: local-dev
+    region: ap-northeast-2
+    auth_type: console_login
+
   - name: staging
     profile: staging
     region: eu-west-1
@@ -171,6 +176,7 @@ contexts:
 | Auth Type | Meaning | Required Fields |
 |---|---|---|
 | `credential` | Use shared AWS profile credentials | `profile` |
+| `console_login` | Run `aws login` during `unic context setup`, then use the resulting profile-backed console credentials | `profile` |
 | `assume_role` | Assume a role from a base profile | `profile`, `role_arn` |
 | `sso` | Use AWS IAM Identity Center / SSO | `profile`, `sso_start_url`, and for concrete contexts `sso_account_id`, `sso_role_name` |
 

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -41,6 +41,7 @@ Owns non-TUI commands:
 - `unic context setup`
   - live incremental filtering for large context/account/role lists
   - interactive context ordering via `unic context order`
+  - can trigger `aws login` for `console_login` contexts
 - `unic context unset`
 
 ### `internal/config/`
@@ -58,8 +59,10 @@ Owns `~/.config/unic/config.yaml` handling:
 Owns shell export and interactive setup workflows:
 
 - build shell exports for `credential`, `assume_role`, and concrete `sso` contexts
+- build profile-based exports for `console_login` contexts after `aws login`
 - include a `UNIC_CONTEXT` marker in shell exports and cleanup commands
 - run interactive setup for SSO base contexts
+- run `aws login` for standalone `console_login` contexts
 - share SSO account / role resolution helpers across CLI and TUI flows
 - discover available SSO accounts and roles
 - return clipboard-friendly export strings
@@ -141,13 +144,20 @@ Supporting files include `styles.go`, `filter.go`, and `messages.go`.
 
 ## Authentication Model
 
-UNIC supports three main auth modes.
+UNIC supports four main auth modes.
 
 ### `credential`
 
 - uses shared AWS profile credentials
 - `unic env` exports `AWS_PROFILE` and region variables
 - TUI uses AWS SDK shared config loading
+
+### `console_login`
+
+- uses a shared AWS profile plus AWS CLI `aws login`
+- `unic context setup` runs `aws login --profile <profile> --region <region>`
+- remains profile-backed after login, so `unic env` exports `AWS_PROFILE` and region variables
+- currently supported only as a standalone context and does not chain with `role_arn`
 
 ### `assume_role`
 

--- a/docs/architecture.ko.md
+++ b/docs/architecture.ko.md
@@ -41,6 +41,7 @@ cmd/unic/main.go
 - `unic context setup`
   - 많은 context/account/role 목록에서 live incremental filtering 지원
   - `unic context order`를 통한 interactive context ordering 지원
+  - `console_login` context에서 `aws login` 실행 가능
 - `unic context unset`
 
 ### `internal/config/`
@@ -58,8 +59,10 @@ cmd/unic/main.go
 쉘 export와 interactive setup 흐름을 담당한다.
 
 - `credential`, `assume_role`, concrete `sso` context용 export 문자열 생성
+- `console_login` context에서 `aws login` 이후 profile 기반 export 생성
 - 쉘 export와 cleanup command에 `UNIC_CONTEXT` marker 포함
 - SSO base context setup 실행
+- standalone `console_login` context에서 `aws login` 실행
 - CLI와 TUI에서 함께 쓰는 SSO account / role resolution helper 제공
 - 사용 가능한 SSO account / role 조회
 - clipboard에 붙여넣기 쉬운 export 문자열 반환
@@ -155,6 +158,13 @@ UNIC은 현재 세 가지 인증 모드를 지원한다.
 - STS `AssumeRole` 호출
 - `unic env`는 임시 세션 자격증명을 export
 - SDK client는 assume-role 결과 자격증명으로 초기화
+
+### `console_login`
+
+- shared AWS profile과 AWS CLI `aws login`을 함께 사용
+- `unic context setup`이 `aws login --profile <profile> --region <region>`을 실행
+- login 이후에도 profile 기반이므로 `unic env`는 `AWS_PROFILE`과 region 변수를 export
+- 현재는 standalone context로만 지원하며 `role_arn` chaining은 지원하지 않음
 
 ### `sso`
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -50,6 +50,7 @@ Prefer tests for:
 - repository methods with mocked AWS clients
 - config and auth helpers
 - TUI transition logic when a feature adds or changes a flow
+- context add/setup flows when auth types or auth-specific branches change
 
 ## Docs Ownership Model
 

--- a/docs/project-overview.en.md
+++ b/docs/project-overview.en.md
@@ -43,6 +43,7 @@ The app supports:
 - legacy flat config
 - context-based config with `current`
 - `credential` auth
+- `console_login` auth for AWS CLI `aws login`-backed local development profiles
 - `assume_role` auth
 - `sso` auth, including base contexts resolved by `unic context setup`
 

--- a/docs/project-overview.ko.md
+++ b/docs/project-overview.ko.md
@@ -43,6 +43,7 @@ Inspector mode는 이제 built-in security scan과 함께 RDS, security group, s
 - legacy flat config
 - `current`를 포함한 context 기반 config
 - `credential` 인증
+- AWS CLI `aws login` 기반 로컬 개발 profile을 위한 `console_login` 인증
 - `assume_role` 인증
 - `unic context setup`으로 concrete context를 만드는 `sso` 인증
 

--- a/internal/app/context_add.go
+++ b/internal/app/context_add.go
@@ -15,7 +15,7 @@ type fieldDef struct {
 	required bool
 }
 
-var authTypes = []string{"sso", "credential", "assume_role"}
+var authTypes = []string{"sso", "credential", "console_login", "assume_role"}
 
 var fieldsByAuthType = map[string][]fieldDef{
 	"sso": {
@@ -27,6 +27,12 @@ var fieldsByAuthType = map[string][]fieldDef{
 		{key: "sso_role_name", label: "SSO Role Name", required: true},
 	},
 	"credential": {
+		{key: "name", label: "Name", required: true},
+		{key: "order", label: "Display Order (optional, lower first)", required: false},
+		{key: "region", label: "Region", required: true},
+		{key: "profile", label: "Profile", required: true},
+	},
+	"console_login": {
 		{key: "name", label: "Name", required: true},
 		{key: "order", label: "Display Order (optional, lower first)", required: false},
 		{key: "region", label: "Region", required: true},

--- a/internal/app/context_add_test.go
+++ b/internal/app/context_add_test.go
@@ -1,0 +1,45 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestContextAddShowsConsoleLoginAuthType(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenContextAdd
+	m.addStep = 0
+
+	view := m.viewContextAdd()
+	if !strings.Contains(view, "console_login") {
+		t.Fatalf("expected console_login in auth type selection, got %q", view)
+	}
+}
+
+func TestContextAddSelectsConsoleLoginFields(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenContextAdd
+	m.addStep = 0
+	m.addValues = map[string]string{}
+
+	for i, authType := range authTypes {
+		if authType == "console_login" {
+			m.addAuthIdx = i
+			break
+		}
+	}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model := updated.(Model)
+	if model.addValues["auth_type"] != "console_login" {
+		t.Fatalf("expected console_login selection, got %q", model.addValues["auth_type"])
+	}
+	if len(model.addFields) != 4 {
+		t.Fatalf("expected 4 fields for console_login, got %d", len(model.addFields))
+	}
+	if model.addFields[3].key != "profile" {
+		t.Fatalf("expected profile field, got %+v", model.addFields)
+	}
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -28,6 +28,8 @@ func PostSwitch(cfg *config.Config) (string, error) {
 		msg, err = postSwitchSSO(cfg)
 	case config.AuthTypeCredential:
 		msg, err = postSwitchCredential(cfg)
+	case config.AuthTypeConsoleLogin:
+		msg, err = postSwitchConsoleLogin(cfg)
 	case config.AuthTypeAssumeRole:
 		msg, err = postSwitchAssumeRole(cfg)
 	default:
@@ -73,6 +75,16 @@ func postSwitchCredential(cfg *config.Config) (string, error) {
 	}
 
 	return fmt.Sprintf("Using credentials profile %q from ~/.aws/credentials (region: %s)", cfg.Profile, cfg.Region), nil
+}
+
+func postSwitchConsoleLogin(cfg *config.Config) (string, error) {
+	if err := awsservice.ValidateConsoleLoginContext(cfg); err != nil {
+		return "", err
+	}
+	if err := awsservice.RunConsoleLogin(cfg); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Console login complete for profile %q (region: %s)", cfg.Profile, cfg.Region), nil
 }
 
 func postSwitchAssumeRole(cfg *config.Config) (string, error) {

--- a/internal/auth/env.go
+++ b/internal/auth/env.go
@@ -53,7 +53,12 @@ func BuildEnvExports(ctx context.Context, cfg *config.Config) (string, error) {
 		values["AWS_DEFAULT_REGION"] = cfg.Region
 		values["AWS_PROFILE"] = ""
 
-	case config.AuthTypeCredential, config.AuthTypeDefault:
+	case config.AuthTypeCredential, config.AuthTypeConsoleLogin, config.AuthTypeDefault:
+		if cfg.AuthType == config.AuthTypeConsoleLogin {
+			if err := awsservice.ValidateConsoleLoginContext(cfg); err != nil {
+				return "", err
+			}
+		}
 		profile := cfg.Profile
 		if profile == "" {
 			profile = "default"

--- a/internal/auth/env_test.go
+++ b/internal/auth/env_test.go
@@ -36,6 +36,33 @@ func TestBuildEnvExportsCredentialContext(t *testing.T) {
 	}
 }
 
+func TestBuildEnvExportsConsoleLoginContext(t *testing.T) {
+	cfg := &config.Config{
+		ContextName: "local-dev",
+		AuthType:    config.AuthTypeConsoleLogin,
+		Profile:     "local-dev",
+		Region:      "ap-northeast-2",
+	}
+
+	exports, err := BuildEnvExports(context.Background(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, expected := range []string{
+		"export AWS_PROFILE='local-dev'",
+		"export AWS_REGION='ap-northeast-2'",
+		"export AWS_DEFAULT_REGION='ap-northeast-2'",
+		"unset AWS_ACCESS_KEY_ID",
+		"unset AWS_SECRET_ACCESS_KEY",
+		"unset AWS_SESSION_TOKEN",
+	} {
+		if !strings.Contains(exports, expected) {
+			t.Fatalf("expected exports to contain %q, got:\n%s", expected, exports)
+		}
+	}
+}
+
 func TestBuildEnvExportsAssumeRoleContext(t *testing.T) {
 	orig := assumeRoleFn
 	t.Cleanup(func() { assumeRoleFn = orig })

--- a/internal/auth/setup.go
+++ b/internal/auth/setup.go
@@ -16,6 +16,7 @@ var (
 	listSSOAccountsFn     = awsservice.ListSSOAccounts
 	listSSOAccountRolesFn = awsservice.ListSSOAccountRoles
 	buildEnvExportsFn     = BuildEnvExports
+	runConsoleLoginFn     = awsservice.RunConsoleLogin
 )
 
 // SelectContext interactively selects a context without changing current state.
@@ -60,6 +61,11 @@ func SetupContext(ctx context.Context, configPath string, in io.Reader, errOut i
 	finalCfg, err := config.LoadNamedContext(configPath, finalName)
 	if err != nil {
 		return "", err
+	}
+	if finalCfg.AuthType == config.AuthTypeConsoleLogin {
+		if err := runConsoleLoginFn(finalCfg); err != nil {
+			return "", err
+		}
 	}
 
 	fmt.Fprintf(errOut, "Selected context: %s\n", finalName)

--- a/internal/auth/setup_test.go
+++ b/internal/auth/setup_test.go
@@ -24,10 +24,12 @@ func TestSetupContextUpsertsConcreteSSOContext(t *testing.T) {
 	origAccounts := listSSOAccountsFn
 	origRoles := listSSOAccountRolesFn
 	origBuild := buildEnvExportsFn
+	origConsoleLogin := runConsoleLoginFn
 	defer func() {
 		listSSOAccountsFn = origAccounts
 		listSSOAccountRolesFn = origRoles
 		buildEnvExportsFn = origBuild
+		runConsoleLoginFn = origConsoleLogin
 	}()
 
 	listSSOAccountsFn = func(ctx context.Context, cfg *config.Config) ([]awsservice.SSOAccount, error) {
@@ -39,6 +41,7 @@ func TestSetupContextUpsertsConcreteSSOContext(t *testing.T) {
 	buildEnvExportsFn = func(ctx context.Context, cfg *config.Config) (string, error) {
 		return "export AWS_REGION='ap-northeast-2'", nil
 	}
+	runConsoleLoginFn = func(cfg *config.Config) error { return nil }
 
 	dir := t.TempDir()
 	path := writeConfig(t, dir, `
@@ -74,6 +77,50 @@ contexts:
 	}
 	if len(infos) != 2 {
 		t.Fatalf("expected 2 contexts after upsert, got %d", len(infos))
+	}
+}
+
+func TestSetupContextRunsConsoleLoginForConsoleLoginContext(t *testing.T) {
+	origBuild := buildEnvExportsFn
+	origConsoleLogin := runConsoleLoginFn
+	defer func() {
+		buildEnvExportsFn = origBuild
+		runConsoleLoginFn = origConsoleLogin
+	}()
+
+	var ran bool
+	buildEnvExportsFn = func(ctx context.Context, cfg *config.Config) (string, error) {
+		return "export AWS_PROFILE='local-dev'", nil
+	}
+	runConsoleLoginFn = func(cfg *config.Config) error {
+		ran = true
+		if cfg.Profile != "local-dev" {
+			t.Fatalf("expected local-dev profile, got %q", cfg.Profile)
+		}
+		return nil
+	}
+
+	dir := t.TempDir()
+	path := writeConfig(t, dir, `
+defaults:
+  region: ap-northeast-2
+contexts:
+  - name: local-dev
+    auth_type: console_login
+    profile: local-dev
+    region: ap-northeast-2
+`)
+
+	var stderr strings.Builder
+	exports, err := SetupContext(context.Background(), path, strings.NewReader("1\n"), &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ran {
+		t.Fatal("expected console login to run")
+	}
+	if !strings.Contains(exports, "export AWS_PROFILE='local-dev'") {
+		t.Fatalf("expected exports, got %q", exports)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,10 +36,11 @@ type fileDefaults struct {
 type AuthType string
 
 const (
-	AuthTypeDefault    AuthType = ""
-	AuthTypeSSO        AuthType = "sso"
-	AuthTypeCredential AuthType = "credential"
-	AuthTypeAssumeRole AuthType = "assume_role"
+	AuthTypeDefault      AuthType = ""
+	AuthTypeSSO          AuthType = "sso"
+	AuthTypeCredential   AuthType = "credential"
+	AuthTypeConsoleLogin AuthType = "console_login"
+	AuthTypeAssumeRole   AuthType = "assume_role"
 )
 
 // ContextEntry represents a single context definition in config.yaml.
@@ -79,6 +80,8 @@ func normalizeAuthType(value string) AuthType {
 		return AuthTypeSSO
 	case "credential", "credentials":
 		return AuthTypeCredential
+	case "console_login", "console-login":
+		return AuthTypeConsoleLogin
 	case "assume_role", "assume-role":
 		return AuthTypeAssumeRole
 	default:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -394,6 +394,28 @@ contexts:
 	}
 }
 
+func TestContextWithConsoleLoginAuthType(t *testing.T) {
+	dir := t.TempDir()
+	path := writeUnicConfig(t, dir, `
+current: local-dev
+contexts:
+  - name: local-dev
+    auth_type: console_login
+    profile: local-dev
+    region: ap-northeast-2
+`)
+	cfg, err := Load(nil, nil, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AuthType != AuthTypeConsoleLogin {
+		t.Errorf("expected auth_type 'console_login', got '%s'", cfg.AuthType)
+	}
+	if cfg.Profile != "local-dev" {
+		t.Errorf("expected profile 'local-dev', got '%s'", cfg.Profile)
+	}
+}
+
 func TestContextWithCredentialsAliasAuthType(t *testing.T) {
 	dir := t.TempDir()
 	path := writeUnicConfig(t, dir, `

--- a/internal/services/aws/login.go
+++ b/internal/services/aws/login.go
@@ -1,0 +1,48 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"unic/internal/config"
+)
+
+// RunConsoleLogin executes `aws login` for a profile-backed context.
+func RunConsoleLogin(cfg *config.Config) error {
+	cmd, err := BuildConsoleLoginCmd(cfg)
+	if err != nil {
+		return err
+	}
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	fmt.Printf("Starting console login for profile %s ...\n", cfg.Profile)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("aws login failed: %w", err)
+	}
+	return nil
+}
+
+// BuildConsoleLoginCmd creates an *exec.Cmd for `aws login`.
+func BuildConsoleLoginCmd(cfg *config.Config) (*exec.Cmd, error) {
+	if err := ValidateConsoleLoginContext(cfg); err != nil {
+		return nil, err
+	}
+	args := []string{"login", "--profile", cfg.Profile}
+	if cfg.Region != "" {
+		args = append(args, "--region", cfg.Region)
+	}
+	return exec.Command("aws", args...), nil
+}
+
+func ValidateConsoleLoginContext(cfg *config.Config) error {
+	if cfg.Profile == "" {
+		return fmt.Errorf("console_login context %q requires profile", cfg.ContextName)
+	}
+	if cfg.RoleArn != "" {
+		return fmt.Errorf("console_login context %q does not support role_arn", cfg.ContextName)
+	}
+	return nil
+}

--- a/internal/services/aws/login.go
+++ b/internal/services/aws/login.go
@@ -34,7 +34,11 @@ func BuildConsoleLoginCmd(cfg *config.Config) (*exec.Cmd, error) {
 	if cfg.Region != "" {
 		args = append(args, "--region", cfg.Region)
 	}
-	return exec.Command("aws", args...), nil
+	awsPath, err := exec.LookPath("aws")
+	if err != nil {
+		return nil, fmt.Errorf("aws CLI not found in PATH: %w", err)
+	}
+	return exec.Command(awsPath, args...), nil
 }
 
 func ValidateConsoleLoginContext(cfg *config.Config) error {

--- a/internal/services/aws/login_test.go
+++ b/internal/services/aws/login_test.go
@@ -1,0 +1,35 @@
+package aws
+
+import (
+	"testing"
+
+	"unic/internal/config"
+)
+
+func TestBuildConsoleLoginCmd(t *testing.T) {
+	cmd, err := BuildConsoleLoginCmd(&config.Config{
+		ContextName: "local-dev",
+		AuthType:    config.AuthTypeConsoleLogin,
+		Profile:     "local-dev",
+		Region:      "ap-northeast-2",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cmd.Args; len(got) != 6 || got[0] != "aws" || got[1] != "login" || got[2] != "--profile" || got[3] != "local-dev" || got[4] != "--region" || got[5] != "ap-northeast-2" {
+		t.Fatalf("unexpected args: %#v", got)
+	}
+}
+
+func TestBuildConsoleLoginCmdRejectsRoleArn(t *testing.T) {
+	_, err := BuildConsoleLoginCmd(&config.Config{
+		ContextName: "local-dev",
+		AuthType:    config.AuthTypeConsoleLogin,
+		Profile:     "local-dev",
+		Region:      "ap-northeast-2",
+		RoleArn:     "arn:aws:iam::123456789012:role/Admin",
+	})
+	if err == nil {
+		t.Fatal("expected role_arn rejection")
+	}
+}

--- a/internal/services/aws/login_test.go
+++ b/internal/services/aws/login_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"path/filepath"
 	"testing"
 
 	"unic/internal/config"
@@ -16,7 +17,7 @@ func TestBuildConsoleLoginCmd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := cmd.Args; len(got) != 6 || got[0] != "aws" || got[1] != "login" || got[2] != "--profile" || got[3] != "local-dev" || got[4] != "--region" || got[5] != "ap-northeast-2" {
+	if got := cmd.Args; len(got) != 6 || filepath.Base(got[0]) != "aws" || got[1] != "login" || got[2] != "--profile" || got[3] != "local-dev" || got[4] != "--region" || got[5] != "ap-northeast-2" {
 		t.Fatalf("unexpected args: %#v", got)
 	}
 }

--- a/internal/services/aws/repository.go
+++ b/internal/services/aws/repository.go
@@ -269,7 +269,12 @@ func NewAwsRepository(ctx context.Context, cfg *config.Config) (*AwsRepository, 
 			return nil, err
 		}
 
-	case config.AuthTypeCredential:
+	case config.AuthTypeCredential, config.AuthTypeConsoleLogin:
+		if cfg.AuthType == config.AuthTypeConsoleLogin {
+			if err := ValidateConsoleLoginContext(cfg); err != nil {
+				return nil, err
+			}
+		}
 		awsCfg, err = LoadBaseConfig(ctx, cfg.Region, cfg.Profile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load AWS config: %w", err)


### PR DESCRIPTION
## Summary
- add `auth_type: console_login` for profile-backed AWS CLI `aws login` flows
- run `aws login` from `unic context setup` for standalone `console_login` contexts
- expose `console_login` in the TUI add-context flow
- document the new auth mode across README and docs

## What Changed
- added config support and auth-type normalization for `console_login`
- added AWS helper logic to validate and execute `aws login`
- treated `console_login` contexts as standalone profile-backed contexts
- exported `AWS_PROFILE`, `AWS_REGION`, and `AWS_DEFAULT_REGION` for `console_login`
- added TUI add-context support and tests for selecting the new auth type
- updated architecture, project overview, and development docs

## Constraints
- `console_login` is standalone-only in this first version
- `role_arn` chaining is not supported for `console_login`
- a `profile` is required

## Validation
- `make test`
- `make build`

Closes #151
