### PR TITLE
feat: improve list filtering and navigation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 APP_NAME := unic
-VERSION  := 0.0.4
+VERSION  := 0.1.3
 DIST_DIR := dist
 CMD_PATH := ./cmd/unic
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ current: dev-sso
 defaults:
   region: ap-northeast-2
 
+favorites:
+  services:
+    - Bedrock
+    - ECS
+
 contexts:
   - name: dev-sso
     order: 10
@@ -305,7 +310,7 @@ checks:
 | `i` | Enter Inspector mode from the service list |
 | `C` | Open context picker |
 | `/` | Toggle filter mode on supported screens |
-| `s` | Toggle name/catalog sorting on the service list |
+| `f` | Favorite/unfavorite the selected service on the service list |
 | `?` | Toggle context-aware shortcut help |
 | `Ctrl+C` | Force quit |
 
@@ -330,7 +335,7 @@ checks:
 | Context Picker | `a` add context, type or `/` filter, `s` setup selected context and quit, `y` copy selected exports and quit, `u` clear shell context and quit with a final confirmation message |
 | Lambda | `Enter` invoke, `d` detail, `l` view CloudWatch Logs, `/` filter, `r` refresh |
 
-The service list supports `/` filtering across service names, feature names, and feature descriptions, plus `s` to toggle catalog/name sorting. Shared list filters use fuzzy matching with inline match highlighting. While filter mode stays active, `↑`/`↓` continue to move through the filtered results without requiring an extra Enter first. Filtering is currently available on the service list, EC2 instances, IAM users, VPCs, subnets, RDS instances, Route53 zones/records, CloudWatch metrics, CloudWatch log groups/streams, Secrets Manager resources, ECS clusters/services, S3 buckets/objects, Lambda functions, Bedrock API keys, and the context picker.
+The service list defaults to favorites first, then alphabetical order. Press `f` to favorite or unfavorite the selected service; favorites are saved under `favorites.services` in `config.yaml` and rendered with a distinct marker/style. The service list supports `/` filtering across service names, feature names, and feature descriptions. Shared list filters use fuzzy matching with inline match highlighting. While filter mode stays active, `↑`/`↓` continue to move through the filtered results without requiring an extra Enter first. Filtering is currently available on the service list, EC2 instances, IAM users, VPCs, subnets, RDS instances, Route53 zones/records, CloudWatch metrics, CloudWatch log groups/streams, Secrets Manager resources, ECS clusters/services, S3 buckets/objects, Lambda functions, Bedrock API keys, and the context picker.
 
 Bedrock API key management uses the active unic AWS context and IAM service-specific credential APIs for `bedrock.amazonaws.com`. The TUI lists long-term Bedrock API key metadata, opens a detail screen for inspection, defaults new key generation to the current IAM user when that user can be inferred from caller identity, and keeps another-user generation as an explicit option. Creation supports an optional expiration period, where blank or `0` means no expiration, rotates secrets with a one-time result screen, and deletes keys only after typed confirmation. Generated and rotated key values are intentionally copy-only and are not printed to the terminal; on the result screen, `c` copies the key and `e` copies `export AWS_BEARER_TOKEN_BEDROCK=...`.
 

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ checks:
 
 | Key | Action |
 |---|---|
-| `j` / `k`, `↑` / `↓` | Move selection |
+| `j` / `k`, `↑` / `↓` | Move selection, wrapping at list boundaries |
 | `Enter` | Select / drill down |
 | `Esc` | Go back |
 | `q` | Quit from top-level screens |
@@ -305,6 +305,7 @@ checks:
 | `i` | Enter Inspector mode from the service list |
 | `C` | Open context picker |
 | `/` | Toggle filter mode on supported screens |
+| `s` | Toggle name/catalog sorting on the service list |
 | `?` | Toggle context-aware shortcut help |
 | `Ctrl+C` | Force quit |
 
@@ -329,7 +330,7 @@ checks:
 | Context Picker | `a` add context, type or `/` filter, `s` setup selected context and quit, `y` copy selected exports and quit, `u` clear shell context and quit with a final confirmation message |
 | Lambda | `Enter` invoke, `d` detail, `l` view CloudWatch Logs, `/` filter, `r` refresh |
 
-Shared list filters now use fuzzy matching with inline match highlighting. While filter mode stays active, `↑`/`↓` continue to move through the filtered results without requiring an extra Enter first. Filtering is currently available on EC2 instances, IAM users, VPCs, subnets, RDS instances, Route53 zones/records, CloudWatch metrics, CloudWatch log groups/streams, Secrets Manager resources, ECS clusters/services, S3 buckets/objects, Lambda functions, Bedrock API keys, and the context picker.
+The service list supports `/` filtering across service names, feature names, and feature descriptions, plus `s` to toggle catalog/name sorting. Shared list filters use fuzzy matching with inline match highlighting. While filter mode stays active, `↑`/`↓` continue to move through the filtered results without requiring an extra Enter first. Filtering is currently available on the service list, EC2 instances, IAM users, VPCs, subnets, RDS instances, Route53 zones/records, CloudWatch metrics, CloudWatch log groups/streams, Secrets Manager resources, ECS clusters/services, S3 buckets/objects, Lambda functions, Bedrock API keys, and the context picker.
 
 Bedrock API key management uses the active unic AWS context and IAM service-specific credential APIs for `bedrock.amazonaws.com`. The TUI lists long-term Bedrock API key metadata, opens a detail screen for inspection, defaults new key generation to the current IAM user when that user can be inferred from caller identity, and keeps another-user generation as an explicit option. Creation supports an optional expiration period, where blank or `0` means no expiration, rotates secrets with a one-time result screen, and deletes keys only after typed confirmation. Generated and rotated key values are intentionally copy-only and are not printed to the terminal; on the result screen, `c` copies the key and `e` copies `export AWS_BEARER_TOKEN_BEDROCK=...`.
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -104,7 +104,7 @@ type Model struct {
 	services         []domain.Service
 	filteredServices []domain.Service
 	svcIdx           int
-	serviceSort      serviceSortMode
+	favoriteServices map[domain.AwsService]struct{}
 
 	// Feature selection
 	features []domain.Feature
@@ -352,6 +352,10 @@ func New(cfg *config.Config, configPath string, version string, checklistPath ..
 	if len(checklistPath) > 0 {
 		configuredChecklistPath = checklistPath[0]
 	}
+	var favoriteServiceNames []string
+	if cfg != nil {
+		favoriteServiceNames = cfg.FavoriteServices
+	}
 	model := Model{
 		cfg:                    cfg,
 		configPath:             configPath,
@@ -359,7 +363,7 @@ func New(cfg *config.Config, configPath string, version string, checklistPath ..
 		screen:                 screenContextPicker,
 		ctxPrevScreen:          screenServiceList,
 		services:               services,
-		filteredServices:       services,
+		favoriteServices:       favoriteServiceSet(favoriteServiceNames),
 		inspectorChecklistPath: configuredChecklistPath,
 		inspectorWorkflows:     inspector.Workflows(configuredChecklistPath),
 		loadingSpinner:         newLoadingSpinner(),
@@ -370,6 +374,7 @@ func New(cfg *config.Config, configPath string, version string, checklistPath ..
 	model.cwMetrics = newCloudWatchMetricsModel()
 	model.cwLogs = newCloudWatchLogsModel()
 	model.bedrock = newBedrockModel()
+	model.applyServiceListFilter()
 	return model
 }
 
@@ -696,8 +701,13 @@ func (m Model) updateServiceList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.svcIdx = nextListIndex(m.svcIdx, len(m.serviceList()))
 	case "/":
 		return m, m.activateFilter(filterServices)
-	case "s":
-		m.toggleServiceSort()
+	case "f":
+		if service, ok := m.selectedService(); ok {
+			if err := m.toggleFavoriteService(service.Name); err != nil {
+				m.errMsg = err.Error()
+				m.screen = screenError
+			}
+		}
 	case "i":
 		m.enterInspectorMode()
 	case "enter":
@@ -961,17 +971,25 @@ func (m Model) viewServiceList() string {
 				cursor = "> "
 				style = selectedStyle
 			}
-			panel.WriteString(style.Render(fmt.Sprintf("%s%s", cursor, m.renderHighlightedValue(filterServices, string(svc.Name)))))
+			favoriteMarker := "  "
+			if m.isFavoriteService(svc.Name) {
+				favoriteMarker = favoriteServiceStyle.Render("* ")
+			}
+			label := m.renderHighlightedValue(filterServices, string(svc.Name))
+			if m.isFavoriteService(svc.Name) {
+				label = favoriteServiceStyle.Render(label)
+			}
+			panel.WriteString(style.Render(cursor) + favoriteMarker + style.Render(label))
 			panel.WriteString("\n")
 		}
 
 		panel.WriteString("\n")
-		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d services • sort: %s", len(services), len(m.services), m.serviceSortLabel())))
+		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d services • %s", len(services), len(m.services), m.serviceListSummary())))
 	}
 
 	b.WriteString(m.renderListPanel(panel.String()))
 	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • s: sort • enter: select • i: Inspector mode • esc: context • q: quit"))
+	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • f: favorite • enter: select • i: Inspector mode • esc: context • q: quit"))
 	return b.String()
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -101,8 +101,10 @@ type Model struct {
 	exitTitle   string
 
 	// Service selection
-	services []domain.Service
-	svcIdx   int
+	services         []domain.Service
+	filteredServices []domain.Service
+	svcIdx           int
+	serviceSort      serviceSortMode
 
 	// Feature selection
 	features []domain.Feature
@@ -357,6 +359,7 @@ func New(cfg *config.Config, configPath string, version string, checklistPath ..
 		screen:                 screenContextPicker,
 		ctxPrevScreen:          screenServiceList,
 		services:               services,
+		filteredServices:       services,
 		inspectorChecklistPath: configuredChecklistPath,
 		inspectorWorkflows:     inspector.Workflows(configuredChecklistPath),
 		loadingSpinner:         newLoadingSpinner(),
@@ -673,26 +676,33 @@ func (m Model) handleSecretMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 }
 
 func (m Model) updateServiceList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
+	key := msg.String()
+
+	if cmd, handled := m.updateSharedFilter(msg, filterServices); handled {
+		return m, cmd
+	}
+
+	switch key {
 	case "q":
 		m.quitting = true
 		return m, tea.Quit
 	case "esc":
+		m.resetFilter(filterServices)
 		m.ctxPrevScreen = screenServiceList
 		return m, m.loadContexts()
 	case "up", "k":
-		if m.svcIdx > 0 {
-			m.svcIdx--
-		}
+		m.svcIdx = previousListIndex(m.svcIdx, len(m.serviceList()))
 	case "down", "j":
-		if m.svcIdx < len(m.services)-1 {
-			m.svcIdx++
-		}
+		m.svcIdx = nextListIndex(m.svcIdx, len(m.serviceList()))
+	case "/":
+		return m, m.activateFilter(filterServices)
+	case "s":
+		m.toggleServiceSort()
 	case "i":
 		m.enterInspectorMode()
 	case "enter":
-		if m.svcIdx < len(m.services) {
-			m.features = m.services[m.svcIdx].Features
+		if service, ok := m.selectedService(); ok {
+			m.features = service.Features
 			m.featIdx = 0
 			m.screen = screenFeatureList
 		}
@@ -705,13 +715,9 @@ func (m Model) updateFeatureList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "q", "esc":
 		m.screen = screenServiceList
 	case "up", "k":
-		if m.featIdx > 0 {
-			m.featIdx--
-		}
+		m.featIdx = previousListIndex(m.featIdx, len(m.features))
 	case "down", "j":
-		if m.featIdx < len(m.features)-1 {
-			m.featIdx++
-		}
+		m.featIdx = nextListIndex(m.featIdx, len(m.features))
 	case "enter":
 		if m.featIdx < len(m.features) {
 			feat := m.features[m.featIdx]
@@ -928,33 +934,44 @@ func (m Model) View() string {
 func (m Model) viewServiceList() string {
 	var b strings.Builder
 	var panel strings.Builder
+	services := m.serviceList()
 	b.WriteString(m.renderStatusBar())
 	b.WriteString(titleStyle.Render("Select AWS Service"))
+	b.WriteString("\n")
+	b.WriteString(m.renderFilterValue(filterServices))
 	b.WriteString("\n\n")
 
-	// overhead: status bar (2) + title (1) + blank (1) + list panel (2) + blank (1) + help bar (1) = 8
-	visibleLines := max(m.height-8, 3)
+	// overhead: status bar (2) + title (1) + filter (1) + blank (1) + list panel (2) + blank (1) + help bar (1) = 9
+	visibleLines := max(m.height-9, 3)
 	start := 0
 	if m.svcIdx >= visibleLines {
 		start = m.svcIdx - visibleLines + 1
 	}
-	end := min(start+visibleLines, len(m.services))
+	end := min(start+visibleLines, len(services))
 
-	for i := start; i < end; i++ {
-		svc := m.services[i]
-		cursor := "  "
-		style := normalStyle
-		if i == m.svcIdx {
-			cursor = "> "
-			style = selectedStyle
-		}
-		panel.WriteString(style.Render(fmt.Sprintf("%s%s", cursor, svc.Name)))
+	if len(services) == 0 {
+		panel.WriteString(dimStyle.Render("  No matching services"))
 		panel.WriteString("\n")
+	} else {
+		for i := start; i < end; i++ {
+			svc := services[i]
+			cursor := "  "
+			style := normalStyle
+			if i == m.svcIdx {
+				cursor = "> "
+				style = selectedStyle
+			}
+			panel.WriteString(style.Render(fmt.Sprintf("%s%s", cursor, m.renderHighlightedValue(filterServices, string(svc.Name)))))
+			panel.WriteString("\n")
+		}
+
+		panel.WriteString("\n")
+		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d services • sort: %s", len(services), len(m.services), m.serviceSortLabel())))
 	}
 
 	b.WriteString(m.renderListPanel(panel.String()))
 	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("↑/↓: navigate • enter: select • i: Inspector mode • esc: context • q: quit"))
+	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • s: sort • enter: select • i: Inspector mode • esc: context • q: quit"))
 	return b.String()
 }
 
@@ -962,7 +979,11 @@ func (m Model) viewFeatureList() string {
 	var b strings.Builder
 	var panel strings.Builder
 	b.WriteString(m.renderStatusBar())
-	svcName := m.services[m.svcIdx].Name
+	svc, ok := m.selectedService()
+	if !ok {
+		return m.viewServiceList()
+	}
+	svcName := svc.Name
 	b.WriteString(titleStyle.Render(fmt.Sprintf("%s > Select Feature", svcName)))
 	b.WriteString("\n\n")
 
@@ -1073,13 +1094,9 @@ func (m Model) updateSecretList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.screen = screenFeatureList
 		m.resetFilter(filterSecrets)
 	case "up", "k":
-		if m.secretIdx > 0 {
-			m.secretIdx--
-		}
+		m.secretIdx = previousListIndex(m.secretIdx, len(m.filteredSecrets))
 	case "down", "j":
-		if m.secretIdx < len(m.filteredSecrets)-1 {
-			m.secretIdx++
-		}
+		m.secretIdx = nextListIndex(m.secretIdx, len(m.filteredSecrets))
 	case "/":
 		return m, m.activateFilter(filterSecrets)
 	case "enter":

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -150,14 +150,106 @@ func TestLoadingSpinnerTickUpdatesOnlyOnLoadingScreen(t *testing.T) {
 	}
 }
 
+func TestListIndexHelpersWrapAndClamp(t *testing.T) {
+	if got := previousListIndex(0, 3); got != 2 {
+		t.Fatalf("expected previous from first to wrap to 2, got %d", got)
+	}
+	if got := nextListIndex(2, 3); got != 0 {
+		t.Fatalf("expected next from last to wrap to 0, got %d", got)
+	}
+	if got := previousListIndex(4, 0); got != 0 {
+		t.Fatalf("expected empty previous list to stay 0, got %d", got)
+	}
+	if got := clampListIndex(9, 3); got != 2 {
+		t.Fatalf("expected clamp to last index 2, got %d", got)
+	}
+}
+
 func TestServiceListNavigation(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenServiceList
-	// Press down — should move to index 1 (now 2 services: EC2, VPC)
+
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	model := updated.(Model)
 	if model.svcIdx != 1 {
 		t.Errorf("expected svcIdx 1 after pressing j, got %d", model.svcIdx)
+	}
+}
+
+func TestServiceListNavigationWraps(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenServiceList
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	model := updated.(Model)
+	if got, want := model.svcIdx, len(model.serviceList())-1; got != want {
+		t.Fatalf("expected up from first service to wrap to %d, got %d", want, got)
+	}
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	model = updated.(Model)
+	if model.svcIdx != 0 {
+		t.Fatalf("expected down from last service to wrap to 0, got %d", model.svcIdx)
+	}
+}
+
+func TestFeatureListNavigationWraps(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenFeatureList
+	m.features = []domain.Feature{
+		{Kind: domain.FeatureSSMSession},
+		{Kind: domain.FeatureSecurityGroupBrowser},
+	}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	model := updated.(Model)
+	if model.featIdx != 1 {
+		t.Fatalf("expected up from first feature to wrap to last, got %d", model.featIdx)
+	}
+}
+
+func TestServiceListFiltersByFeatureDescription(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenServiceList
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	model := updated.(Model)
+	for _, ch := range []rune("long-term") {
+		updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{ch}})
+		model = updated.(Model)
+	}
+
+	if got := len(model.filteredServices); got != 1 {
+		t.Fatalf("expected 1 service matching feature description, got %d", got)
+	}
+	if got := model.filteredServices[0].Name; got != domain.ServiceBedrock {
+		t.Fatalf("expected Bedrock to match feature description, got %s", got)
+	}
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	if model.screen != screenFeatureList {
+		t.Fatalf("expected filtered service enter to open feature list, got %v", model.screen)
+	}
+	if got := model.features[0].Kind; got != domain.FeatureBedrockAPIKeys {
+		t.Fatalf("expected Bedrock feature after filtered enter, got %s", got)
+	}
+}
+
+func TestServiceListSortByName(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenServiceList
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	model := updated.(Model)
+
+	if model.serviceSort != serviceSortName {
+		t.Fatalf("expected service sort mode name, got %v", model.serviceSort)
+	}
+	if got := model.filteredServices[0].Name; got != domain.ServiceBedrock {
+		t.Fatalf("expected Bedrock first in name sort, got %s", got)
 	}
 }
 
@@ -168,6 +260,27 @@ func TestServiceListEnterGoesToFeatures(t *testing.T) {
 	model := updated.(Model)
 	if model.screen != screenFeatureList {
 		t.Errorf("expected feature list screen, got %d", model.screen)
+	}
+}
+
+func TestRDSListNavigationWraps(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenRDSList
+	m.filteredRDS = []awsservice.RDSInstance{
+		{DBInstanceID: "db-a"},
+		{DBInstanceID: "db-b"},
+	}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	model := updated.(Model)
+	if model.rdsIdx != 1 {
+		t.Fatalf("expected up from first RDS instance to wrap to last, got %d", model.rdsIdx)
+	}
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	model = updated.(Model)
+	if model.rdsIdx != 0 {
+		t.Fatalf("expected down from last RDS instance to wrap to first, got %d", model.rdsIdx)
 	}
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -238,18 +238,64 @@ func TestServiceListFiltersByFeatureDescription(t *testing.T) {
 	}
 }
 
-func TestServiceListSortByName(t *testing.T) {
+func TestServiceListDefaultsToAlphabeticalOrder(t *testing.T) {
 	m := New(testConfig(), "", "dev")
-	m.screen = screenServiceList
 
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
-	model := updated.(Model)
-
-	if model.serviceSort != serviceSortName {
-		t.Fatalf("expected service sort mode name, got %v", model.serviceSort)
-	}
-	if got := model.filteredServices[0].Name; got != domain.ServiceBedrock {
+	if got := m.filteredServices[0].Name; got != domain.ServiceBedrock {
 		t.Fatalf("expected Bedrock first in name sort, got %s", got)
+	}
+}
+
+func TestServiceListFavoritesSortFirst(t *testing.T) {
+	cfg := testConfig()
+	cfg.FavoriteServices = []string{string(domain.ServiceRDS)}
+	m := New(cfg, "", "dev")
+
+	if got := m.filteredServices[0].Name; got != domain.ServiceRDS {
+		t.Fatalf("expected favorite service first, got %s", got)
+	}
+	if !m.isFavoriteService(domain.ServiceRDS) {
+		t.Fatal("expected RDS to be tracked as a favorite")
+	}
+}
+
+func TestServiceListFavoriteTogglePersists(t *testing.T) {
+	originalSetFavoriteServicesFn := configSetFavoriteServicesFn
+	t.Cleanup(func() {
+		configSetFavoriteServicesFn = originalSetFavoriteServicesFn
+	})
+
+	var gotPath string
+	var gotFavorites []string
+	configSetFavoriteServicesFn = func(path string, services []string) error {
+		gotPath = path
+		gotFavorites = append([]string(nil), services...)
+		return nil
+	}
+
+	cfg := testConfig()
+	m := New(cfg, "/tmp/unic-test-config.yaml", "dev")
+	m.screen = screenServiceList
+	for i, svc := range m.filteredServices {
+		if svc.Name == domain.ServiceRDS {
+			m.svcIdx = i
+			break
+		}
+	}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	model := updated.(Model)
+	if gotPath != "/tmp/unic-test-config.yaml" {
+		t.Fatalf("expected favorite persistence path, got %q", gotPath)
+	}
+	if len(gotFavorites) != 1 || gotFavorites[0] != string(domain.ServiceRDS) {
+		t.Fatalf("expected persisted RDS favorite, got %v", gotFavorites)
+	}
+	if model.filteredServices[0].Name != domain.ServiceRDS {
+		t.Fatalf("expected toggled favorite to move first, got %s", model.filteredServices[0].Name)
+	}
+	if len(cfg.FavoriteServices) != 1 || cfg.FavoriteServices[0] != string(domain.ServiceRDS) {
+		t.Fatalf("expected config favorite services to update, got %v", cfg.FavoriteServices)
 	}
 }
 

--- a/internal/app/context_add.go
+++ b/internal/app/context_add.go
@@ -60,13 +60,9 @@ func (m Model) updateContextAdd(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "esc":
 			return m, m.loadContexts()
 		case "up", "k":
-			if m.addAuthIdx > 0 {
-				m.addAuthIdx--
-			}
+			m.addAuthIdx = previousListIndex(m.addAuthIdx, len(authTypes))
 		case "down", "j":
-			if m.addAuthIdx < len(authTypes)-1 {
-				m.addAuthIdx++
-			}
+			m.addAuthIdx = nextListIndex(m.addAuthIdx, len(authTypes))
 		case "enter":
 			selected := authTypes[m.addAuthIdx]
 			m.addValues["auth_type"] = selected

--- a/internal/app/context_terminal.go
+++ b/internal/app/context_terminal.go
@@ -193,13 +193,9 @@ func (m Model) updateContextSSOAccountList(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 	case "esc":
 		m.screen = screenContextPicker
 	case "up", "k":
-		if m.contextSSOAccountIdx > 0 {
-			m.contextSSOAccountIdx--
-		}
+		m.contextSSOAccountIdx = previousListIndex(m.contextSSOAccountIdx, len(m.contextSSOAccounts))
 	case "down", "j":
-		if m.contextSSOAccountIdx < len(m.contextSSOAccounts)-1 {
-			m.contextSSOAccountIdx++
-		}
+		m.contextSSOAccountIdx = nextListIndex(m.contextSSOAccountIdx, len(m.contextSSOAccounts))
 	case "enter":
 		if len(m.contextSSOAccounts) == 0 {
 			return m, nil
@@ -221,13 +217,9 @@ func (m Model) updateContextSSORoleList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "esc":
 		m.screen = screenContextSSOAccountList
 	case "up", "k":
-		if m.contextSSORoleIdx > 0 {
-			m.contextSSORoleIdx--
-		}
+		m.contextSSORoleIdx = previousListIndex(m.contextSSORoleIdx, len(m.contextSSORoles))
 	case "down", "j":
-		if m.contextSSORoleIdx < len(m.contextSSORoles)-1 {
-			m.contextSSORoleIdx++
-		}
+		m.contextSSORoleIdx = nextListIndex(m.contextSSORoleIdx, len(m.contextSSORoles))
 	case "enter":
 		if len(m.contextSSORoles) == 0 {
 			return m, nil

--- a/internal/app/filter.go
+++ b/internal/app/filter.go
@@ -9,6 +9,7 @@ type filterTarget int
 
 const (
 	filterNone filterTarget = iota
+	filterServices
 	filterInstances
 	filterSubnetIPs
 	filterRDS
@@ -156,6 +157,8 @@ func (m *Model) applyFilterTarget(target filterTarget) {
 	}
 
 	switch target {
+	case filterServices:
+		m.applyServiceListFilter()
 	case filterInstances:
 		m.filtered = applyFilter(m.instances, m.filterValue(target))
 		m.instIdx = 0

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -118,7 +118,7 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 		return []helpShortcut{
 			{"↑/↓, j/k", "Move between AWS services"},
 			{"/", "Start filtering services"},
-			{"s", "Toggle service sort order"},
+			{"f", "Favorite or unfavorite the selected service"},
 			{"enter", "Open the selected service"},
 			{"i", "Open Inspector mode"},
 			{"esc", "Open the context picker"},

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -117,6 +117,8 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 	case screenServiceList:
 		return []helpShortcut{
 			{"↑/↓, j/k", "Move between AWS services"},
+			{"/", "Start filtering services"},
+			{"s", "Toggle service sort order"},
 			{"enter", "Open the selected service"},
 			{"i", "Open Inspector mode"},
 			{"esc", "Open the context picker"},
@@ -667,8 +669,8 @@ func (m Model) helpScreenTitle() string {
 	case screenServiceList:
 		return "Service List"
 	case screenFeatureList:
-		if len(m.services) > 0 && m.svcIdx < len(m.services) {
-			return fmt.Sprintf("%s Feature List", m.services[m.svcIdx].Name)
+		if service, ok := m.selectedService(); ok {
+			return fmt.Sprintf("%s Feature List", service.Name)
 		}
 		return "Feature List"
 	case screenInstanceList:

--- a/internal/app/list_navigation.go
+++ b/internal/app/list_navigation.go
@@ -1,0 +1,34 @@
+package app
+
+func previousListIndex(index, length int) int {
+	if length <= 0 {
+		return 0
+	}
+	if index <= 0 || index >= length {
+		return length - 1
+	}
+	return index - 1
+}
+
+func nextListIndex(index, length int) int {
+	if length <= 0 {
+		return 0
+	}
+	if index < 0 || index >= length-1 {
+		return 0
+	}
+	return index + 1
+}
+
+func clampListIndex(index, length int) int {
+	if length <= 0 {
+		return 0
+	}
+	if index < 0 {
+		return 0
+	}
+	if index >= length {
+		return length - 1
+	}
+	return index
+}

--- a/internal/app/screen_bedrock.go
+++ b/internal/app/screen_bedrock.go
@@ -234,13 +234,9 @@ func (bm *bedrockModel) updateList(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd
 		bm.selectedKey = nil
 		m.resetFilter(filterBedrockKeys)
 	case "up", "k":
-		if bm.keyIdx > 0 {
-			bm.keyIdx--
-		}
+		bm.keyIdx = previousListIndex(bm.keyIdx, len(bm.filteredKeys))
 	case "down", "j":
-		if bm.keyIdx < len(bm.filteredKeys)-1 {
-			bm.keyIdx++
-		}
+		bm.keyIdx = nextListIndex(bm.keyIdx, len(bm.filteredKeys))
 	case "/":
 		return *m, m.activateFilter(filterBedrockKeys)
 	case "c":
@@ -302,12 +298,12 @@ func (bm *bedrockModel) updateCreate(m *Model, msg tea.KeyMsg) (tea.Model, tea.C
 		m.screen = screenBedrockKeyList
 		bm.status = ""
 	case "up", "k":
-		if bm.createField == bedrockCreateFieldMode && bm.createMode > 0 {
-			bm.createMode--
+		if bm.createField == bedrockCreateFieldMode {
+			bm.createMode = previousListIndex(bm.createMode, 2)
 		}
 	case "down", "j":
-		if bm.createField == bedrockCreateFieldMode && bm.createMode < 1 {
-			bm.createMode++
+		if bm.createField == bedrockCreateFieldMode {
+			bm.createMode = nextListIndex(bm.createMode, 2)
 		}
 	case "enter":
 		if bm.createValues == nil {

--- a/internal/app/screen_cloudwatchlogs.go
+++ b/internal/app/screen_cloudwatchlogs.go
@@ -257,13 +257,9 @@ func (cw *cloudWatchLogsModel) updateGroupList(m *Model, msg tea.KeyMsg) (tea.Mo
 		m.screen = screenFeatureList
 		m.resetFilter(filterCWLogGroups)
 	case "up", "k":
-		if cw.groupIdx > 0 {
-			cw.groupIdx--
-		}
+		cw.groupIdx = previousListIndex(cw.groupIdx, len(cw.filteredGroups))
 	case "down", "j":
-		if cw.groupIdx < len(cw.filteredGroups)-1 {
-			cw.groupIdx++
-		}
+		cw.groupIdx = nextListIndex(cw.groupIdx, len(cw.filteredGroups))
 	case "/":
 		return *m, m.activateFilter(filterCWLogGroups)
 	case "n":
@@ -371,13 +367,9 @@ func (cw *cloudWatchLogsModel) updateStreamList(m *Model, msg tea.KeyMsg) (tea.M
 		}
 		m.resetFilter(filterCWLogStreams)
 	case "up", "k":
-		if cw.streamIdx > 0 {
-			cw.streamIdx--
-		}
+		cw.streamIdx = previousListIndex(cw.streamIdx, len(cw.filteredStreams))
 	case "down", "j":
-		if cw.streamIdx < len(cw.filteredStreams)-1 {
-			cw.streamIdx++
-		}
+		cw.streamIdx = nextListIndex(cw.streamIdx, len(cw.filteredStreams))
 	case "/":
 		return *m, m.activateFilter(filterCWLogStreams)
 	case "n":

--- a/internal/app/screen_cloudwatchmetrics.go
+++ b/internal/app/screen_cloudwatchmetrics.go
@@ -210,13 +210,9 @@ func (cw *cloudWatchMetricsModel) updateMetricList(m *Model, msg tea.KeyMsg) (te
 		m.screen = screenFeatureList
 		m.resetFilter(filterCWMetrics)
 	case "up", "k":
-		if cw.metricIdx > 0 {
-			cw.metricIdx--
-		}
+		cw.metricIdx = previousListIndex(cw.metricIdx, len(cw.filteredCWMetrics))
 	case "down", "j":
-		if cw.metricIdx < len(cw.filteredCWMetrics)-1 {
-			cw.metricIdx++
-		}
+		cw.metricIdx = nextListIndex(cw.metricIdx, len(cw.filteredCWMetrics))
 	case "/":
 		return *m, m.activateFilter(filterCWMetrics)
 	case "r":

--- a/internal/app/screen_context.go
+++ b/internal/app/screen_context.go
@@ -127,6 +127,12 @@ func (m Model) updateContextPicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "/":
 		return m, m.activateFilter(filterContexts)
+	case "up", "k":
+		m.ctxIdx = previousListIndex(m.ctxIdx, len(m.filteredCtxList))
+		m.contextTable.SetCursor(m.ctxIdx)
+	case "down", "j":
+		m.ctxIdx = nextListIndex(m.ctxIdx, len(m.filteredCtxList))
+		m.contextTable.SetCursor(m.ctxIdx)
 	case "enter":
 		cursor := m.contextTable.Cursor()
 		if len(m.filteredCtxList) > 0 && cursor >= 0 && cursor < len(m.filteredCtxList) {

--- a/internal/app/screen_context_test.go
+++ b/internal/app/screen_context_test.go
@@ -86,6 +86,35 @@ func TestContextPickerNavigationUsesTableModel(t *testing.T) {
 	}
 }
 
+func TestContextPickerNavigationWraps(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.width = 80
+	m.height = 20
+
+	updated, _ := m.Update(contextsLoadedMsg{contexts: testContexts()})
+	model := updated.(Model)
+	model.ctxIdx = 0
+	model.contextTable.SetCursor(0)
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	model = updated.(Model)
+	if model.ctxIdx != 2 {
+		t.Fatalf("expected up from first context to wrap to last, got %d", model.ctxIdx)
+	}
+	if model.contextTable.Cursor() != 2 {
+		t.Fatalf("expected table cursor to wrap to last, got %d", model.contextTable.Cursor())
+	}
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	model = updated.(Model)
+	if model.ctxIdx != 0 {
+		t.Fatalf("expected down from last context to wrap to first, got %d", model.ctxIdx)
+	}
+	if model.contextTable.Cursor() != 0 {
+		t.Fatalf("expected table cursor to wrap to first, got %d", model.contextTable.Cursor())
+	}
+}
+
 func TestContextPickerFilterUpdatesTableRows(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.width = 80

--- a/internal/app/screen_ec2.go
+++ b/internal/app/screen_ec2.go
@@ -90,13 +90,9 @@ func (m Model) updateInstanceList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.screen = screenFeatureList
 		m.resetFilter(filterInstances)
 	case "up", "k":
-		if m.instIdx > 0 {
-			m.instIdx--
-		}
+		m.instIdx = previousListIndex(m.instIdx, len(m.filtered))
 	case "down", "j":
-		if m.instIdx < len(m.filtered)-1 {
-			m.instIdx++
-		}
+		m.instIdx = nextListIndex(m.instIdx, len(m.filtered))
 	case "/":
 		return m, m.activateFilter(filterInstances)
 	case "r":

--- a/internal/app/screen_ecs.go
+++ b/internal/app/screen_ecs.go
@@ -86,13 +86,9 @@ func (m Model) updateECSClusterList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "q", "esc":
 		m.screen = screenFeatureList
 	case "up", "k":
-		if m.ecsClusterIdx > 0 {
-			m.ecsClusterIdx--
-		}
+		m.ecsClusterIdx = previousListIndex(m.ecsClusterIdx, len(m.filteredECSClusters))
 	case "down", "j":
-		if m.ecsClusterIdx < len(m.filteredECSClusters)-1 {
-			m.ecsClusterIdx++
-		}
+		m.ecsClusterIdx = nextListIndex(m.ecsClusterIdx, len(m.filteredECSClusters))
 	case "/":
 		return m, m.activateFilter(filterECSClusters)
 	case "r":
@@ -163,13 +159,9 @@ func (m Model) updateECSServiceList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "q", "esc":
 		m.screen = screenECSClusterList
 	case "up", "k":
-		if m.ecsServiceIdx > 0 {
-			m.ecsServiceIdx--
-		}
+		m.ecsServiceIdx = previousListIndex(m.ecsServiceIdx, len(m.filteredECSServices))
 	case "down", "j":
-		if m.ecsServiceIdx < len(m.filteredECSServices)-1 {
-			m.ecsServiceIdx++
-		}
+		m.ecsServiceIdx = nextListIndex(m.ecsServiceIdx, len(m.filteredECSServices))
 	case "/":
 		return m, m.activateFilter(filterECSServices)
 	case "r":
@@ -379,13 +371,9 @@ func (m Model) updateECSTaskList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "q", "esc":
 		m.screen = screenECSServiceDetail
 	case "up", "k":
-		if m.ecsTaskIdx > 0 {
-			m.ecsTaskIdx--
-		}
+		m.ecsTaskIdx = previousListIndex(m.ecsTaskIdx, len(m.ecsTasks))
 	case "down", "j":
-		if m.ecsTaskIdx < len(m.ecsTasks)-1 {
-			m.ecsTaskIdx++
-		}
+		m.ecsTaskIdx = nextListIndex(m.ecsTaskIdx, len(m.ecsTasks))
 	case "r":
 		return m.startLoading(m.loadECSTasks())
 	case "enter":
@@ -449,13 +437,9 @@ func (m Model) updateECSContainerList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "q", "esc":
 		m.screen = screenECSTaskList
 	case "up", "k":
-		if m.ecsContainerIdx > 0 {
-			m.ecsContainerIdx--
-		}
+		m.ecsContainerIdx = previousListIndex(m.ecsContainerIdx, len(m.ecsContainers))
 	case "down", "j":
-		if m.ecsContainerIdx < len(m.ecsContainers)-1 {
-			m.ecsContainerIdx++
-		}
+		m.ecsContainerIdx = nextListIndex(m.ecsContainerIdx, len(m.ecsContainers))
 	case "enter":
 		if len(m.ecsContainers) > 0 && m.ecsContainerIdx < len(m.ecsContainers) {
 			container := m.ecsContainers[m.ecsContainerIdx]

--- a/internal/app/screen_iam.go
+++ b/internal/app/screen_iam.go
@@ -344,13 +344,9 @@ func (m Model) updateIAMUserList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.filteredIAMUsers = nil
 		m.iamUserIdx = 0
 	case "up", "k":
-		if m.iamUserIdx > 0 {
-			m.iamUserIdx--
-		}
+		m.iamUserIdx = previousListIndex(m.iamUserIdx, len(m.filteredIAMUsers))
 	case "down", "j":
-		if m.iamUserIdx < len(m.filteredIAMUsers)-1 {
-			m.iamUserIdx++
-		}
+		m.iamUserIdx = nextListIndex(m.iamUserIdx, len(m.filteredIAMUsers))
 	case "/":
 		filterCmd := m.activateFilter(filterIAMUsers)
 		if m.iamUserHasMore && !m.iamUserLoadingMore {
@@ -404,13 +400,9 @@ func (m Model) updateIAMKeyList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.screen = screenFeatureList
 		m.iamKeyIdx = 0
 	case "up", "k":
-		if m.iamKeyIdx > 0 {
-			m.iamKeyIdx--
-		}
+		m.iamKeyIdx = previousListIndex(m.iamKeyIdx, len(m.iamKeys))
 	case "down", "j":
-		if m.iamKeyIdx < len(m.iamKeys)-1 {
-			m.iamKeyIdx++
-		}
+		m.iamKeyIdx = nextListIndex(m.iamKeyIdx, len(m.iamKeys))
 	case "enter":
 		if len(m.iamKeys) > 0 && m.iamKeyIdx < len(m.iamKeys) {
 			selected := m.iamKeys[m.iamKeyIdx]

--- a/internal/app/screen_inspector.go
+++ b/internal/app/screen_inspector.go
@@ -227,13 +227,9 @@ func (m Model) updateInspectorHome(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "q", "esc":
 		m.screen = screenServiceList
 	case "up", "k":
-		if m.inspectorWorkflowIdx > 0 {
-			m.inspectorWorkflowIdx--
-		}
+		m.inspectorWorkflowIdx = previousListIndex(m.inspectorWorkflowIdx, len(m.inspectorWorkflows))
 	case "down", "j":
-		if m.inspectorWorkflowIdx < len(m.inspectorWorkflows)-1 {
-			m.inspectorWorkflowIdx++
-		}
+		m.inspectorWorkflowIdx = nextListIndex(m.inspectorWorkflowIdx, len(m.inspectorWorkflows))
 	case "r":
 		if m.currentInspectorWorkflow().Available {
 			return m.startInspectorWorkflow(m.currentInspectorWorkflow().Kind)
@@ -298,13 +294,9 @@ func (m Model) updateInspectorResults(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.selectedInspectorFinding = nil
 		m.screen = screenInspectorHome
 	case "up", "k":
-		if m.inspectorIdx > 0 {
-			m.inspectorIdx--
-		}
+		m.inspectorIdx = previousListIndex(m.inspectorIdx, len(m.inspectorFindings))
 	case "down", "j":
-		if m.inspectorIdx < len(m.inspectorFindings)-1 {
-			m.inspectorIdx++
-		}
+		m.inspectorIdx = nextListIndex(m.inspectorIdx, len(m.inspectorFindings))
 	case "enter":
 		if len(m.inspectorFindings) > 0 && m.inspectorIdx < len(m.inspectorFindings) {
 			selected := m.inspectorFindings[m.inspectorIdx]
@@ -341,12 +333,12 @@ func (m Model) updateInspectorChecklistResults(msg tea.KeyMsg) (tea.Model, tea.C
 	case "l":
 		return m.openChecklistPicker()
 	case "up", "k":
-		if m.inspectorChecklistIdx > 0 {
-			m.inspectorChecklistIdx--
+		if m.inspectorChecklistReport != nil {
+			m.inspectorChecklistIdx = previousListIndex(m.inspectorChecklistIdx, len(m.inspectorChecklistReport.Results))
 		}
 	case "down", "j":
-		if m.inspectorChecklistReport != nil && m.inspectorChecklistIdx < len(m.inspectorChecklistReport.Results)-1 {
-			m.inspectorChecklistIdx++
+		if m.inspectorChecklistReport != nil {
+			m.inspectorChecklistIdx = nextListIndex(m.inspectorChecklistIdx, len(m.inspectorChecklistReport.Results))
 		}
 	case "enter":
 		if m.inspectorChecklistReport != nil && len(m.inspectorChecklistReport.Results) > 0 && m.inspectorChecklistIdx < len(m.inspectorChecklistReport.Results) {
@@ -381,13 +373,9 @@ func (m Model) updateInspectorChecklistPicker(msg tea.KeyMsg) (tea.Model, tea.Cm
 	case "q", "esc":
 		m.screen = screenInspectorHome
 	case "up", "k":
-		if m.inspectorChecklistFileIdx > 0 {
-			m.inspectorChecklistFileIdx--
-		}
+		m.inspectorChecklistFileIdx = previousListIndex(m.inspectorChecklistFileIdx, len(m.filteredChecklistFiles))
 	case "down", "j":
-		if m.inspectorChecklistFileIdx < len(m.filteredChecklistFiles)-1 {
-			m.inspectorChecklistFileIdx++
-		}
+		m.inspectorChecklistFileIdx = nextListIndex(m.inspectorChecklistFileIdx, len(m.filteredChecklistFiles))
 	case "/":
 		return m, m.activateFilter(filterInspectorChecklistFiles)
 	case "enter":

--- a/internal/app/screen_lambda.go
+++ b/internal/app/screen_lambda.go
@@ -52,13 +52,9 @@ func (m Model) updateLambdaFunctionList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "q", "esc":
 		m.screen = screenFeatureList
 	case "up", "k":
-		if m.lambdaFunctionIdx > 0 {
-			m.lambdaFunctionIdx--
-		}
+		m.lambdaFunctionIdx = previousListIndex(m.lambdaFunctionIdx, len(m.filteredLambdaFunctions))
 	case "down", "j":
-		if m.lambdaFunctionIdx < len(m.filteredLambdaFunctions)-1 {
-			m.lambdaFunctionIdx++
-		}
+		m.lambdaFunctionIdx = nextListIndex(m.lambdaFunctionIdx, len(m.filteredLambdaFunctions))
 	case "/":
 		return m, m.activateFilter(filterLambdaFunctions)
 	case "r":
@@ -204,9 +200,9 @@ func (m Model) updateLambdaInvokeInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "esc":
 			m.screen = screenLambdaFunctionList
 		case "up", "k":
-			m.lambdaPayloadSource = lambdaPayloadManual
+			m.lambdaPayloadSource = lambdaPayloadSource(previousListIndex(int(m.lambdaPayloadSource), 2))
 		case "down", "j":
-			m.lambdaPayloadSource = lambdaPayloadFile
+			m.lambdaPayloadSource = lambdaPayloadSource(nextListIndex(int(m.lambdaPayloadSource), 2))
 		case "enter":
 			m.lambdaInvokeStep = 1
 			m.lambdaInvokePayload = ""

--- a/internal/app/screen_rds.go
+++ b/internal/app/screen_rds.go
@@ -71,13 +71,9 @@ func (m Model) updateRDSList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.screen = screenFeatureList
 		m.resetFilter(filterRDS)
 	case "up", "k":
-		if m.rdsIdx > 0 {
-			m.rdsIdx--
-		}
+		m.rdsIdx = previousListIndex(m.rdsIdx, len(m.filteredRDS))
 	case "down", "j":
-		if m.rdsIdx < len(m.filteredRDS)-1 {
-			m.rdsIdx++
-		}
+		m.rdsIdx = nextListIndex(m.rdsIdx, len(m.filteredRDS))
 	case "/":
 		return m, m.activateFilter(filterRDS)
 	case "enter":

--- a/internal/app/screen_reachability.go
+++ b/internal/app/screen_reachability.go
@@ -60,13 +60,9 @@ func (m Model) updateReachabilityRegionList(msg tea.KeyMsg) (tea.Model, tea.Cmd)
 	case "q", "esc":
 		m.screen = screenFeatureList
 	case "up", "k":
-		if m.reachabilityRegionIdx > 0 {
-			m.reachabilityRegionIdx--
-		}
+		m.reachabilityRegionIdx = previousListIndex(m.reachabilityRegionIdx, len(m.filteredReachabilityRegions))
 	case "down", "j":
-		if m.reachabilityRegionIdx < len(m.filteredReachabilityRegions)-1 {
-			m.reachabilityRegionIdx++
-		}
+		m.reachabilityRegionIdx = nextListIndex(m.reachabilityRegionIdx, len(m.filteredReachabilityRegions))
 	case "/":
 		m.reachabilityRegionFiltering = true
 	case "enter":
@@ -184,13 +180,9 @@ func (m Model) updateReachabilitySourceList(msg tea.KeyMsg) (tea.Model, tea.Cmd)
 			m.reachabilityIdx = 0
 		}
 	case "up", "k":
-		if m.reachabilityIdx > 0 {
-			m.reachabilityIdx--
-		}
+		m.reachabilityIdx = previousListIndex(m.reachabilityIdx, len(m.filteredReachabilityTargets))
 	case "down", "j":
-		if m.reachabilityIdx < len(m.filteredReachabilityTargets)-1 {
-			m.reachabilityIdx++
-		}
+		m.reachabilityIdx = nextListIndex(m.reachabilityIdx, len(m.filteredReachabilityTargets))
 	case "/":
 		m.reachabilityFilterActive = true
 	case "r":
@@ -257,13 +249,9 @@ func (m Model) updateReachabilityDestinationList(msg tea.KeyMsg) (tea.Model, tea
 			m.reachabilityIdx = 0
 		}
 	case "up", "k":
-		if m.reachabilityIdx > 0 {
-			m.reachabilityIdx--
-		}
+		m.reachabilityIdx = previousListIndex(m.reachabilityIdx, len(m.filteredReachabilityTargets))
 	case "down", "j":
-		if m.reachabilityIdx < len(m.filteredReachabilityTargets)-1 {
-			m.reachabilityIdx++
-		}
+		m.reachabilityIdx = nextListIndex(m.reachabilityIdx, len(m.filteredReachabilityTargets))
 	case "/":
 		m.reachabilityFilterActive = true
 	case "r":
@@ -298,17 +286,17 @@ func (m Model) updateReachabilityConfig(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "esc":
 		m.screen = screenReachabilityDestinationList
 	case "up", "k":
-		if m.reachabilityConfigField > 0 {
-			m.reachabilityConfigField--
+		maxField := 1
+		if m.reachabilityDestination != nil && m.reachabilityDestination.ManualIP {
+			maxField = 2
 		}
+		m.reachabilityConfigField = previousListIndex(m.reachabilityConfigField, maxField+1)
 	case "down", "j", "tab":
 		maxField := 1
 		if m.reachabilityDestination != nil && m.reachabilityDestination.ManualIP {
 			maxField = 2
 		}
-		if m.reachabilityConfigField < maxField {
-			m.reachabilityConfigField++
-		}
+		m.reachabilityConfigField = nextListIndex(m.reachabilityConfigField, maxField+1)
 	case "left", "h":
 		if m.reachabilityConfigField == 0 && m.reachabilityProtocolIdx > 0 {
 			m.reachabilityProtocolIdx--

--- a/internal/app/screen_route53.go
+++ b/internal/app/screen_route53.go
@@ -79,13 +79,9 @@ func (m Model) updateRoute53ZoneList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.screen = screenFeatureList
 		m.resetFilter(filterRoute53Zones)
 	case "up", "k":
-		if m.route53ZoneIdx > 0 {
-			m.route53ZoneIdx--
-		}
+		m.route53ZoneIdx = previousListIndex(m.route53ZoneIdx, len(m.filteredRoute53Zones))
 	case "down", "j":
-		if m.route53ZoneIdx < len(m.filteredRoute53Zones)-1 {
-			m.route53ZoneIdx++
-		}
+		m.route53ZoneIdx = nextListIndex(m.route53ZoneIdx, len(m.filteredRoute53Zones))
 	case "/":
 		return m, m.activateFilter(filterRoute53Zones)
 	case "enter":
@@ -110,13 +106,9 @@ func (m Model) updateRoute53RecordList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.screen = screenRoute53ZoneList
 		m.resetFilter(filterRoute53Records)
 	case "up", "k":
-		if m.route53RecordIdx > 0 {
-			m.route53RecordIdx--
-		}
+		m.route53RecordIdx = previousListIndex(m.route53RecordIdx, len(m.filteredRoute53Records))
 	case "down", "j":
-		if m.route53RecordIdx < len(m.filteredRoute53Records)-1 {
-			m.route53RecordIdx++
-		}
+		m.route53RecordIdx = nextListIndex(m.route53RecordIdx, len(m.filteredRoute53Records))
 	case "/":
 		return m, m.activateFilter(filterRoute53Records)
 	case "c":
@@ -450,13 +442,9 @@ func (m Model) updateRoute53TypeSelect(key string) (tea.Model, tea.Cmd) {
 	case "esc":
 		m.screen = screenRoute53RecordList
 	case "up", "k":
-		if m.route53EditSelectIdx > 0 {
-			m.route53EditSelectIdx--
-		}
+		m.route53EditSelectIdx = previousListIndex(m.route53EditSelectIdx, len(route53TypeOptions))
 	case "down", "j":
-		if m.route53EditSelectIdx < len(route53TypeOptions)-1 {
-			m.route53EditSelectIdx++
-		}
+		m.route53EditSelectIdx = nextListIndex(m.route53EditSelectIdx, len(route53TypeOptions))
 	case "enter":
 		m.route53EditValues["type"] = route53TypeOptions[m.route53EditSelectIdx]
 		m.route53EditField++

--- a/internal/app/screen_s3.go
+++ b/internal/app/screen_s3.go
@@ -124,13 +124,9 @@ func (m Model) updateS3BucketList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.screen = screenFeatureList
 		m.resetFilter(filterS3Buckets)
 	case "up", "k":
-		if m.s3BucketIdx > 0 {
-			m.s3BucketIdx--
-		}
+		m.s3BucketIdx = previousListIndex(m.s3BucketIdx, len(m.filteredS3Buckets))
 	case "down", "j":
-		if m.s3BucketIdx < len(m.filteredS3Buckets)-1 {
-			m.s3BucketIdx++
-		}
+		m.s3BucketIdx = nextListIndex(m.s3BucketIdx, len(m.filteredS3Buckets))
 	case "/":
 		return m, m.activateFilter(filterS3Buckets)
 	case "enter":
@@ -168,13 +164,9 @@ func (m Model) updateS3ObjectList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		nextPrefix := awsservice.ParentS3Prefix(m.s3CurrentPrefix)
 		return m.startLoading(m.loadS3Objects(m.selectedS3Bucket.Name, nextPrefix))
 	case "up", "k":
-		if m.s3ObjectIdx > 0 {
-			m.s3ObjectIdx--
-		}
+		m.s3ObjectIdx = previousListIndex(m.s3ObjectIdx, len(m.filteredS3Objects))
 	case "down", "j":
-		if m.s3ObjectIdx < len(m.filteredS3Objects)-1 {
-			m.s3ObjectIdx++
-		}
+		m.s3ObjectIdx = nextListIndex(m.s3ObjectIdx, len(m.filteredS3Objects))
 	case "/":
 		return m, m.activateFilter(filterS3Objects)
 	case "enter":

--- a/internal/app/screen_securitygroup.go
+++ b/internal/app/screen_securitygroup.go
@@ -174,13 +174,9 @@ func (m Model) updateSecurityGroupList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.screen = screenFeatureList
 		m.resetFilter(filterSecurityGroups)
 	case "up", "k":
-		if m.sgIdx > 0 {
-			m.sgIdx--
-		}
+		m.sgIdx = previousListIndex(m.sgIdx, len(m.filteredSecurityGroups))
 	case "down", "j":
-		if m.sgIdx < len(m.filteredSecurityGroups)-1 {
-			m.sgIdx++
-		}
+		m.sgIdx = nextListIndex(m.sgIdx, len(m.filteredSecurityGroups))
 	case "/":
 		return m, m.activateFilter(filterSecurityGroups)
 	case "r":
@@ -265,14 +261,9 @@ func (m Model) updateSecurityGroupDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.sgRuleIdx = 0
 	case "up", "k":
-		if m.sgRuleIdx > 0 {
-			m.sgRuleIdx--
-		}
+		m.sgRuleIdx = previousListIndex(m.sgRuleIdx, len(m.activeRules()))
 	case "down", "j":
-		rules := m.activeRules()
-		if m.sgRuleIdx < len(rules)-1 {
-			m.sgRuleIdx++
-		}
+		m.sgRuleIdx = nextListIndex(m.sgRuleIdx, len(m.activeRules()))
 	case "a":
 		m.sgAddField = 0
 		m.sgAddValues = map[string]string{}
@@ -414,13 +405,9 @@ func (m Model) updateSGAddSelect(key string, options []string) (tea.Model, tea.C
 	case "esc":
 		m.screen = screenSecurityGroupDetail
 	case "up", "k":
-		if m.sgAddSelectIdx > 0 {
-			m.sgAddSelectIdx--
-		}
+		m.sgAddSelectIdx = previousListIndex(m.sgAddSelectIdx, len(options))
 	case "down", "j":
-		if m.sgAddSelectIdx < len(options)-1 {
-			m.sgAddSelectIdx++
-		}
+		m.sgAddSelectIdx = nextListIndex(m.sgAddSelectIdx, len(options))
 	case "enter":
 		fieldKey := strings.ToLower(sgAddFieldLabels[m.sgAddField])
 		if m.sgAddField == 0 {

--- a/internal/app/screen_vpc.go
+++ b/internal/app/screen_vpc.go
@@ -21,13 +21,9 @@ func (m Model) updateVPCList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.vpcIdx = 0
 		m.resetFilter(filterVPCs)
 	case "up", "k":
-		if m.vpcIdx > 0 {
-			m.vpcIdx--
-		}
+		m.vpcIdx = previousListIndex(m.vpcIdx, len(m.filteredVPCs))
 	case "down", "j":
-		if m.vpcIdx < len(m.filteredVPCs)-1 {
-			m.vpcIdx++
-		}
+		m.vpcIdx = nextListIndex(m.vpcIdx, len(m.filteredVPCs))
 	case "/":
 		return m, m.activateFilter(filterVPCs)
 	case "enter":
@@ -51,13 +47,9 @@ func (m Model) updateSubnetList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.subnetIdx = 0
 		m.resetFilter(filterSubnets)
 	case "up", "k":
-		if m.subnetIdx > 0 {
-			m.subnetIdx--
-		}
+		m.subnetIdx = previousListIndex(m.subnetIdx, len(m.filteredSubnets))
 	case "down", "j":
-		if m.subnetIdx < len(m.filteredSubnets)-1 {
-			m.subnetIdx++
-		}
+		m.subnetIdx = nextListIndex(m.subnetIdx, len(m.filteredSubnets))
 	case "/":
 		return m, m.activateFilter(filterSubnets)
 	case "enter":

--- a/internal/app/service_list.go
+++ b/internal/app/service_list.go
@@ -1,17 +1,15 @@
 package app
 
 import (
+	"fmt"
 	"sort"
+	"strings"
 
+	"unic/internal/config"
 	"unic/internal/domain"
 )
 
-type serviceSortMode int
-
-const (
-	serviceSortCatalog serviceSortMode = iota
-	serviceSortName
-)
+var configSetFavoriteServicesFn = config.SetFavoriteServices
 
 func (m Model) serviceList() []domain.Service {
 	if m.filteredServices != nil {
@@ -31,26 +29,84 @@ func (m Model) selectedService() (domain.Service, bool) {
 func (m *Model) applyServiceListFilter() {
 	filtered := applyFilter(m.services, m.filterValue(filterServices))
 	m.filteredServices = append([]domain.Service(nil), filtered...)
-	if m.serviceSort == serviceSortName {
-		sort.SliceStable(m.filteredServices, func(i, j int) bool {
-			return m.filteredServices[i].Name < m.filteredServices[j].Name
-		})
-	}
+	sort.SliceStable(m.filteredServices, m.lessService)
 	m.svcIdx = clampListIndex(m.svcIdx, len(m.filteredServices))
 }
 
-func (m *Model) toggleServiceSort() {
-	if m.serviceSort == serviceSortName {
-		m.serviceSort = serviceSortCatalog
-	} else {
-		m.serviceSort = serviceSortName
+func (m Model) lessService(i, j int) bool {
+	left := m.filteredServices[i]
+	right := m.filteredServices[j]
+	leftFavorite := m.isFavoriteService(left.Name)
+	rightFavorite := m.isFavoriteService(right.Name)
+	if leftFavorite != rightFavorite {
+		return leftFavorite
 	}
-	m.applyServiceListFilter()
+	return string(left.Name) < string(right.Name)
 }
 
-func (m Model) serviceSortLabel() string {
-	if m.serviceSort == serviceSortName {
-		return "name"
+func favoriteServiceSet(names []string) map[domain.AwsService]struct{} {
+	favorites := make(map[domain.AwsService]struct{}, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		favorites[domain.AwsService(name)] = struct{}{}
 	}
-	return "catalog"
+	return favorites
+}
+
+func (m Model) isFavoriteService(name domain.AwsService) bool {
+	_, ok := m.favoriteServices[name]
+	return ok
+}
+
+func (m *Model) toggleFavoriteService(name domain.AwsService) error {
+	if m.favoriteServices == nil {
+		m.favoriteServices = make(map[domain.AwsService]struct{})
+	}
+	if m.isFavoriteService(name) {
+		delete(m.favoriteServices, name)
+	} else {
+		m.favoriteServices[name] = struct{}{}
+	}
+	favorites := m.favoriteServiceNames()
+	if m.cfg != nil {
+		m.cfg.FavoriteServices = favorites
+	}
+	if strings.TrimSpace(m.configPath) != "" {
+		if err := configSetFavoriteServicesFn(m.configPath, favorites); err != nil {
+			return err
+		}
+	}
+	m.applyServiceListFilter()
+	m.selectServiceByName(name)
+	return nil
+}
+
+func (m Model) favoriteServiceNames() []string {
+	names := make([]string, 0, len(m.favoriteServices))
+	for name := range m.favoriteServices {
+		names = append(names, string(name))
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (m Model) serviceListSummary() string {
+	favoriteCount := len(m.favoriteServices)
+	if favoriteCount == 1 {
+		return "favorites first, A-Z • 1 favorite"
+	}
+	return fmt.Sprintf("favorites first, A-Z • %d favorites", favoriteCount)
+}
+
+func (m *Model) selectServiceByName(name domain.AwsService) {
+	for i, service := range m.filteredServices {
+		if service.Name == name {
+			m.svcIdx = i
+			return
+		}
+	}
+	m.svcIdx = clampListIndex(m.svcIdx, len(m.filteredServices))
 }

--- a/internal/app/service_list.go
+++ b/internal/app/service_list.go
@@ -1,0 +1,56 @@
+package app
+
+import (
+	"sort"
+
+	"unic/internal/domain"
+)
+
+type serviceSortMode int
+
+const (
+	serviceSortCatalog serviceSortMode = iota
+	serviceSortName
+)
+
+func (m Model) serviceList() []domain.Service {
+	if m.filteredServices != nil {
+		return m.filteredServices
+	}
+	return m.services
+}
+
+func (m Model) selectedService() (domain.Service, bool) {
+	services := m.serviceList()
+	if len(services) == 0 {
+		return domain.Service{}, false
+	}
+	return services[clampListIndex(m.svcIdx, len(services))], true
+}
+
+func (m *Model) applyServiceListFilter() {
+	filtered := applyFilter(m.services, m.filterValue(filterServices))
+	m.filteredServices = append([]domain.Service(nil), filtered...)
+	if m.serviceSort == serviceSortName {
+		sort.SliceStable(m.filteredServices, func(i, j int) bool {
+			return m.filteredServices[i].Name < m.filteredServices[j].Name
+		})
+	}
+	m.svcIdx = clampListIndex(m.svcIdx, len(m.filteredServices))
+}
+
+func (m *Model) toggleServiceSort() {
+	if m.serviceSort == serviceSortName {
+		m.serviceSort = serviceSortCatalog
+	} else {
+		m.serviceSort = serviceSortName
+	}
+	m.applyServiceListFilter()
+}
+
+func (m Model) serviceSortLabel() string {
+	if m.serviceSort == serviceSortName {
+		return "name"
+	}
+	return "catalog"
+}

--- a/internal/app/styles.go
+++ b/internal/app/styles.go
@@ -22,6 +22,7 @@ var (
 	pathLineStyle           = lipgloss.NewStyle().Foreground(lipgloss.Color("67"))
 	filterStyle             = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
 	matchStyle              = lipgloss.NewStyle().Bold(true).Underline(true)
+	favoriteServiceStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true)
 	statusBarStyle          = lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Background(lipgloss.Color("236"))
 	listPanelStyle          = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("240")).Padding(0, 1)
 	helpStyle               = lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Background(lipgloss.Color("237"))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,13 +23,18 @@ type fileConfig struct {
 	DefaultRegion  string `yaml:"default_region"`
 
 	// New contexts-based format
-	Current  string         `yaml:"current"`
-	Defaults fileDefaults   `yaml:"defaults"`
-	Contexts []contextEntry `yaml:"contexts"`
+	Current   string         `yaml:"current"`
+	Defaults  fileDefaults   `yaml:"defaults"`
+	Favorites fileFavorites  `yaml:"favorites,omitempty"`
+	Contexts  []contextEntry `yaml:"contexts"`
 }
 
 type fileDefaults struct {
 	Region string `yaml:"region"`
+}
+
+type fileFavorites struct {
+	Services []string `yaml:"services,omitempty"`
 }
 
 // AuthType represents the authentication method for a context.
@@ -61,15 +66,16 @@ type ContextEntry struct {
 type contextEntry = ContextEntry
 
 type Config struct {
-	Profile      string
-	Region       string
-	ContextName  string
-	AuthType     AuthType
-	RoleArn      string
-	ExternalID   string
-	SSOStartURL  string
-	SSOAccountID string
-	SSORoleName  string
+	Profile          string
+	Region           string
+	ContextName      string
+	AuthType         AuthType
+	RoleArn          string
+	ExternalID       string
+	SSOStartURL      string
+	SSOAccountID     string
+	SSORoleName      string
+	FavoriteServices []string
 }
 
 func normalizeAuthType(value string) AuthType {
@@ -177,15 +183,16 @@ func Load(cliProfile, cliRegion *string, configPath string) (*Config, error) {
 	)
 
 	return &Config{
-		Profile:      profile,
-		Region:       region,
-		ContextName:  contextName,
-		AuthType:     authType,
-		RoleArn:      roleArn,
-		ExternalID:   externalID,
-		SSOStartURL:  ssoStartURL,
-		SSOAccountID: ssoAccountID,
-		SSORoleName:  ssoRoleName,
+		Profile:          profile,
+		Region:           region,
+		ContextName:      contextName,
+		AuthType:         authType,
+		RoleArn:          roleArn,
+		ExternalID:       externalID,
+		SSOStartURL:      ssoStartURL,
+		SSOAccountID:     ssoAccountID,
+		SSORoleName:      ssoRoleName,
+		FavoriteServices: normalizeFavoriteServices(fc.Favorites.Services),
 	}, nil
 }
 
@@ -220,19 +227,38 @@ func LoadNamedContext(configPath, name string) (*Config, error) {
 		}
 
 		return &Config{
-			Profile:      profile,
-			Region:       region,
-			ContextName:  ctx.Name,
-			AuthType:     normalizeAuthType(ctx.AuthType),
-			RoleArn:      ctx.RoleArn,
-			ExternalID:   ctx.ExternalID,
-			SSOStartURL:  ctx.SSOStartURL,
-			SSOAccountID: ctx.SSOAccountID,
-			SSORoleName:  ctx.SSORoleName,
+			Profile:          profile,
+			Region:           region,
+			ContextName:      ctx.Name,
+			AuthType:         normalizeAuthType(ctx.AuthType),
+			RoleArn:          ctx.RoleArn,
+			ExternalID:       ctx.ExternalID,
+			SSOStartURL:      ctx.SSOStartURL,
+			SSOAccountID:     ctx.SSOAccountID,
+			SSORoleName:      ctx.SSORoleName,
+			FavoriteServices: normalizeFavoriteServices(fc.Favorites.Services),
 		}, nil
 	}
 
 	return nil, fmt.Errorf("context %q not found in config", name)
+}
+
+func normalizeFavoriteServices(services []string) []string {
+	seen := make(map[string]struct{}, len(services))
+	normalized := make([]string, 0, len(services))
+	for _, service := range services {
+		service = strings.TrimSpace(service)
+		if service == "" {
+			continue
+		}
+		if _, ok := seen[service]; ok {
+			continue
+		}
+		seen[service] = struct{}{}
+		normalized = append(normalized, service)
+	}
+	sort.Strings(normalized)
+	return normalized
 }
 
 // Contexts reads the config file and returns all defined contexts.
@@ -549,6 +575,35 @@ func SetContextOrders(configPath string, names []string) error {
 	out, err := yaml.Marshal(&fc)
 	if err != nil {
 		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+	if err := os.WriteFile(configPath, out, 0644); err != nil {
+		return fmt.Errorf("failed to write config: %w", err)
+	}
+	return nil
+}
+
+// SetFavoriteServices updates the user's preferred service ordering.
+func SetFavoriteServices(configPath string, services []string) error {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to read config: %w", err)
+		}
+		data = []byte(defaultContent())
+	}
+
+	var fc fileConfig
+	if err := yaml.Unmarshal(data, &fc); err != nil {
+		return fmt.Errorf("failed to parse %s: %w", configPath, err)
+	}
+	fc.Favorites.Services = normalizeFavoriteServices(services)
+
+	out, err := yaml.Marshal(&fc)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 	if err := os.WriteFile(configPath, out, 0644); err != nil {
 		return fmt.Errorf("failed to write config: %w", err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -84,6 +84,30 @@ default_profile: prod
 	}
 }
 
+func TestLoadReadsFavoriteServices(t *testing.T) {
+	dir := t.TempDir()
+	path := writeUnicConfig(t, dir, `
+favorites:
+  services:
+    - RDS
+    - Bedrock
+    - RDS
+`)
+	cfg, err := Load(nil, nil, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"Bedrock", "RDS"}
+	if len(cfg.FavoriteServices) != len(want) {
+		t.Fatalf("expected favorite services %v, got %v", want, cfg.FavoriteServices)
+	}
+	for i := range want {
+		if cfg.FavoriteServices[i] != want[i] {
+			t.Fatalf("expected favorite services %v, got %v", want, cfg.FavoriteServices)
+		}
+	}
+}
+
 func TestCLIProfileWithConfigRegion(t *testing.T) {
 	dir := t.TempDir()
 	path := writeUnicConfig(t, dir, `
@@ -99,6 +123,35 @@ default_region: ap-southeast-1
 	}
 	if cfg.Region != "ap-southeast-1" {
 		t.Errorf("expected region 'ap-southeast-1', got '%s'", cfg.Region)
+	}
+}
+
+func TestSetFavoriteServicesWritesConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := writeUnicConfig(t, dir, `
+default_region: ap-northeast-2
+favorites:
+  services:
+    - EC2
+`)
+	if err := SetFavoriteServices(path, []string{"RDS", "Bedrock", "RDS"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(nil, nil, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"Bedrock", "RDS"}
+	if len(cfg.FavoriteServices) != len(want) {
+		t.Fatalf("expected favorite services %v, got %v", want, cfg.FavoriteServices)
+	}
+	for i := range want {
+		if cfg.FavoriteServices[i] != want[i] {
+			t.Fatalf("expected favorite services %v, got %v", want, cfg.FavoriteServices)
+		}
+	}
+	if cfg.Region != "ap-northeast-2" {
+		t.Fatalf("expected existing region to be preserved, got %q", cfg.Region)
 	}
 }
 

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -1,5 +1,7 @@
 package domain
 
+import "strings"
+
 // AwsService represents an AWS service category.
 type AwsService string
 
@@ -50,4 +52,13 @@ type Feature struct {
 type Service struct {
 	Name     AwsService
 	Features []Feature
+}
+
+// FilterText returns a lowercase string for matching service names and features.
+func (s Service) FilterText() string {
+	parts := []string{string(s.Name)}
+	for _, feature := range s.Features {
+		parts = append(parts, string(feature.Kind), feature.Description)
+	}
+	return strings.ToLower(strings.Join(parts, " "))
 }


### PR DESCRIPTION
## Summary
- add service-list filtering across service and feature text
- default service ordering to favorites first, then alphabetical order
- add persistent service favorites with distinct TUI styling
- make selectable TUI lists wrap at top and bottom boundaries
- bump Makefile local build version to 0.1.3
- document the new service-list controls and add navigation/filter/favorite tests

Closes #157.
Closes #161.

## Validation
- make test
- make build