### PR TITLE
fix: reuse cached SSO sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ contexts:
 | `credential` | Use shared AWS profile credentials | `profile` |
 | `console_login` | Run `aws login` during `unic context setup`, then use the resulting profile-backed console credentials | `profile` |
 | `assume_role` | Assume a role from a base profile | `profile`, `role_arn` |
-| `sso` | Use AWS IAM Identity Center / SSO | `profile`, `sso_start_url`, and for concrete contexts `sso_account_id`, `sso_role_name` |
+| `sso` | Use AWS IAM Identity Center / SSO, reusing a valid AWS CLI SSO cache and prompting for login only when needed | `profile`, `sso_start_url`, and for concrete contexts `sso_account_id`, `sso_role_name` |
 
 Optional context fields:
 

--- a/internal/app/context_terminal.go
+++ b/internal/app/context_terminal.go
@@ -40,6 +40,9 @@ var (
 	contextListSSORolesFn        = auth.ListSSOContextRoles
 	contextResolveSSOSelectionFn = auth.ResolveSSOContextSelection
 	contextDetectEnvFn           = auth.DetectEnvContext
+	contextCheckSSOSessionFn     = awsservice.CheckSSOSession
+	contextBuildSSOLoginCmdFn    = awsservice.BuildSSOLoginCmd
+	contextFinalizeSwitchFn      = func(m Model) tea.Cmd { return m.doFinalizeContextSwitch() }
 )
 
 func (m Model) selectedContextInfo() (config.ContextInfo, bool) {

--- a/internal/app/screen_context.go
+++ b/internal/app/screen_context.go
@@ -183,7 +183,15 @@ func (m Model) switchContext(name string) tea.Cmd {
 
 		// SSO needs interactive terminal — hand off via tea.ExecProcess
 		if cfg.AuthType == config.AuthTypeSSO {
-			cmd, cleanup, err := awsservice.BuildSSOLoginCmd(cfg)
+			check, err := contextCheckSSOSessionFn(cfg)
+			if err != nil {
+				return errMsg{err: err}
+			}
+			if !check.LoginRequired {
+				return contextFinalizeSwitchFn(m)()
+			}
+
+			cmd, cleanup, err := contextBuildSSOLoginCmdFn(cfg)
 			if err != nil {
 				return errMsg{err: err}
 			}

--- a/internal/app/screen_context_test.go
+++ b/internal/app/screen_context_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -377,6 +378,118 @@ contexts:
 	}
 	if cfg.ContextName != "prod" {
 		t.Fatalf("expected current context to remain prod, got %q", cfg.ContextName)
+	}
+}
+
+func TestSwitchContextSSOReusesCachedSessionWithoutLoginCommand(t *testing.T) {
+	path := writeContextConfig(t, `
+current: dev-sso
+defaults:
+  region: us-east-1
+contexts:
+  - name: dev-sso
+    auth_type: sso
+    sso_start_url: https://example.awsapps.com/start
+    sso_account_id: "123456789012"
+    sso_role_name: AdministratorAccess
+    region: us-east-1
+`)
+
+	origCheck := contextCheckSSOSessionFn
+	origBuildLogin := contextBuildSSOLoginCmdFn
+	origFinalize := contextFinalizeSwitchFn
+	defer func() {
+		contextCheckSSOSessionFn = origCheck
+		contextBuildSSOLoginCmdFn = origBuildLogin
+		contextFinalizeSwitchFn = origFinalize
+	}()
+
+	checkCalled := false
+	buildCalled := false
+	contextCheckSSOSessionFn = func(cfg *config.Config) (awsservice.SSOSessionCheck, error) {
+		checkCalled = true
+		return awsservice.SSOSessionCheck{StartURL: cfg.SSOStartURL}, nil
+	}
+	contextBuildSSOLoginCmdFn = func(*config.Config) (*exec.Cmd, func(), error) {
+		buildCalled = true
+		return exec.Command("true"), func() {}, nil
+	}
+	contextFinalizeSwitchFn = func(m Model) tea.Cmd {
+		return func() tea.Msg {
+			return contextSwitchedMsg{
+				cfg: &config.Config{
+					ContextName: "dev-sso",
+					AuthType:    config.AuthTypeSSO,
+					Region:      "us-east-1",
+				},
+			}
+		}
+	}
+
+	m := New(testConfig(), path, "dev")
+	msg := m.switchContext("dev-sso")()
+	if _, ok := msg.(contextSwitchedMsg); !ok {
+		t.Fatalf("expected cached SSO context to finalize immediately, got %T", msg)
+	}
+	if !checkCalled {
+		t.Fatal("expected SSO session cache check")
+	}
+	if buildCalled {
+		t.Fatal("expected valid cached SSO session to skip login command")
+	}
+}
+
+func TestSwitchContextSSORunsLoginWhenCacheMissing(t *testing.T) {
+	path := writeContextConfig(t, `
+current: dev-sso
+defaults:
+  region: us-east-1
+contexts:
+  - name: dev-sso
+    auth_type: sso
+    sso_start_url: https://example.awsapps.com/start
+    sso_account_id: "123456789012"
+    sso_role_name: AdministratorAccess
+    region: us-east-1
+`)
+
+	origCheck := contextCheckSSOSessionFn
+	origBuildLogin := contextBuildSSOLoginCmdFn
+	origFinalize := contextFinalizeSwitchFn
+	defer func() {
+		contextCheckSSOSessionFn = origCheck
+		contextBuildSSOLoginCmdFn = origBuildLogin
+		contextFinalizeSwitchFn = origFinalize
+	}()
+
+	buildCalled := false
+	contextCheckSSOSessionFn = func(cfg *config.Config) (awsservice.SSOSessionCheck, error) {
+		return awsservice.SSOSessionCheck{
+			StartURL:      cfg.SSOStartURL,
+			LoginRequired: true,
+		}, nil
+	}
+	contextBuildSSOLoginCmdFn = func(*config.Config) (*exec.Cmd, func(), error) {
+		buildCalled = true
+		return exec.Command("true"), func() {}, nil
+	}
+	contextFinalizeSwitchFn = func(Model) tea.Cmd {
+		return func() tea.Msg {
+			t.Fatal("SSO context should not finalize before login completes")
+			return nil
+		}
+	}
+
+	m := New(testConfig(), path, "dev")
+	msg := m.switchContext("dev-sso")()
+	if _, ok := msg.(contextSwitchedMsg); ok {
+		t.Fatal("SSO context should not finalize before login command runs")
+	}
+	if _, ok := msg.(ssoLoginDoneMsg); ok {
+		t.Fatal("SSO login command should be handed to Bubble Tea before completion")
+	}
+	if !buildCalled {
+		t.Fatal("expected login command to be built when cache is missing")
 	}
 }
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -15,6 +15,8 @@ import (
 	awsservice "unic/internal/services/aws"
 )
 
+var ensureSSOLoginFn = awsservice.EnsureSSOLogin
+
 // PostSwitch performs the auth action after switching to a context.
 // Returns a human-readable status message.
 func PostSwitch(cfg *config.Config) (string, error) {
@@ -50,11 +52,15 @@ func PostSwitch(cfg *config.Config) (string, error) {
 }
 
 func postSwitchSSO(cfg *config.Config) (string, error) {
-	uniclog.Debug("auth", "starting SSO login", "sso_start_url", cfg.SSOStartURL)
-	if err := awsservice.RunSSOLogin(cfg); err != nil {
+	uniclog.Debug("auth", "ensuring SSO login", "sso_start_url", cfg.SSOStartURL)
+	result, err := ensureSSOLoginFn(cfg)
+	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("SSO login complete for %s (account: %s, role: %s)", cfg.SSOStartURL, cfg.SSOAccountID, cfg.SSORoleName), nil
+	if result.Refreshed {
+		return fmt.Sprintf("SSO login refreshed for %s (account: %s, role: %s)", result.StartURL, cfg.SSOAccountID, cfg.SSORoleName), nil
+	}
+	return fmt.Sprintf("SSO session active for %s (cached; account: %s, role: %s)", result.StartURL, cfg.SSOAccountID, cfg.SSORoleName), nil
 }
 
 func postSwitchCredential(cfg *config.Config) (string, error) {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,61 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+
+	"unic/internal/config"
+	awsservice "unic/internal/services/aws"
+)
+
+func testPostSwitchSSOCfg() *config.Config {
+	return &config.Config{
+		ContextName:  "dev-sso",
+		AuthType:     config.AuthTypeSSO,
+		Region:       "us-east-1",
+		SSOStartURL:  "https://example.awsapps.com/start",
+		SSOAccountID: "123456789012",
+		SSORoleName:  "AdministratorAccess",
+	}
+}
+
+func TestPostSwitchSSOReportsCachedSession(t *testing.T) {
+	origEnsure := ensureSSOLoginFn
+	defer func() { ensureSSOLoginFn = origEnsure }()
+	ensureSSOLoginFn = func(*config.Config) (awsservice.SSOLoginResult, error) {
+		return awsservice.SSOLoginResult{
+			StartURL: "https://example.awsapps.com/start",
+		}, nil
+	}
+
+	msg, err := postSwitchSSO(testPostSwitchSSOCfg())
+	if err != nil {
+		t.Fatalf("expected cached SSO post-switch to succeed, got %v", err)
+	}
+	for _, want := range []string{"SSO session active", "cached", "123456789012", "AdministratorAccess"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("expected %q in message %q", want, msg)
+		}
+	}
+}
+
+func TestPostSwitchSSOReportsRefreshedLogin(t *testing.T) {
+	origEnsure := ensureSSOLoginFn
+	defer func() { ensureSSOLoginFn = origEnsure }()
+	ensureSSOLoginFn = func(*config.Config) (awsservice.SSOLoginResult, error) {
+		return awsservice.SSOLoginResult{
+			StartURL:  "https://example.awsapps.com/start",
+			Refreshed: true,
+		}, nil
+	}
+
+	msg, err := postSwitchSSO(testPostSwitchSSOCfg())
+	if err != nil {
+		t.Fatalf("expected refreshed SSO post-switch to succeed, got %v", err)
+	}
+	for _, want := range []string{"SSO login refreshed", "123456789012", "AdministratorAccess"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("expected %q in message %q", want, msg)
+		}
+	}
+}

--- a/internal/services/aws/sso.go
+++ b/internal/services/aws/sso.go
@@ -44,6 +44,8 @@ var newSSOClient = func(cfg aws.Config) SSOClientAPI {
 	return sso.NewFromConfig(cfg)
 }
 
+var runSSOLoginFn = RunSSOLogin
+
 // ssoTokenCache represents the cached SSO token file structure.
 type ssoTokenCache struct {
 	AccessToken string `json:"accessToken"`
@@ -52,22 +54,23 @@ type ssoTokenCache struct {
 	StartURL    string `json:"startUrl"`
 }
 
+// SSOSessionCheck describes whether a cached AWS CLI SSO session can be reused.
+type SSOSessionCheck struct {
+	StartURL      string
+	LoginRequired bool
+}
+
+// SSOLoginResult describes whether EnsureSSOLogin reused cache or refreshed login.
+type SSOLoginResult struct {
+	StartURL  string
+	Refreshed bool
+}
+
 // resolveSSOCredentials handles SSO authentication and returns an aws.Config with SSO credentials.
 func resolveSSOCredentials(ctx context.Context, cfg *config.Config) (aws.Config, error) {
-	startURL, err := resolveSSOStartURL(cfg)
+	token, err := ensureSSOToken(cfg)
 	if err != nil {
 		return aws.Config{}, err
-	}
-	token, err := loadSSOToken(startURL)
-	if err != nil || isTokenExpired(token) {
-		// Token missing or expired — run aws sso login
-		if err := RunSSOLogin(cfg); err != nil {
-			return aws.Config{}, fmt.Errorf("SSO login failed: %w", err)
-		}
-		token, err = loadSSOToken(startURL)
-		if err != nil {
-			return aws.Config{}, fmt.Errorf("failed to read SSO token after login: %w", err)
-		}
 	}
 
 	// Use the SSO token to get role credentials
@@ -101,6 +104,18 @@ func ResolveSSOCredentials(ctx context.Context, cfg *config.Config) (aws.Config,
 	return resolveSSOCredentials(ctx, cfg)
 }
 
+// CheckSSOSession reports whether the AWS CLI SSO token cache can be reused.
+func CheckSSOSession(cfg *config.Config) (SSOSessionCheck, error) {
+	_, check, err := checkSSOToken(cfg)
+	return check, err
+}
+
+// EnsureSSOLogin reuses a valid cached AWS CLI SSO token or runs login if needed.
+func EnsureSSOLogin(cfg *config.Config) (SSOLoginResult, error) {
+	_, result, err := ensureSSOTokenWithResult(cfg)
+	return result, err
+}
+
 // loadSSOToken reads the cached SSO token for the given start URL.
 func loadSSOToken(startURL string) (*ssoTokenCache, error) {
 	cacheDir, err := ssoTokenCacheDir()
@@ -126,23 +141,48 @@ func loadSSOToken(startURL string) (*ssoTokenCache, error) {
 	return &token, nil
 }
 
-func ensureSSOToken(cfg *config.Config) (*ssoTokenCache, error) {
+func checkSSOToken(cfg *config.Config) (*ssoTokenCache, SSOSessionCheck, error) {
 	startURL, err := resolveSSOStartURL(cfg)
 	if err != nil {
-		return nil, err
+		return nil, SSOSessionCheck{}, err
 	}
+	check := SSOSessionCheck{StartURL: startURL}
 	token, err := loadSSOToken(startURL)
 	if err == nil && !isTokenExpired(token) {
-		return token, nil
+		return token, check, nil
 	}
-	if err := RunSSOLogin(cfg); err != nil {
-		return nil, fmt.Errorf("SSO login failed: %w", err)
-	}
-	token, err = loadSSOToken(startURL)
+
+	check.LoginRequired = true
+	return nil, check, nil
+}
+
+func ensureSSOToken(cfg *config.Config) (*ssoTokenCache, error) {
+	token, _, err := ensureSSOTokenWithResult(cfg)
+	return token, err
+}
+
+func ensureSSOTokenWithResult(cfg *config.Config) (*ssoTokenCache, SSOLoginResult, error) {
+	token, check, err := checkSSOToken(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read SSO token after login: %w", err)
+		return nil, SSOLoginResult{}, err
 	}
-	return token, nil
+	result := SSOLoginResult{StartURL: check.StartURL}
+	if !check.LoginRequired {
+		return token, result, nil
+	}
+
+	if err := runSSOLoginFn(cfg); err != nil {
+		return nil, SSOLoginResult{}, fmt.Errorf("SSO login failed: %w", err)
+	}
+	token, err = loadSSOToken(check.StartURL)
+	if err != nil {
+		return nil, SSOLoginResult{}, fmt.Errorf("failed to read SSO token after login: %w", err)
+	}
+	if isTokenExpired(token) {
+		return nil, SSOLoginResult{}, fmt.Errorf("SSO token is still expired after login")
+	}
+	result.Refreshed = true
+	return token, result, nil
 }
 
 // ListSSOAccounts lists accessible AWS accounts for the configured SSO start URL.

--- a/internal/services/aws/sso_test.go
+++ b/internal/services/aws/sso_test.go
@@ -1,0 +1,143 @@
+package aws
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"unic/internal/config"
+)
+
+const testSSOStartURL = "https://example.awsapps.com/start"
+
+func testSSOConfig() *config.Config {
+	return &config.Config{
+		ContextName:  "dev-sso",
+		AuthType:     config.AuthTypeSSO,
+		Region:       "us-east-1",
+		SSOStartURL:  testSSOStartURL,
+		SSOAccountID: "123456789012",
+		SSORoleName:  "AdministratorAccess",
+	}
+}
+
+func writeTestSSOToken(t *testing.T, home string, startURL string, expiresAt time.Time) {
+	t.Helper()
+	cacheDir := filepath.Join(home, ".aws", "sso", "cache")
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	token := ssoTokenCache{
+		AccessToken: "cached-token",
+		ExpiresAt:   expiresAt.UTC().Format(time.RFC3339),
+		Region:      "us-east-1",
+		StartURL:    startURL,
+	}
+	data, err := json.Marshal(token)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hash := sha1.Sum([]byte(startURL))
+	filename := hex.EncodeToString(hash[:]) + ".json"
+	if err := os.WriteFile(filepath.Join(cacheDir, filename), data, 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckSSOSessionUsesValidCachedToken(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeTestSSOToken(t, home, testSSOStartURL, time.Now().Add(time.Hour))
+
+	check, err := CheckSSOSession(testSSOConfig())
+	if err != nil {
+		t.Fatalf("expected session check to succeed, got %v", err)
+	}
+	if check.LoginRequired {
+		t.Fatal("expected valid cached SSO token to skip login")
+	}
+	if check.StartURL != testSSOStartURL {
+		t.Fatalf("expected start URL %q, got %q", testSSOStartURL, check.StartURL)
+	}
+}
+
+func TestEnsureSSOLoginReusesValidCachedToken(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeTestSSOToken(t, home, testSSOStartURL, time.Now().Add(time.Hour))
+
+	origRunLogin := runSSOLoginFn
+	defer func() { runSSOLoginFn = origRunLogin }()
+	runSSOLoginFn = func(*config.Config) error {
+		t.Fatal("RunSSOLogin should not be called with a valid cached token")
+		return nil
+	}
+
+	result, err := EnsureSSOLogin(testSSOConfig())
+	if err != nil {
+		t.Fatalf("expected cached SSO login to succeed, got %v", err)
+	}
+	if result.Refreshed {
+		t.Fatal("expected cached SSO token to be reused")
+	}
+	if result.StartURL != testSSOStartURL {
+		t.Fatalf("expected start URL %q, got %q", testSSOStartURL, result.StartURL)
+	}
+}
+
+func TestEnsureSSOLoginRunsLoginWhenTokenMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origRunLogin := runSSOLoginFn
+	defer func() { runSSOLoginFn = origRunLogin }()
+	loginCalls := 0
+	runSSOLoginFn = func(*config.Config) error {
+		loginCalls++
+		writeTestSSOToken(t, home, testSSOStartURL, time.Now().Add(time.Hour))
+		return nil
+	}
+
+	result, err := EnsureSSOLogin(testSSOConfig())
+	if err != nil {
+		t.Fatalf("expected missing SSO token to trigger login, got %v", err)
+	}
+	if loginCalls != 1 {
+		t.Fatalf("expected one login call, got %d", loginCalls)
+	}
+	if !result.Refreshed {
+		t.Fatal("expected login result to report a refreshed session")
+	}
+}
+
+func TestEnsureSSOLoginRunsLoginWhenTokenExpired(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeTestSSOToken(t, home, testSSOStartURL, time.Now().Add(-time.Hour))
+
+	origRunLogin := runSSOLoginFn
+	defer func() { runSSOLoginFn = origRunLogin }()
+	loginCalls := 0
+	runSSOLoginFn = func(*config.Config) error {
+		loginCalls++
+		writeTestSSOToken(t, home, testSSOStartURL, time.Now().Add(time.Hour))
+		return nil
+	}
+
+	result, err := EnsureSSOLogin(testSSOConfig())
+	if err != nil {
+		t.Fatalf("expected expired SSO token to trigger login, got %v", err)
+	}
+	if loginCalls != 1 {
+		t.Fatalf("expected one login call, got %d", loginCalls)
+	}
+	if !result.Refreshed {
+		t.Fatal("expected login result to report a refreshed session")
+	}
+}


### PR DESCRIPTION
### Summary

- add cache-aware SSO session checks that reuse valid AWS CLI SSO cache entries
- skip the TUI Attempting to open your default browser.
If the browser does not open, open the following URL:

https://oidc.ap-northeast-2.amazonaws.com/authorize?response_type=code&client_id=7JgCbgFojE5mEMo5Kj9X5GFwLW5vcnRoZWFzdC0y&redirect_uri=http%3A%2F%2F127.0.0.1%3A50321%2Foauth%2Fcallback&state=d972e3c6-47a2-44b0-81fd-72e5f8bfded5&code_challenge_method=S256&scopes=sso%3Aaccount%3Aaccess&code_challenge=TbEatLm-BX5nUDj8bbtOpoAvSdhe7EyyXGr0A17Ws50 handoff when an SSO token is still valid
- keep login refresh behavior for missing, expired, or unreadable SSO cache entries
- update post-switch SSO messages, README auth behavior, and tests

### Related Issues

Closes #159

### Validation

- go test ./internal/services/aws ./internal/auth ./internal/app
- make test
- make build

### Checklist

- [x] Scope is focused
- [x] Branch name follows docs/branch-naming-harness.md
- [x] Documentation harness reviewed (docs/documentation-harness.md)
- [x] README updated if user-facing behavior changed
- [x] Relevant docs/ pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented