### PR TITLE
feat: add ECR login helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ eval "$(unic env prod-admin)"
 # Interactively choose/setup a context and copy exports to clipboard
 unic context setup
 
+# Print an ECR login command for the current context
+unic ecr login
+
+# Copy a Podman ECR login command to the clipboard
+unic ecr login --runtime podman --copy
+
 # Set a display order for a context
 unic context order prod-admin 10
 
@@ -106,6 +112,7 @@ unic context unset
 
 `unic context setup` writes its prompts to `stderr` and copies the generated shell commands to the clipboard.
 `unic env` prints shell commands to `stdout` so it can be used with `eval`.
+`unic ecr login` prints a machine-usable container registry login command to `stdout` and can optionally copy it to the clipboard with `--copy`.
 Both flows now include a `UNIC_CONTEXT` marker in the generated exports so the TUI can show which shell context is currently active.
 Contexts can be prioritized in the setup picker with an `order` field in config.
 In the CLI `unic context setup` flow, the picker now filters contexts, SSO accounts, and SSO roles as you type, with arrow-key navigation and Enter to confirm.
@@ -216,6 +223,7 @@ Context ordering:
 | Secrets Manager | Secrets Browser |
 | CloudWatch | Metrics Viewer |
 | CloudWatch Logs | Logs Browser |
+| ECR | ECR Login Helper |
 | ECS | ECS Browser & Exec |
 | S3 | S3 Browser |
 | Lambda | Lambda Browser |
@@ -327,6 +335,7 @@ checks:
 | Bedrock API Keys | `c` create, choose current IAM user or another user, `r` rotate secret, `d` delete, type the IAM user/key ID to confirm, `c` copy one-time key without printing it, `e` copy `AWS_BEARER_TOKEN_BEDROCK` export |
 | CloudWatch Metrics | preset-driven metric list/detail flow, `/` filter, `space` select related series, `g` preset cycle, `t/p/s` range-period-stat controls, `r` refresh, in-terminal single-series and comparison charts |
 | CloudWatch Logs | log groups/streams load 10 at a time, `n` load more, `1`-`6` time presets, `t` live tail, `f` filter pattern, `w` wrap toggle, `h/l` horizontal scroll |
+| ECR Login | CLI helper: `unic ecr login [--runtime docker|podman] [--copy]` |
 | ECS Exec | `r` refresh, `Enter` drill down / exec |
 | ECS Rollout / Exec | cluster/service lists support refresh and drill-down, service detail shows deployments/task definition images/events, `Enter` continues into tasks and exec |
 | Inspector Mode | `i` open mode from the service list, `Enter` open the selected workflow, `l` open the checklist file picker |

--- a/internal/cli/ecr.go
+++ b/internal/cli/ecr.go
@@ -1,0 +1,87 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"unic/internal/clipboard"
+	"unic/internal/config"
+	awsservice "unic/internal/services/aws"
+)
+
+var (
+	ecrDefaultPathFn        = config.DefaultPath
+	ecrEnsureConfigExistsFn = config.EnsureConfigExists
+	ecrLoadConfigFn         = config.Load
+	ecrResolveRegistryURIFn = awsservice.ResolvePrivateECRRegistryURI
+	ecrBuildLoginCommandFn  = awsservice.BuildECRLoginCommand
+	ecrCopyClipboardFn      = clipboard.Copy
+)
+
+func newECRCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ecr",
+		Short: "ECR helper commands",
+	}
+
+	cmd.AddCommand(newECRLoginCmd())
+	return cmd
+}
+
+func newECRLoginCmd() *cobra.Command {
+	var runtime string
+	var copyToClipboard bool
+
+	cmd := &cobra.Command{
+		Use:   "login",
+		Short: "Print an ECR login command for the current AWS context",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configPath, err := ecrDefaultPathFn()
+			if err != nil {
+				return err
+			}
+			if err := ecrEnsureConfigExistsFn(configPath); err != nil {
+				return err
+			}
+
+			cfg, err := ecrLoadConfigFn(Profile(), Region(), configPath)
+			if err != nil {
+				return err
+			}
+
+			parsedRuntime, err := awsservice.ParseECRRuntime(runtime)
+			if err != nil {
+				return err
+			}
+
+			registryURI, _, err := ecrResolveRegistryURIFn(context.Background(), cfg)
+			if err != nil {
+				return err
+			}
+
+			command, err := ecrBuildLoginCommandFn(registryURI, cfg.Region, parsedRuntime)
+			if err != nil {
+				return err
+			}
+
+			if _, err := fmt.Fprintln(cmd.OutOrStdout(), command); err != nil {
+				return err
+			}
+
+			if copyToClipboard {
+				if err := ecrCopyClipboardFn(command); err != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "Clipboard unavailable: %v\n", err)
+				} else {
+					fmt.Fprintf(cmd.ErrOrStderr(), "Login command copied to clipboard for %s.\n", registryURI)
+				}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&runtime, "runtime", string(awsservice.ECRRuntimeDocker), "Container runtime to target (docker or podman)")
+	cmd.Flags().BoolVar(&copyToClipboard, "copy", false, "Copy the generated login command to the clipboard")
+	return cmd
+}

--- a/internal/cli/ecr_test.go
+++ b/internal/cli/ecr_test.go
@@ -1,0 +1,116 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"unic/internal/config"
+	awsservice "unic/internal/services/aws"
+)
+
+func TestRootIncludesECRLoginCommand(t *testing.T) {
+	cmd := NewRootCmd()
+	if _, _, err := cmd.Find([]string{"ecr", "login"}); err != nil {
+		t.Fatalf("expected ecr login command: %v", err)
+	}
+}
+
+func TestECRLoginPrintsCommand(t *testing.T) {
+	origDefaultPath := ecrDefaultPathFn
+	origEnsure := ecrEnsureConfigExistsFn
+	origLoad := ecrLoadConfigFn
+	origResolve := ecrResolveRegistryURIFn
+	origBuild := ecrBuildLoginCommandFn
+	defer func() {
+		ecrDefaultPathFn = origDefaultPath
+		ecrEnsureConfigExistsFn = origEnsure
+		ecrLoadConfigFn = origLoad
+		ecrResolveRegistryURIFn = origResolve
+		ecrBuildLoginCommandFn = origBuild
+	}()
+
+	ecrDefaultPathFn = func() (string, error) { return "/tmp/config.yaml", nil }
+	ecrEnsureConfigExistsFn = func(string) error { return nil }
+	ecrLoadConfigFn = func(*string, *string, string) (*config.Config, error) {
+		return &config.Config{Region: "ap-northeast-2"}, nil
+	}
+	ecrResolveRegistryURIFn = func(context.Context, *config.Config) (string, string, error) {
+		return "123456789012.dkr.ecr.ap-northeast-2.amazonaws.com", "123456789012", nil
+	}
+	ecrBuildLoginCommandFn = func(registryURI, region string, runtime awsservice.ECRRuntime) (string, error) {
+		if runtime != awsservice.ECRRuntimePodman {
+			t.Fatalf("expected podman runtime, got %s", runtime)
+		}
+		return "aws ecr get-login-password --region ap-northeast-2 | podman login --username AWS --password-stdin 123456789012.dkr.ecr.ap-northeast-2.amazonaws.com", nil
+	}
+
+	cmd := NewRootCmd()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"ecr", "login", "--runtime", "podman"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(stdout.String()); !strings.Contains(got, "podman login") {
+		t.Fatalf("expected podman login command, got %q", got)
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("expected no stderr output, got %q", stderr.String())
+	}
+}
+
+func TestECRLoginCopyReportsSuccessOnStderr(t *testing.T) {
+	origDefaultPath := ecrDefaultPathFn
+	origEnsure := ecrEnsureConfigExistsFn
+	origLoad := ecrLoadConfigFn
+	origResolve := ecrResolveRegistryURIFn
+	origBuild := ecrBuildLoginCommandFn
+	origCopy := ecrCopyClipboardFn
+	defer func() {
+		ecrDefaultPathFn = origDefaultPath
+		ecrEnsureConfigExistsFn = origEnsure
+		ecrLoadConfigFn = origLoad
+		ecrResolveRegistryURIFn = origResolve
+		ecrBuildLoginCommandFn = origBuild
+		ecrCopyClipboardFn = origCopy
+	}()
+
+	ecrDefaultPathFn = func() (string, error) { return "/tmp/config.yaml", nil }
+	ecrEnsureConfigExistsFn = func(string) error { return nil }
+	ecrLoadConfigFn = func(*string, *string, string) (*config.Config, error) {
+		return &config.Config{Region: "us-east-1"}, nil
+	}
+	ecrResolveRegistryURIFn = func(context.Context, *config.Config) (string, string, error) {
+		return "123456789012.dkr.ecr.us-east-1.amazonaws.com", "123456789012", nil
+	}
+	ecrBuildLoginCommandFn = func(string, string, awsservice.ECRRuntime) (string, error) {
+		return "aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 123456789012.dkr.ecr.us-east-1.amazonaws.com", nil
+	}
+	var copied string
+	ecrCopyClipboardFn = func(text string) error {
+		copied = text
+		return nil
+	}
+
+	cmd := NewRootCmd()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"ecr", "login", "--copy"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(copied, "docker login") {
+		t.Fatalf("expected copied login command, got %q", copied)
+	}
+	if !strings.Contains(stderr.String(), "copied to clipboard") {
+		t.Fatalf("expected clipboard success message, got %q", stderr.String())
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -29,6 +29,7 @@ func NewRootCmd() *cobra.Command {
 
 	cmd.AddCommand(newInitCmd())
 	cmd.AddCommand(newContextCmd())
+	cmd.AddCommand(newECRCmd())
 	cmd.AddCommand(newEnvCmd())
 	cmd.AddCommand(newUpdateCmd())
 

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -7,24 +7,36 @@ import (
 	"strings"
 )
 
+var lookPath = exec.LookPath
+var command = exec.Command
+
 // Copy copies text to the system clipboard.
 func Copy(text string) error {
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = exec.Command("pbcopy")
-	case "linux":
-		if _, err := exec.LookPath("wl-copy"); err == nil {
-			cmd = exec.Command("wl-copy")
-		} else if _, err := exec.LookPath("xclip"); err == nil {
-			cmd = exec.Command("xclip", "-selection", "clipboard")
-		} else {
-			cmd = exec.Command("xsel", "--clipboard", "--input")
-		}
-	default:
-		return fmt.Errorf("clipboard not supported on %s", runtime.GOOS)
+	cmd, err := clipboardCommand(runtime.GOOS)
+	if err != nil {
+		return err
 	}
 
 	cmd.Stdin = strings.NewReader(text)
 	return cmd.Run()
+}
+
+func clipboardCommand(goos string) (*exec.Cmd, error) {
+	switch goos {
+	case "darwin":
+		return command("pbcopy"), nil
+	case "linux":
+		if _, err := lookPath("wl-copy"); err == nil {
+			return command("wl-copy"), nil
+		}
+		if _, err := lookPath("xclip"); err == nil {
+			return command("xclip", "-selection", "clipboard"), nil
+		}
+		if _, err := lookPath("xsel"); err == nil {
+			return command("xsel", "--clipboard", "--input"), nil
+		}
+		return nil, fmt.Errorf("no clipboard utility found (tried: wl-copy, xclip, xsel)")
+	default:
+		return nil, fmt.Errorf("clipboard not supported on %s", goos)
+	}
 }

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -14,7 +14,9 @@ func Copy(text string) error {
 	case "darwin":
 		cmd = exec.Command("pbcopy")
 	case "linux":
-		if _, err := exec.LookPath("xclip"); err == nil {
+		if _, err := exec.LookPath("wl-copy"); err == nil {
+			cmd = exec.Command("wl-copy")
+		} else if _, err := exec.LookPath("xclip"); err == nil {
 			cmd = exec.Command("xclip", "-selection", "clipboard")
 		} else {
 			cmd = exec.Command("xsel", "--clipboard", "--input")

--- a/internal/clipboard/clipboard_test.go
+++ b/internal/clipboard/clipboard_test.go
@@ -1,0 +1,57 @@
+package clipboard
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+)
+
+func TestClipboardCommandLinuxUsesXselWhenAvailable(t *testing.T) {
+	originalLookPath := lookPath
+	originalCommand := command
+	defer func() {
+		lookPath = originalLookPath
+		command = originalCommand
+	}()
+
+	lookPath = func(file string) (string, error) {
+		switch file {
+		case "wl-copy", "xclip":
+			return "", errors.New("missing")
+		case "xsel":
+			return "/usr/bin/xsel", nil
+		default:
+			return "", errors.New("unexpected")
+		}
+	}
+	command = func(name string, args ...string) *exec.Cmd {
+		cmd := exec.Command("echo")
+		cmd.Args = append([]string{name}, args...)
+		return cmd
+	}
+
+	cmd, err := clipboardCommand("linux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cmd.Args) != 3 || cmd.Args[0] != "xsel" || cmd.Args[1] != "--clipboard" || cmd.Args[2] != "--input" {
+		t.Fatalf("unexpected command args: %#v", cmd.Args)
+	}
+}
+
+func TestClipboardCommandLinuxErrorsWhenNoUtilityExists(t *testing.T) {
+	originalLookPath := lookPath
+	defer func() { lookPath = originalLookPath }()
+
+	lookPath = func(file string) (string, error) {
+		return "", errors.New("missing")
+	}
+
+	_, err := clipboardCommand("linux")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != "no clipboard utility found (tried: wl-copy, xclip, xsel)" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/services/aws/ecr.go
+++ b/internal/services/aws/ecr.go
@@ -1,0 +1,69 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"unic/internal/config"
+)
+
+type ECRRuntime string
+
+const (
+	ECRRuntimeDocker ECRRuntime = "docker"
+	ECRRuntimePodman ECRRuntime = "podman"
+)
+
+func ParseECRRuntime(raw string) (ECRRuntime, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", string(ECRRuntimeDocker):
+		return ECRRuntimeDocker, nil
+	case string(ECRRuntimePodman):
+		return ECRRuntimePodman, nil
+	default:
+		return "", fmt.Errorf("unsupported runtime %q (expected docker or podman)", raw)
+	}
+}
+
+func BuildPrivateECRRegistryURI(accountID, region string) (string, error) {
+	accountID = strings.TrimSpace(accountID)
+	region = strings.TrimSpace(region)
+	if accountID == "" {
+		return "", fmt.Errorf("account ID is required")
+	}
+	if region == "" {
+		return "", fmt.Errorf("region is required")
+	}
+	return fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", accountID, region), nil
+}
+
+func BuildECRLoginCommand(registryURI, region string, runtime ECRRuntime) (string, error) {
+	if strings.TrimSpace(registryURI) == "" {
+		return "", fmt.Errorf("registry URI is required")
+	}
+	parsed, err := ParseECRRuntime(string(runtime))
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(region) == "" {
+		return "", fmt.Errorf("region is required")
+	}
+	return fmt.Sprintf("aws ecr get-login-password --region %s | %s login --username AWS --password-stdin %s", region, parsed, registryURI), nil
+}
+
+func ResolvePrivateECRRegistryURI(ctx context.Context, cfg *config.Config) (string, string, error) {
+	repo, err := NewAwsRepository(ctx, cfg)
+	if err != nil {
+		return "", "", err
+	}
+	identity, err := repo.GetCallerIdentity(ctx)
+	if err != nil {
+		return "", "", err
+	}
+	registry, err := BuildPrivateECRRegistryURI(identity.Account, cfg.Region)
+	if err != nil {
+		return "", "", err
+	}
+	return registry, identity.Account, nil
+}

--- a/internal/services/aws/ecr.go
+++ b/internal/services/aws/ecr.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"unic/internal/config"
@@ -13,6 +14,11 @@ type ECRRuntime string
 const (
 	ECRRuntimeDocker ECRRuntime = "docker"
 	ECRRuntimePodman ECRRuntime = "podman"
+)
+
+var (
+	awsRegionPattern   = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)+$`)
+	ecrRegistryPattern = regexp.MustCompile(`^[0-9]{12}\.dkr\.ecr\.([a-z0-9]+(?:-[a-z0-9]+)+)\.amazonaws\.com$`)
 )
 
 func ParseECRRuntime(raw string) (ECRRuntime, error) {
@@ -32,23 +38,48 @@ func BuildPrivateECRRegistryURI(accountID, region string) (string, error) {
 	if accountID == "" {
 		return "", fmt.Errorf("account ID is required")
 	}
+	if !isValidAWSAccountID(accountID) {
+		return "", fmt.Errorf("invalid AWS account ID")
+	}
 	if region == "" {
 		return "", fmt.Errorf("region is required")
+	}
+	if !isValidAWSRegion(region) {
+		return "", fmt.Errorf("invalid AWS region")
 	}
 	return fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", accountID, region), nil
 }
 
 func BuildECRLoginCommand(registryURI, region string, runtime ECRRuntime) (string, error) {
-	if strings.TrimSpace(registryURI) == "" {
+	registryURI = strings.TrimSpace(registryURI)
+	if registryURI == "" {
 		return "", fmt.Errorf("registry URI is required")
 	}
+	if !isValidECRRegistryURI(registryURI) {
+		return "", fmt.Errorf("invalid ECR registry URI")
+	}
+
 	parsed, err := ParseECRRuntime(string(runtime))
 	if err != nil {
 		return "", err
 	}
-	if strings.TrimSpace(region) == "" {
+
+	region = strings.TrimSpace(region)
+	if region == "" {
 		return "", fmt.Errorf("region is required")
 	}
+	if !isValidAWSRegion(region) {
+		return "", fmt.Errorf("invalid AWS region")
+	}
+
+	registryRegion := ecrRegistryRegion(registryURI)
+	if registryRegion == "" {
+		return "", fmt.Errorf("invalid ECR registry URI")
+	}
+	if registryRegion != region {
+		return "", fmt.Errorf("registry URI region does not match requested region")
+	}
+
 	return fmt.Sprintf("aws ecr get-login-password --region %s | %s login --username AWS --password-stdin %s", region, parsed, registryURI), nil
 }
 
@@ -66,4 +97,33 @@ func ResolvePrivateECRRegistryURI(ctx context.Context, cfg *config.Config) (stri
 		return "", "", err
 	}
 	return registry, identity.Account, nil
+}
+
+func isValidAWSAccountID(accountID string) bool {
+	if len(accountID) != 12 {
+		return false
+	}
+	for _, ch := range accountID {
+		if ch < '0' || ch > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func isValidAWSRegion(region string) bool {
+	return awsRegionPattern.MatchString(region)
+}
+
+func isValidECRRegistryURI(registryURI string) bool {
+	matches := ecrRegistryPattern.FindStringSubmatch(registryURI)
+	return len(matches) == 2 && isValidAWSRegion(matches[1])
+}
+
+func ecrRegistryRegion(registryURI string) string {
+	matches := ecrRegistryPattern.FindStringSubmatch(registryURI)
+	if len(matches) != 2 {
+		return ""
+	}
+	return matches[1]
 }

--- a/internal/services/aws/ecr_test.go
+++ b/internal/services/aws/ecr_test.go
@@ -1,0 +1,42 @@
+package aws
+
+import "testing"
+
+func TestBuildPrivateECRRegistryURI(t *testing.T) {
+	got, err := BuildPrivateECRRegistryURI("123456789012", "ap-northeast-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "123456789012.dkr.ecr.ap-northeast-2.amazonaws.com"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestBuildECRLoginCommandDocker(t *testing.T) {
+	got, err := BuildECRLoginCommand("123456789012.dkr.ecr.ap-northeast-2.amazonaws.com", "ap-northeast-2", ECRRuntimeDocker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin 123456789012.dkr.ecr.ap-northeast-2.amazonaws.com"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestBuildECRLoginCommandPodman(t *testing.T) {
+	got, err := BuildECRLoginCommand("123456789012.dkr.ecr.us-east-1.amazonaws.com", "us-east-1", ECRRuntimePodman)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "aws ecr get-login-password --region us-east-1 | podman login --username AWS --password-stdin 123456789012.dkr.ecr.us-east-1.amazonaws.com"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestParseECRRuntimeRejectsUnknown(t *testing.T) {
+	if _, err := ParseECRRuntime("nerdctl"); err == nil {
+		t.Fatal("expected unsupported runtime error")
+	}
+}

--- a/internal/services/aws/ecr_test.go
+++ b/internal/services/aws/ecr_test.go
@@ -1,6 +1,9 @@
 package aws
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestBuildPrivateECRRegistryURI(t *testing.T) {
 	got, err := BuildPrivateECRRegistryURI("123456789012", "ap-northeast-2")
@@ -10,6 +13,25 @@ func TestBuildPrivateECRRegistryURI(t *testing.T) {
 	want := "123456789012.dkr.ecr.ap-northeast-2.amazonaws.com"
 	if got != want {
 		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestBuildPrivateECRRegistryURIRejectsInvalidInput(t *testing.T) {
+	tests := []struct {
+		name      string
+		accountID string
+		region    string
+	}{
+		{name: "invalid account", accountID: "1234abc", region: "ap-northeast-2"},
+		{name: "invalid region", accountID: "123456789012", region: "ap-northeast-2; rm -rf /"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := BuildPrivateECRRegistryURI(tc.accountID, tc.region); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
 	}
 }
 
@@ -32,6 +54,42 @@ func TestBuildECRLoginCommandPodman(t *testing.T) {
 	want := "aws ecr get-login-password --region us-east-1 | podman login --username AWS --password-stdin 123456789012.dkr.ecr.us-east-1.amazonaws.com"
 	if got != want {
 		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestBuildECRLoginCommandRejectsInjectionAttempts(t *testing.T) {
+	tests := []struct {
+		name        string
+		registryURI string
+		region      string
+	}{
+		{
+			name:        "region injection",
+			registryURI: "123456789012.dkr.ecr.ap-northeast-2.amazonaws.com",
+			region:      "ap-northeast-2; rm -rf /",
+		},
+		{
+			name:        "registry injection",
+			registryURI: "123456789012.dkr.ecr.ap-northeast-2.amazonaws.com; curl bad",
+			region:      "ap-northeast-2",
+		},
+		{
+			name:        "registry region mismatch",
+			registryURI: "123456789012.dkr.ecr.us-east-1.amazonaws.com",
+			region:      "ap-northeast-2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := BuildECRLoginCommand(tc.registryURI, tc.region, ECRRuntimeDocker)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if strings.Contains(err.Error(), "; rm -rf /") || strings.Contains(err.Error(), "curl bad") {
+				t.Fatalf("error should not echo malicious shell payload verbatim: %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
### Summary

Add a CLI-first ECR login helper that resolves the private registry for the active AWS context and prints a ready-to-run login command.

- add `unic ecr login`
- support `--runtime docker|podman`
- support optional `--copy` clipboard flow
- add Wayland clipboard support via `wl-copy`
- update README usage and feature docs

### Related Issues

Closes #165

### Validation

- `PATH=/opt/homebrew/bin:$PATH make test`
- `PATH=/opt/homebrew/bin:$PATH make build`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed
- [ ] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [ ] Breaking changes documented
