### PR TITLE
refactor: extract RDS submodel

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -155,15 +155,6 @@ type Model struct {
 	reachabilityConfigField     int
 	reachabilityResult          *awsservice.ReachabilityAnalysisResult
 	reachabilityScrollOffset    int
-	// RDS browser state
-	rdsInstances    []awsservice.RDSInstance
-	filteredRDS     []awsservice.RDSInstance
-	rdsIdx          int
-	selectedRDS     *awsservice.RDSInstance
-	rdsAction       string // "start", "stop", "failover"
-	rdsConfirmInput string // typed input for destructive action confirmation
-	rdsPolling      bool
-
 	// Route53 browser state
 	route53Zones           []awsservice.HostedZone
 	filteredRoute53Zones   []awsservice.HostedZone
@@ -249,6 +240,7 @@ type Model struct {
 	// Feature submodels
 	cwMetrics cloudWatchMetricsModel
 	cwLogs    cloudWatchLogsModel
+	rds       rdsModel
 	bedrock   bedrockModel
 
 	// S3 browser state
@@ -373,6 +365,7 @@ func New(cfg *config.Config, configPath string, version string, checklistPath ..
 	}
 	model.cwMetrics = newCloudWatchMetricsModel()
 	model.cwLogs = newCloudWatchLogsModel()
+	model.rds = newRDSModel()
 	model.bedrock = newBedrockModel()
 	model.applyServiceListFilter()
 	return model
@@ -471,7 +464,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	for _, h := range []func(tea.Msg) (tea.Model, tea.Cmd, bool){
 		m.handleEC2VPCMsg,
 		m.handleRoute53Msg,
-		m.handleRDSMsg,
 		m.handleSecurityGroupMsg,
 		m.handleIAMMsg,
 		m.handleSecretMsg,
@@ -561,12 +553,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateReachabilityConfig(msg)
 		case screenReachabilityResult:
 			return m.updateReachabilityResult(msg)
-		case screenRDSList:
-			return m.updateRDSList(msg)
-		case screenRDSDetail:
-			return m.updateRDSDetail(msg)
-		case screenRDSConfirm:
-			return m.updateRDSConfirm(msg)
 		case screenRoute53ZoneList:
 			return m.updateRoute53ZoneList(msg)
 		case screenRoute53RecordList:
@@ -757,7 +743,7 @@ func (m Model) updateFeatureList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.screen = screenReachabilityRegionList
 				return m, nil
 			case domain.FeatureRDSBrowser:
-				return m.startLoading(m.loadRDSInstances())
+				return m.rds.Start(&m)
 			case domain.FeatureRoute53Browser:
 				return m.startLoading(m.loadRoute53Zones())
 			case domain.FeatureSecretsBrowser:
@@ -840,12 +826,6 @@ func (m Model) View() string {
 		v = m.viewReachabilityConfig()
 	case screenReachabilityResult:
 		v = m.viewReachabilityResult()
-	case screenRDSList:
-		v = m.viewRDSList()
-	case screenRDSDetail:
-		v = m.viewRDSDetail()
-	case screenRDSConfirm:
-		v = m.viewRDSConfirm()
 	case screenRoute53ZoneList:
 		v = m.viewRoute53ZoneList()
 	case screenRoute53RecordList:

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -312,21 +312,21 @@ func TestServiceListEnterGoesToFeatures(t *testing.T) {
 func TestRDSListNavigationWraps(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSList
-	m.filteredRDS = []awsservice.RDSInstance{
+	m.rds.filtered = []awsservice.RDSInstance{
 		{DBInstanceID: "db-a"},
 		{DBInstanceID: "db-b"},
 	}
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
 	model := updated.(Model)
-	if model.rdsIdx != 1 {
-		t.Fatalf("expected up from first RDS instance to wrap to last, got %d", model.rdsIdx)
+	if model.rds.idx != 1 {
+		t.Fatalf("expected up from first RDS instance to wrap to last, got %d", model.rds.idx)
 	}
 
 	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	model = updated.(Model)
-	if model.rdsIdx != 0 {
-		t.Fatalf("expected down from last RDS instance to wrap to first, got %d", model.rdsIdx)
+	if model.rds.idx != 0 {
+		t.Fatalf("expected down from last RDS instance to wrap to first, got %d", model.rds.idx)
 	}
 }
 
@@ -437,7 +437,7 @@ func TestHelpBlocksNavigationWhileOpen(t *testing.T) {
 func TestHelpViewShowsContextAwareRDSActions(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSDetail
-	m.selectedRDS = &awsservice.RDSInstance{
+	m.rds.selected = &awsservice.RDSInstance{
 		DBInstanceID:  "db-1",
 		Status:        "available",
 		MultiAZ:       true,
@@ -485,50 +485,50 @@ func TestHelpViewShowsFilterModeShortcuts(t *testing.T) {
 func TestRDSListNavigation(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSList
-	m.rdsInstances = []awsservice.RDSInstance{
+	m.rds.instances = []awsservice.RDSInstance{
 		{DBInstanceID: "db-1", Engine: "mysql", Status: "available", InstanceClass: "db.t3.micro"},
 		{DBInstanceID: "db-2", Engine: "postgres", Status: "stopped", InstanceClass: "db.t3.small"},
 	}
-	m.filteredRDS = m.rdsInstances
+	m.rds.filtered = m.rds.instances
 
 	// Press down
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	model := updated.(Model)
-	if model.rdsIdx != 1 {
-		t.Errorf("expected rdsIdx 1 after pressing j, got %d", model.rdsIdx)
+	if model.rds.idx != 1 {
+		t.Errorf("expected rds.idx 1 after pressing j, got %d", model.rds.idx)
 	}
 
 	// Press up
 	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
 	model = updated.(Model)
-	if model.rdsIdx != 0 {
-		t.Errorf("expected rdsIdx 0 after pressing k, got %d", model.rdsIdx)
+	if model.rds.idx != 0 {
+		t.Errorf("expected rds.idx 0 after pressing k, got %d", model.rds.idx)
 	}
 }
 
 func TestRDSListEnterGoesToDetail(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSList
-	m.rdsInstances = []awsservice.RDSInstance{
+	m.rds.instances = []awsservice.RDSInstance{
 		{DBInstanceID: "db-1", Engine: "mysql", Status: "available", InstanceClass: "db.t3.micro"},
 	}
-	m.filteredRDS = m.rdsInstances
+	m.rds.filtered = m.rds.instances
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	model := updated.(Model)
 	if model.screen != screenRDSDetail {
 		t.Errorf("expected RDS detail screen, got %d", model.screen)
 	}
-	if model.selectedRDS == nil {
-		t.Error("selectedRDS should not be nil")
+	if model.rds.selected == nil {
+		t.Error("rds.selected should not be nil")
 	}
 }
 
 func TestRDSListEscGoesBack(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSList
-	m.rdsInstances = []awsservice.RDSInstance{}
-	m.filteredRDS = m.rdsInstances
+	m.rds.instances = []awsservice.RDSInstance{}
+	m.rds.filtered = m.rds.instances
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	model := updated.(Model)
@@ -540,7 +540,7 @@ func TestRDSListEscGoesBack(t *testing.T) {
 func TestRDSDetailEscGoesBack(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSDetail
-	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "available"}
+	m.rds.selected = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "available"}
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	model := updated.(Model)
@@ -552,52 +552,52 @@ func TestRDSDetailEscGoesBack(t *testing.T) {
 func TestRDSDetailStopGoesToConfirm(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSDetail
-	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "available", ClusterID: ""}
+	m.rds.selected = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "available", ClusterID: ""}
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
 	model := updated.(Model)
 	if model.screen != screenRDSConfirm {
 		t.Errorf("expected confirm screen, got %d", model.screen)
 	}
-	if model.rdsAction != "stop" {
-		t.Errorf("expected action 'stop', got %q", model.rdsAction)
+	if model.rds.action != "stop" {
+		t.Errorf("expected action 'stop', got %q", model.rds.action)
 	}
 }
 
 func TestRDSDetailStartGoesToConfirm(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSDetail
-	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "stopped"}
+	m.rds.selected = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "stopped"}
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
 	model := updated.(Model)
 	if model.screen != screenRDSConfirm {
 		t.Errorf("expected confirm screen, got %d", model.screen)
 	}
-	if model.rdsAction != "start" {
-		t.Errorf("expected action 'start', got %q", model.rdsAction)
+	if model.rds.action != "start" {
+		t.Errorf("expected action 'start', got %q", model.rds.action)
 	}
 }
 
 func TestRDSDetailFailoverGoesToConfirm(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSDetail
-	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "available", MultiAZ: true}
+	m.rds.selected = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "available", MultiAZ: true}
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
 	model := updated.(Model)
 	if model.screen != screenRDSConfirm {
 		t.Errorf("expected confirm screen, got %d", model.screen)
 	}
-	if model.rdsAction != "failover" {
-		t.Errorf("expected action 'failover', got %q", model.rdsAction)
+	if model.rds.action != "failover" {
+		t.Errorf("expected action 'failover', got %q", model.rds.action)
 	}
 }
 
 func TestRDSDetailStopClusterMember(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSDetail
-	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "available", ClusterID: "my-cluster"}
+	m.rds.selected = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "available", ClusterID: "my-cluster"}
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
 	model := updated.(Model)
@@ -605,8 +605,8 @@ func TestRDSDetailStopClusterMember(t *testing.T) {
 	if model.screen != screenRDSConfirm {
 		t.Errorf("expected confirm screen for cluster stop, got %d", model.screen)
 	}
-	if model.rdsAction != "stop" {
-		t.Errorf("expected action 'stop', got %q", model.rdsAction)
+	if model.rds.action != "stop" {
+		t.Errorf("expected action 'stop', got %q", model.rds.action)
 	}
 }
 
@@ -614,8 +614,8 @@ func TestRDSConfirmNoGoesBack(t *testing.T) {
 	// For start action, 'n' cancels back to detail
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSConfirm
-	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1"}
-	m.rdsAction = "start"
+	m.rds.selected = &awsservice.RDSInstance{DBInstanceID: "db-1"}
+	m.rds.action = "start"
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
 	model := updated.(Model)
@@ -627,8 +627,8 @@ func TestRDSConfirmNoGoesBack(t *testing.T) {
 func TestRDSConfirmEscGoesBack(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSConfirm
-	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1"}
-	m.rdsAction = "stop"
+	m.rds.selected = &awsservice.RDSInstance{DBInstanceID: "db-1"}
+	m.rds.action = "stop"
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	model := updated.(Model)
@@ -640,11 +640,11 @@ func TestRDSConfirmEscGoesBack(t *testing.T) {
 func TestRDSListFilter(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSList
-	m.rdsInstances = []awsservice.RDSInstance{
+	m.rds.instances = []awsservice.RDSInstance{
 		{DBInstanceID: "prod-db", Engine: "mysql", Status: "available", InstanceClass: "db.t3.micro"},
 		{DBInstanceID: "dev-db", Engine: "postgres", Status: "stopped", InstanceClass: "db.t3.small"},
 	}
-	m.filteredRDS = m.rdsInstances
+	m.rds.filtered = m.rds.instances
 
 	// Activate filter
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
@@ -659,23 +659,23 @@ func TestRDSListFilter(t *testing.T) {
 		model = updated.(Model)
 	}
 
-	if len(model.filteredRDS) != 1 {
-		t.Errorf("expected 1 filtered instance, got %d", len(model.filteredRDS))
+	if len(model.rds.filtered) != 1 {
+		t.Errorf("expected 1 filtered instance, got %d", len(model.rds.filtered))
 	}
-	if model.filteredRDS[0].DBInstanceID != "prod-db" {
-		t.Errorf("expected 'prod-db', got %q", model.filteredRDS[0].DBInstanceID)
+	if model.rds.filtered[0].DBInstanceID != "prod-db" {
+		t.Errorf("expected 'prod-db', got %q", model.rds.filtered[0].DBInstanceID)
 	}
 }
 
 func TestRDSListFilterAllowsNavigationWhileFocused(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSList
-	m.rdsInstances = []awsservice.RDSInstance{
+	m.rds.instances = []awsservice.RDSInstance{
 		{DBInstanceID: "prod-api-db", Engine: "mysql", Status: "available", InstanceClass: "db.t3.micro"},
 		{DBInstanceID: "prod-worker-db", Engine: "mysql", Status: "available", InstanceClass: "db.t3.micro"},
 		{DBInstanceID: "dev-db", Engine: "postgres", Status: "stopped", InstanceClass: "db.t3.small"},
 	}
-	m.filteredRDS = m.rdsInstances
+	m.rds.filtered = m.rds.instances
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
 	model := updated.(Model)
@@ -688,11 +688,11 @@ func TestRDSListFilterAllowsNavigationWhileFocused(t *testing.T) {
 	if !model.isFiltering(filterRDS) {
 		t.Fatal("expected RDS filter to stay active after typing")
 	}
-	if got := len(model.filteredRDS); got != 2 {
+	if got := len(model.rds.filtered); got != 2 {
 		t.Fatalf("expected 2 filtered instances, got %d", got)
 	}
-	if model.rdsIdx != 0 {
-		t.Fatalf("expected selection to reset to the first filtered row, got %d", model.rdsIdx)
+	if model.rds.idx != 0 {
+		t.Fatalf("expected selection to reset to the first filtered row, got %d", model.rds.idx)
 	}
 
 	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyDown})
@@ -701,10 +701,10 @@ func TestRDSListFilterAllowsNavigationWhileFocused(t *testing.T) {
 	if !model.isFiltering(filterRDS) {
 		t.Fatal("expected RDS filter to remain active while navigating")
 	}
-	if model.rdsIdx != 1 {
-		t.Fatalf("expected down arrow to move selection to index 1, got %d", model.rdsIdx)
+	if model.rds.idx != 1 {
+		t.Fatalf("expected down arrow to move selection to index 1, got %d", model.rds.idx)
 	}
-	if got := model.filteredRDS[model.rdsIdx].DBInstanceID; got != "prod-worker-db" {
+	if got := model.rds.filtered[model.rds.idx].DBInstanceID; got != "prod-worker-db" {
 		t.Fatalf("expected selection to move to prod-worker-db, got %q", got)
 	}
 }
@@ -712,11 +712,11 @@ func TestRDSListFilterAllowsNavigationWhileFocused(t *testing.T) {
 func TestRDSListFilterStillAcceptsJKCharacters(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSList
-	m.rdsInstances = []awsservice.RDSInstance{
+	m.rds.instances = []awsservice.RDSInstance{
 		{DBInstanceID: "proj-jk-db", Engine: "mysql", Status: "available", InstanceClass: "db.t3.micro"},
 		{DBInstanceID: "prod-db", Engine: "mysql", Status: "available", InstanceClass: "db.t3.micro"},
 	}
-	m.filteredRDS = m.rdsInstances
+	m.rds.filtered = m.rds.instances
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
 	model := updated.(Model)
@@ -729,10 +729,10 @@ func TestRDSListFilterStillAcceptsJKCharacters(t *testing.T) {
 	if got := model.filterValue(filterRDS); got != "jk" {
 		t.Fatalf("expected filter query to accept j/k characters, got %q", got)
 	}
-	if got := len(model.filteredRDS); got != 1 {
+	if got := len(model.rds.filtered); got != 1 {
 		t.Fatalf("expected 1 filtered instance after typing jk, got %d", got)
 	}
-	if got := model.filteredRDS[0].DBInstanceID; got != "proj-jk-db" {
+	if got := model.rds.filtered[0].DBInstanceID; got != "proj-jk-db" {
 		t.Fatalf("expected proj-jk-db to match typed jk filter, got %q", got)
 	}
 }
@@ -740,14 +740,14 @@ func TestRDSListFilterStillAcceptsJKCharacters(t *testing.T) {
 func TestRDSActionDoneMsg_Success(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSDetail
-	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1"}
+	m.rds.selected = &awsservice.RDSInstance{DBInstanceID: "db-1"}
 
 	updated, cmd := m.Update(rdsActionDoneMsg{action: "stop", instanceID: "db-1", err: nil})
 	model := updated.(Model)
 	if model.screen != screenRDSDetail {
 		t.Errorf("expected detail screen after action done, got %d", model.screen)
 	}
-	if !model.rdsPolling {
+	if !model.rds.polling {
 		t.Error("polling should be active after successful action")
 	}
 	if cmd == nil {
@@ -767,8 +767,8 @@ func TestRDSInstancesLoadedMsg(t *testing.T) {
 	if model.screen != screenRDSList {
 		t.Errorf("expected RDS list screen, got %d", model.screen)
 	}
-	if len(model.rdsInstances) != 1 {
-		t.Errorf("expected 1 instance, got %d", len(model.rdsInstances))
+	if len(model.rds.instances) != 1 {
+		t.Errorf("expected 1 instance, got %d", len(model.rds.instances))
 	}
 }
 
@@ -793,10 +793,10 @@ func TestFeatureListRDSBrowserGoesToLoading(t *testing.T) {
 func TestRDSViewNotEmpty(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSList
-	m.rdsInstances = []awsservice.RDSInstance{
+	m.rds.instances = []awsservice.RDSInstance{
 		{DBInstanceID: "db-1", Engine: "mysql", Status: "available", InstanceClass: "db.t3.micro", EngineVersion: "8.0"},
 	}
-	m.filteredRDS = m.rdsInstances
+	m.rds.filtered = m.rds.instances
 	m.height = 30
 
 	v := m.View()
@@ -808,7 +808,7 @@ func TestRDSViewNotEmpty(t *testing.T) {
 func TestRDSDetailViewNotEmpty(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSDetail
-	m.selectedRDS = &awsservice.RDSInstance{
+	m.rds.selected = &awsservice.RDSInstance{
 		DBInstanceID: "db-1", Engine: "mysql", EngineVersion: "8.0",
 		Status: "available", InstanceClass: "db.t3.micro", MultiAZ: true, StorageGB: 20,
 		Endpoint: "db-1.abc.us-east-1.rds.amazonaws.com:3306",
@@ -823,8 +823,8 @@ func TestRDSDetailViewNotEmpty(t *testing.T) {
 func TestRDSConfirmViewNotEmpty(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSConfirm
-	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1"}
-	m.rdsAction = "stop"
+	m.rds.selected = &awsservice.RDSInstance{DBInstanceID: "db-1"}
+	m.rds.action = "stop"
 
 	v := m.View()
 	if v == "" {
@@ -836,9 +836,9 @@ func TestRDSConfirmStopRequiresTypedInput(t *testing.T) {
 	// Test with standalone instance (confirm target = instance ID)
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSConfirm
-	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1", ClusterID: ""}
-	m.rdsAction = "stop"
-	m.rdsConfirmInput = ""
+	m.rds.selected = &awsservice.RDSInstance{DBInstanceID: "db-1", ClusterID: ""}
+	m.rds.action = "stop"
+	m.rds.confirmInput = ""
 
 	// Enter without typing anything — should stay on confirm screen
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -851,7 +851,7 @@ func TestRDSConfirmStopRequiresTypedInput(t *testing.T) {
 	}
 
 	// Type wrong text + enter — should stay on confirm screen
-	model.rdsConfirmInput = "wrong-name"
+	model.rds.confirmInput = "wrong-name"
 	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	model = updated.(Model)
 	if model.screen != screenRDSConfirm {
@@ -862,7 +862,7 @@ func TestRDSConfirmStopRequiresTypedInput(t *testing.T) {
 	}
 
 	// Type correct instance ID + enter — should execute
-	model.rdsConfirmInput = "db-1"
+	model.rds.confirmInput = "db-1"
 	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	model = updated.(Model)
 	if model.screen != screenRDSDetail {
@@ -877,12 +877,12 @@ func TestRDSConfirmStopClusterRequiresClusterID(t *testing.T) {
 	// Test with Aurora cluster member (confirm target = cluster ID)
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSConfirm
-	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "inst-1", ClusterID: "my-cluster", Status: "available"}
-	m.rdsAction = "stop"
-	m.rdsConfirmInput = ""
+	m.rds.selected = &awsservice.RDSInstance{DBInstanceID: "inst-1", ClusterID: "my-cluster", Status: "available"}
+	m.rds.action = "stop"
+	m.rds.confirmInput = ""
 
 	// Type instance ID (wrong target) — should stay
-	m.rdsConfirmInput = "inst-1"
+	m.rds.confirmInput = "inst-1"
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	model := updated.(Model)
 	if model.screen != screenRDSConfirm {
@@ -893,7 +893,7 @@ func TestRDSConfirmStopClusterRequiresClusterID(t *testing.T) {
 	}
 
 	// Type cluster ID (correct target) — should execute
-	model.rdsConfirmInput = "my-cluster"
+	model.rds.confirmInput = "my-cluster"
 	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	model = updated.(Model)
 	if model.screen != screenRDSDetail {
@@ -907,9 +907,9 @@ func TestRDSConfirmStopClusterRequiresClusterID(t *testing.T) {
 func TestRDSConfirmFailoverRequiresTypedInput(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSConfirm
-	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "prod-db", MultiAZ: true}
-	m.rdsAction = "failover"
-	m.rdsConfirmInput = ""
+	m.rds.selected = &awsservice.RDSInstance{DBInstanceID: "prod-db", MultiAZ: true}
+	m.rds.action = "failover"
+	m.rds.confirmInput = ""
 
 	// Enter without typing — should stay
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -922,7 +922,7 @@ func TestRDSConfirmFailoverRequiresTypedInput(t *testing.T) {
 	}
 
 	// Type correct instance ID + enter — should execute
-	model.rdsConfirmInput = "prod-db"
+	model.rds.confirmInput = "prod-db"
 	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	model = updated.(Model)
 	if model.screen != screenRDSDetail {
@@ -936,8 +936,8 @@ func TestRDSConfirmFailoverRequiresTypedInput(t *testing.T) {
 func TestRDSConfirmStartUsesSimpleYN(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSConfirm
-	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "stopped"}
-	m.rdsAction = "start"
+	m.rds.selected = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "stopped"}
+	m.rds.action = "start"
 
 	// Pressing 'y' should execute immediately (no typing required)
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
@@ -953,32 +953,32 @@ func TestRDSConfirmStartUsesSimpleYN(t *testing.T) {
 func TestRDSConfirmInputBackspace(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSConfirm
-	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1"}
-	m.rdsAction = "stop"
-	m.rdsConfirmInput = ""
+	m.rds.selected = &awsservice.RDSInstance{DBInstanceID: "db-1"}
+	m.rds.action = "stop"
+	m.rds.confirmInput = ""
 
 	// Type "abc"
 	for _, ch := range "abc" {
 		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{ch}})
 		m = updated.(Model)
 	}
-	if m.rdsConfirmInput != "abc" {
-		t.Errorf("expected 'abc', got %q", m.rdsConfirmInput)
+	if m.rds.confirmInput != "abc" {
+		t.Errorf("expected 'abc', got %q", m.rds.confirmInput)
 	}
 
 	// Backspace
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
 	m = updated.(Model)
-	if m.rdsConfirmInput != "ab" {
-		t.Errorf("expected 'ab' after backspace, got %q", m.rdsConfirmInput)
+	if m.rds.confirmInput != "ab" {
+		t.Errorf("expected 'ab' after backspace, got %q", m.rds.confirmInput)
 	}
 }
 
 func TestRDSConfirmInputResetOnEntry(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSDetail
-	m.selectedRDS = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "available", ClusterID: ""}
-	m.rdsConfirmInput = "leftover"
+	m.rds.selected = &awsservice.RDSInstance{DBInstanceID: "db-1", Status: "available", ClusterID: ""}
+	m.rds.confirmInput = "leftover"
 
 	// Press 'x' to go to confirm screen
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
@@ -986,8 +986,8 @@ func TestRDSConfirmInputResetOnEntry(t *testing.T) {
 	if model.screen != screenRDSConfirm {
 		t.Errorf("expected confirm screen, got %d", model.screen)
 	}
-	if model.rdsConfirmInput != "" {
-		t.Errorf("expected empty confirm input on entry, got %q", model.rdsConfirmInput)
+	if model.rds.confirmInput != "" {
+		t.Errorf("expected empty confirm input on entry, got %q", model.rds.confirmInput)
 	}
 }
 
@@ -1273,7 +1273,7 @@ func TestViewFitsTerminalHeight(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenRDSDetail
 	m.height = 10
-	m.selectedRDS = &awsservice.RDSInstance{
+	m.rds.selected = &awsservice.RDSInstance{
 		DBInstanceID: "db-1", Engine: "mysql", EngineVersion: "8.0",
 		Status: "available", InstanceClass: "db.t3.micro", MultiAZ: true, StorageGB: 20,
 		Endpoint: "db-1.abc.us-east-1.rds.amazonaws.com:3306",

--- a/internal/app/feature_submodel.go
+++ b/internal/app/feature_submodel.go
@@ -10,5 +10,5 @@ type featureSubmodel interface {
 }
 
 func (m *Model) featureSubmodels() []featureSubmodel {
-	return []featureSubmodel{&m.cwMetrics, &m.cwLogs, &m.bedrock}
+	return []featureSubmodel{&m.cwMetrics, &m.cwLogs, &m.rds, &m.bedrock}
 }

--- a/internal/app/filter.go
+++ b/internal/app/filter.go
@@ -164,9 +164,6 @@ func (m *Model) applyFilterTarget(target filterTarget) {
 		m.instIdx = 0
 	case filterSubnetIPs:
 		m.applyIPFilter()
-	case filterRDS:
-		m.filteredRDS = applyFilter(m.rdsInstances, m.filterValue(target))
-		m.rdsIdx = 0
 	case filterRoute53Zones:
 		m.filteredRoute53Zones = applyFilter(m.route53Zones, m.filterValue(target))
 		m.route53ZoneIdx = 0

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -196,25 +196,25 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 			{"r", "Refresh the selected instance status"},
 			{"q / esc", "Go back to the instance list"},
 		}
-		if m.selectedRDS != nil && m.selectedRDS.CanStart() {
+		if m.rds.selected != nil && m.rds.selected.CanStart() {
 			shortcuts = append([]helpShortcut{{"s", "Start the selected instance or cluster"}}, shortcuts...)
 		}
-		if m.selectedRDS != nil && m.selectedRDS.CanStop() {
+		if m.rds.selected != nil && m.rds.selected.CanStop() {
 			shortcuts = append([]helpShortcut{{"x", "Stop the selected instance or cluster"}}, shortcuts...)
 		}
-		if m.selectedRDS != nil && m.selectedRDS.CanFailover() {
+		if m.rds.selected != nil && m.rds.selected.CanFailover() {
 			shortcuts = append([]helpShortcut{{"f", "Trigger failover for the selected instance or cluster"}}, shortcuts...)
 		}
 		return shortcuts
 	case screenRDSConfirm:
-		if m.rdsAction == "start" {
+		if m.rds.action == "start" {
 			return []helpShortcut{
 				{"y / enter", "Confirm the start action"},
 				{"n / esc", "Cancel and return to the detail screen"},
 			}
 		}
 		target := "instance identifier"
-		if m.selectedRDS != nil && m.selectedRDS.IsClusterMember() {
+		if m.rds.selected != nil && m.rds.selected.IsClusterMember() {
 			target = "cluster identifier"
 		}
 		return []helpShortcut{

--- a/internal/app/screen_rds.go
+++ b/internal/app/screen_rds.go
@@ -11,59 +11,115 @@ import (
 	awsservice "unic/internal/services/aws"
 )
 
-func (m Model) handleRDSMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
+type rdsModel struct {
+	instances    []awsservice.RDSInstance
+	filtered     []awsservice.RDSInstance
+	idx          int
+	selected     *awsservice.RDSInstance
+	action       string // "start", "stop", "failover"
+	confirmInput string // typed input for destructive action confirmation
+	polling      bool
+}
+
+func newRDSModel() rdsModel {
+	return rdsModel{}
+}
+
+func (rm *rdsModel) Start(m *Model) (tea.Model, tea.Cmd) {
+	return m.startLoading(rm.loadInstances(*m))
+}
+
+func (rm *rdsModel) HandleMessage(m *Model, msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 	switch msg := msg.(type) {
 	case rdsInstancesLoadedMsg:
-		m.rdsInstances = msg.instances
-		m.filteredRDS = msg.instances
-		m.rdsIdx = 0
+		rm.instances = msg.instances
+		rm.filtered = applyFilter(rm.instances, m.filterValue(filterRDS))
+		rm.idx = 0
 		m.screen = screenRDSList
-		return m, nil, true
+		return *m, nil, true
 
 	case rdsActionDoneMsg:
 		if msg.err != nil {
 			m.errMsg = msg.err.Error()
 			m.screen = screenError
-			return m, nil, true
+			return *m, nil, true
 		}
-		m.rdsPolling = true
+		rm.polling = true
 		m.screen = screenRDSDetail
-		return m, m.tickRDSPoll(msg.instanceID), true
+		return *m, rm.tickPoll(msg.instanceID), true
 
 	case rdsStatusRefreshedMsg:
 		if msg.err != nil {
-			m.rdsPolling = false
-			return m, nil, true
+			rm.polling = false
+			return *m, nil, true
 		}
-		m.selectedRDS = msg.instance
-		for i, inst := range m.rdsInstances {
+		rm.selected = msg.instance
+		for i, inst := range rm.instances {
 			if inst.DBInstanceID == msg.instance.DBInstanceID {
-				m.rdsInstances[i] = *msg.instance
+				rm.instances[i] = *msg.instance
 				break
 			}
 		}
-		m.filteredRDS = applyFilter(m.rdsInstances, m.filterValue(filterRDS))
-		m.rdsIdx = 0
+		rm.filtered = applyFilter(rm.instances, m.filterValue(filterRDS))
+		rm.idx = 0
 		if awsservice.IsTransitionalStatus(msg.instance.Status) {
-			return m, m.tickRDSPoll(msg.instance.DBInstanceID), true
+			return *m, rm.tickPoll(msg.instance.DBInstanceID), true
 		}
-		m.rdsPolling = false
-		return m, nil, true
+		rm.polling = false
+		return *m, nil, true
 
 	case rdsTickMsg:
-		if m.rdsPolling {
-			return m, m.pollRDSStatus(msg.instanceID), true
+		if rm.polling {
+			return *m, rm.pollStatus(*m, msg.instanceID), true
 		}
-		return m, nil, true
+		return *m, nil, true
 	}
-	return m, nil, false
+	return *m, nil, false
 }
 
-func (m Model) updateRDSList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (rm *rdsModel) HandleKey(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
+	switch m.screen {
+	case screenRDSList:
+		newM, cmd := rm.updateList(m, msg)
+		return newM, cmd, true
+	case screenRDSDetail:
+		newM, cmd := rm.updateDetail(m, msg)
+		return newM, cmd, true
+	case screenRDSConfirm:
+		newM, cmd := rm.updateConfirm(m, msg)
+		return newM, cmd, true
+	default:
+		return *m, nil, false
+	}
+}
+
+func (rm rdsModel) View(m Model) (string, bool) {
+	switch m.screen {
+	case screenRDSList:
+		return rm.viewList(m), true
+	case screenRDSDetail:
+		return rm.viewDetail(m), true
+	case screenRDSConfirm:
+		return rm.viewConfirm(m), true
+	default:
+		return "", false
+	}
+}
+
+func (rm *rdsModel) ApplyFilter(m *Model, target filterTarget) bool {
+	if target != filterRDS {
+		return false
+	}
+	rm.filtered = applyFilter(rm.instances, m.filterValue(target))
+	rm.idx = 0
+	return true
+}
+
+func (rm *rdsModel) updateList(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
 	if cmd, handled := m.updateSharedFilter(msg, filterRDS); handled {
-		return m, cmd
+		return *m, cmd
 	}
 
 	switch key {
@@ -71,98 +127,98 @@ func (m Model) updateRDSList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.screen = screenFeatureList
 		m.resetFilter(filterRDS)
 	case "up", "k":
-		m.rdsIdx = previousListIndex(m.rdsIdx, len(m.filteredRDS))
+		rm.idx = previousListIndex(rm.idx, len(rm.filtered))
 	case "down", "j":
-		m.rdsIdx = nextListIndex(m.rdsIdx, len(m.filteredRDS))
+		rm.idx = nextListIndex(rm.idx, len(rm.filtered))
 	case "/":
-		return m, m.activateFilter(filterRDS)
+		return *m, m.activateFilter(filterRDS)
 	case "enter":
-		if len(m.filteredRDS) > 0 && m.rdsIdx < len(m.filteredRDS) {
-			selected := m.filteredRDS[m.rdsIdx]
-			m.selectedRDS = &selected
+		if len(rm.filtered) > 0 && rm.idx < len(rm.filtered) {
+			selected := rm.filtered[rm.idx]
+			rm.selected = &selected
 			m.screen = screenRDSDetail
 		}
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) updateRDSDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (rm *rdsModel) updateDetail(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "q", "esc":
-		m.rdsPolling = false
+		rm.polling = false
 		m.screen = screenRDSList
 	case "s":
-		if m.selectedRDS != nil && m.selectedRDS.CanStart() {
-			m.rdsAction = "start"
-			m.rdsConfirmInput = ""
+		if rm.selected != nil && rm.selected.CanStart() {
+			rm.action = "start"
+			rm.confirmInput = ""
 			m.screen = screenRDSConfirm
 		}
 	case "x":
-		if m.selectedRDS != nil && m.selectedRDS.CanStop() {
-			m.rdsAction = "stop"
-			m.rdsConfirmInput = ""
+		if rm.selected != nil && rm.selected.CanStop() {
+			rm.action = "stop"
+			rm.confirmInput = ""
 			m.screen = screenRDSConfirm
 		}
 	case "f":
-		if m.selectedRDS != nil && m.selectedRDS.CanFailover() {
-			m.rdsAction = "failover"
-			m.rdsConfirmInput = ""
+		if rm.selected != nil && rm.selected.CanFailover() {
+			rm.action = "failover"
+			rm.confirmInput = ""
 			m.screen = screenRDSConfirm
 		}
 	case "r":
-		if m.selectedRDS != nil {
-			return m, m.pollRDSStatus(m.selectedRDS.DBInstanceID)
+		if rm.selected != nil {
+			return *m, rm.pollStatus(*m, rm.selected.DBInstanceID)
 		}
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) updateRDSConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (rm *rdsModel) updateConfirm(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// Start action uses simple y/n confirmation
-	if m.rdsAction == "start" {
+	if rm.action == "start" {
 		switch msg.String() {
 		case "y", "enter":
-			if m.selectedRDS != nil {
+			if rm.selected != nil {
 				m.screen = screenRDSDetail
-				return m, m.executeRDSAction(m.rdsAction, m.selectedRDS.DBInstanceID)
+				return *m, rm.executeAction(*m, rm.action, rm.selected.DBInstanceID)
 			}
 		case "n", "esc":
 			m.screen = screenRDSDetail
 		}
-		return m, nil
+		return *m, nil
 	}
 
 	// Stop/failover require typing the identifier to confirm
 	// For Aurora cluster members, confirm with cluster ID; for standalone, instance ID
 	confirmTarget := ""
-	if m.selectedRDS != nil {
-		if m.selectedRDS.IsClusterMember() {
-			confirmTarget = m.selectedRDS.ClusterID
+	if rm.selected != nil {
+		if rm.selected.IsClusterMember() {
+			confirmTarget = rm.selected.ClusterID
 		} else {
-			confirmTarget = m.selectedRDS.DBInstanceID
+			confirmTarget = rm.selected.DBInstanceID
 		}
 	}
 	switch msg.String() {
 	case "esc":
 		m.screen = screenRDSDetail
 	case "enter":
-		if m.selectedRDS != nil && m.rdsConfirmInput == confirmTarget {
+		if rm.selected != nil && rm.confirmInput == confirmTarget {
 			m.screen = screenRDSDetail
-			return m, m.executeRDSAction(m.rdsAction, m.selectedRDS.DBInstanceID)
+			return *m, rm.executeAction(*m, rm.action, rm.selected.DBInstanceID)
 		}
 	case "backspace":
-		if len(m.rdsConfirmInput) > 0 {
-			m.rdsConfirmInput = m.rdsConfirmInput[:len(m.rdsConfirmInput)-1]
+		if len(rm.confirmInput) > 0 {
+			rm.confirmInput = rm.confirmInput[:len(rm.confirmInput)-1]
 		}
 	default:
 		if runes := msg.Runes; len(runes) > 0 {
-			m.rdsConfirmInput += string(runes)
+			rm.confirmInput += string(runes)
 		}
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) loadRDSInstances() tea.Cmd {
+func (rm rdsModel) loadInstances(m Model) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
@@ -182,10 +238,10 @@ func (m Model) loadRDSInstances() tea.Cmd {
 	}
 }
 
-func (m Model) executeRDSAction(action, dbInstanceID string) tea.Cmd {
+func (rm rdsModel) executeAction(m Model, action, dbInstanceID string) tea.Cmd {
 	clusterID := ""
-	if m.selectedRDS != nil {
-		clusterID = m.selectedRDS.ClusterID
+	if rm.selected != nil {
+		clusterID = rm.selected.ClusterID
 	}
 	return func() tea.Msg {
 		ctx := context.Background()
@@ -224,7 +280,7 @@ func (m Model) executeRDSAction(action, dbInstanceID string) tea.Cmd {
 	}
 }
 
-func (m Model) pollRDSStatus(dbInstanceID string) tea.Cmd {
+func (rm rdsModel) pollStatus(m Model, dbInstanceID string) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
 		repo := m.awsRepo
@@ -241,13 +297,13 @@ func (m Model) pollRDSStatus(dbInstanceID string) tea.Cmd {
 	}
 }
 
-func (m Model) tickRDSPoll(dbInstanceID string) tea.Cmd {
+func (rm rdsModel) tickPoll(dbInstanceID string) tea.Cmd {
 	return tea.Tick(5*time.Second, func(_ time.Time) tea.Msg {
 		return rdsTickMsg{instanceID: dbInstanceID}
 	})
 }
 
-func (m Model) viewRDSList() string {
+func (rm rdsModel) viewList(m Model) string {
 	var b strings.Builder
 	var panel strings.Builder
 	b.WriteString(m.renderStatusBar())
@@ -257,22 +313,22 @@ func (m Model) viewRDSList() string {
 	b.WriteString(m.renderFilterValue(filterRDS))
 	b.WriteString("\n\n")
 
-	if len(m.filteredRDS) == 0 {
+	if len(rm.filtered) == 0 {
 		panel.WriteString(dimStyle.Render("  No matching instances"))
 		panel.WriteString("\n")
 	} else {
 		visibleLines := max(m.height-10, 5)
 		start := 0
-		if m.rdsIdx >= visibleLines {
-			start = m.rdsIdx - visibleLines + 1
+		if rm.idx >= visibleLines {
+			start = rm.idx - visibleLines + 1
 		}
-		end := min(start+visibleLines, len(m.filteredRDS))
+		end := min(start+visibleLines, len(rm.filtered))
 
 		for i := start; i < end; i++ {
-			inst := m.filteredRDS[i]
+			inst := rm.filtered[i]
 			cursor := "  "
 			style := normalStyle
-			if i == m.rdsIdx {
+			if i == rm.idx {
 				cursor = "> "
 				style = selectedStyle
 			}
@@ -281,7 +337,7 @@ func (m Model) viewRDSList() string {
 		}
 
 		panel.WriteString("\n")
-		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d instances", len(m.filteredRDS), len(m.rdsInstances))))
+		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d instances", len(rm.filtered), len(rm.instances))))
 	}
 
 	b.WriteString(m.renderListPanel(panel.String()))
@@ -290,11 +346,11 @@ func (m Model) viewRDSList() string {
 	return b.String()
 }
 
-func (m Model) viewRDSDetail() string {
-	if m.selectedRDS == nil {
+func (rm rdsModel) viewDetail(m Model) string {
+	if rm.selected == nil {
 		return ""
 	}
-	r := m.selectedRDS
+	r := rm.selected
 	var b strings.Builder
 	b.WriteString(m.renderStatusBar())
 	b.WriteString(titleStyle.Render("RDS Instance Detail"))
@@ -315,7 +371,7 @@ func (m Model) viewRDSDetail() string {
 		statusStr = errorStyle.Render(r.Status)
 	}
 	pollingIndicator := ""
-	if m.rdsPolling {
+	if rm.polling {
 		pollingIndicator = filterStyle.Render(" (polling...)")
 	}
 	b.WriteString(renderDetailLine("Status", statusStr+pollingIndicator))
@@ -378,11 +434,11 @@ func (m Model) viewRDSDetail() string {
 	return b.String()
 }
 
-func (m Model) viewRDSConfirm() string {
-	if m.selectedRDS == nil {
+func (rm rdsModel) viewConfirm(m Model) string {
+	if rm.selected == nil {
 		return ""
 	}
-	r := m.selectedRDS
+	r := rm.selected
 
 	// For Aurora cluster members, show cluster-level info
 	targetLabel := "instance"
@@ -397,20 +453,20 @@ func (m Model) viewRDSConfirm() string {
 	b.WriteString(errorStyle.Render("Confirm Action"))
 	b.WriteString("\n\n")
 
-	if m.rdsAction == "start" {
+	if rm.action == "start" {
 		b.WriteString(normalStyle.Render(fmt.Sprintf("  Are you sure you want to start %s %s?",
 			targetLabel, targetID)))
 		b.WriteString("\n\n")
 		b.WriteString(normalStyle.Render("  [y] Yes  [n] No"))
 		b.WriteString("\n")
 	} else {
-		b.WriteString(normalStyle.Render(fmt.Sprintf("  You are about to %s %s:", m.rdsAction, targetLabel)))
+		b.WriteString(normalStyle.Render(fmt.Sprintf("  You are about to %s %s:", rm.action, targetLabel)))
 		b.WriteString("\n")
 		b.WriteString(selectedStyle.Render(fmt.Sprintf("  %s", targetID)))
 		b.WriteString("\n\n")
 		b.WriteString(normalStyle.Render(fmt.Sprintf("  Type the %s identifier to confirm:", targetLabel)))
 		b.WriteString("\n")
-		b.WriteString(filterStyle.Render(fmt.Sprintf("  %s▏", m.rdsConfirmInput)))
+		b.WriteString(filterStyle.Render(fmt.Sprintf("  %s▏", rm.confirmInput)))
 		b.WriteString("\n\n")
 		b.WriteString(m.renderHelpBar("enter: confirm • esc: cancel"))
 		b.WriteString("\n")


### PR DESCRIPTION
## Summary
- move RDS state, message handling, key handling, filtering, and views into an RDS feature submodel
- remove RDS-specific root Model fields and app.go dispatch/view branches
- keep existing RDS list/detail/confirmation behavior covered by existing tests

Progresses #107.

## Validation
- make test
- make build