### PR TITLE
feat: add EC2 instance browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It combines a Bubble Tea application, Cobra-based CLI commands, and AWS SDK v2 c
 - Drill down into resources with filters, detail views, and action screens
 - Open a context-aware keyboard shortcut help screen with `?`
 - Show animated loading indicators while async AWS data is being fetched
-- Perform operational workflows such as SSM sessions, RDS control, Route53 record changes, ECS rollout inspection/exec, IAM access key rotation, and Bedrock API key management
+- Perform operational workflows such as EC2 inventory inspection, SSM sessions, RDS control, Route53 record changes, ECS rollout inspection/exec, IAM access key rotation, and Bedrock API key management
 - Press `i` from the service picker to enter Inspector mode, then run either the Security Inspector workflow for built-in findings or the Checklist Inspector workflow for YAML-driven readiness checks across databases, network resources, DNS, logging, secrets, and baseline posture. Checklist files can be loaded from the in-TUI picker or preloaded with `--checklist <path>`
 
 ## Documentation Map
@@ -208,6 +208,7 @@ Context ordering:
 | Service | Feature |
 |---|---|
 | EC2 | SSM Session Manager |
+| EC2 | Instance Browser |
 | EC2 | Security Group Browser |
 | VPC | VPC Browser |
 | VPC | Reachability Analyzer |
@@ -319,6 +320,7 @@ checks:
 | Area | Keys |
 |---|---|
 | EC2 SSM | `r` refresh, `Enter` connect |
+| EC2 Instance Browser | `r` refresh, `/` filter, `Enter` detail |
 | Security Groups | `a` add rule, `d` delete rule, `Tab` switch ingress/egress |
 | Reachability Analyzer | Region select first, `←`/`→` or `Tab` change type, `/` filter, `Enter` advance, `Tab`/`↑`/`↓` move config fields, `←`/`→` protocol, `r` rerun |
 | RDS | `s` start, `x` stop, `f` failover, `r` refresh |
@@ -335,7 +337,9 @@ checks:
 | Context Picker | `a` add context, type or `/` filter, `s` setup selected context and quit, `y` copy selected exports and quit, `u` clear shell context and quit with a final confirmation message |
 | Lambda | `Enter` invoke, `d` detail, `l` view CloudWatch Logs, `/` filter, `r` refresh |
 
-The service list defaults to favorites first, then alphabetical order. Press `f` to favorite or unfavorite the selected service; favorites are saved under `favorites.services` in `config.yaml` and rendered with a distinct marker/style. The service list supports `/` filtering across service names, feature names, and feature descriptions. Shared list filters use fuzzy matching with inline match highlighting. While filter mode stays active, `↑`/`↓` continue to move through the filtered results without requiring an extra Enter first. Filtering is currently available on the service list, EC2 instances, IAM users, VPCs, subnets, RDS instances, Route53 zones/records, CloudWatch metrics, CloudWatch log groups/streams, Secrets Manager resources, ECS clusters/services, S3 buckets/objects, Lambda functions, Bedrock API keys, and the context picker.
+The service list defaults to favorites first, then alphabetical order. Press `f` to favorite or unfavorite the selected service; favorites are saved under `favorites.services` in `config.yaml` and rendered with a distinct marker/style. The service list supports `/` filtering across service names, feature names, and feature descriptions. Shared list filters use fuzzy matching with inline match highlighting. While filter mode stays active, `↑`/`↓` continue to move through the filtered results without requiring an extra Enter first. Filtering is currently available on the service list, EC2 SSM instances, EC2 inventory instances, IAM users, VPCs, subnets, RDS instances, Route53 zones/records, CloudWatch metrics, CloudWatch log groups/streams, Secrets Manager resources, ECS clusters/services, S3 buckets/objects, Lambda functions, Bedrock API keys, and the context picker.
+
+The EC2 Instance Browser lists EC2 instances across available states for the active context and region, separate from the SSM session picker that only lists connectable running instances. The detail screen shows core metadata including instance ID, name tag, state, instance type, AZ, VPC, subnet, private and public IPs, launch time, platform details, IAM profile, and tags.
 
 Bedrock API key management uses the active unic AWS context and IAM service-specific credential APIs for `bedrock.amazonaws.com`. The TUI lists long-term Bedrock API key metadata, opens a detail screen for inspection, defaults new key generation to the current IAM user when that user can be inferred from caller identity, and keeps another-user generation as an explicit option. Creation supports an optional expiration period, where blank or `0` means no expiration, rotates secrets with a one-time result screen, and deletes keys only after typed confirmation. Generated and rotated key values are intentionally copy-only and are not printed to the terminal; on the result screen, `c` copies the key and `e` copies `export AWS_BEARER_TOKEN_BEDROCK=...`.
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -23,6 +23,8 @@ const (
 	screenServiceList screen = iota
 	screenFeatureList
 	screenInstanceList
+	screenEC2InstanceBrowserList
+	screenEC2InstanceBrowserDetail
 	screenVPCList
 	screenSubnetList
 	screenSubnetDetail
@@ -238,10 +240,11 @@ type Model struct {
 	ecsContainerIdx int
 
 	// Feature submodels
-	cwMetrics cloudWatchMetricsModel
-	cwLogs    cloudWatchLogsModel
-	rds       rdsModel
-	bedrock   bedrockModel
+	ec2Browser ec2InstanceBrowserModel
+	cwMetrics  cloudWatchMetricsModel
+	cwLogs     cloudWatchLogsModel
+	rds        rdsModel
+	bedrock    bedrockModel
 
 	// S3 browser state
 	s3Buckets         []awsservice.S3Bucket
@@ -363,6 +366,7 @@ func New(cfg *config.Config, configPath string, version string, checklistPath ..
 		filters:                make(map[filterTarget]string),
 		contextTable:           newContextTable(),
 	}
+	model.ec2Browser = newEC2InstanceBrowserModel()
 	model.cwMetrics = newCloudWatchMetricsModel()
 	model.cwLogs = newCloudWatchLogsModel()
 	model.rds = newRDSModel()
@@ -720,6 +724,8 @@ func (m Model) updateFeatureList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			switch feat.Kind {
 			case domain.FeatureSSMSession:
 				return m.startLoading(m.loadInstances())
+			case domain.FeatureEC2InstanceBrowser:
+				return m.ec2Browser.Start(&m)
 			case domain.FeatureVPCBrowser:
 				return m.startLoading(m.loadVPCs())
 			case domain.FeatureReachabilityAnalyzer:

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -330,6 +330,148 @@ func TestRDSListNavigationWraps(t *testing.T) {
 	}
 }
 
+// --- EC2 instance browser tests ---
+
+func TestFeatureListEC2InstanceBrowserGoesToLoading(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenFeatureList
+	m.features = []domain.Feature{
+		{Kind: domain.FeatureEC2InstanceBrowser, Description: "Browse EC2 instances"},
+	}
+	m.featIdx = 0
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model := updated.(Model)
+	if model.screen != screenLoading {
+		t.Errorf("expected loading screen, got %d", model.screen)
+	}
+	if cmd == nil {
+		t.Error("expected a command to load EC2 instances")
+	}
+}
+
+func TestEC2BrowserInstancesLoadedMsg(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenLoading
+
+	instances := []awsservice.EC2Instance{
+		{InstanceID: "i-1", Name: "app-a", State: "running", InstanceType: "t3.micro"},
+	}
+	updated, _ := m.Update(ec2BrowserInstancesLoadedMsg{instances: instances})
+	model := updated.(Model)
+	if model.screen != screenEC2InstanceBrowserList {
+		t.Errorf("expected EC2 browser list screen, got %d", model.screen)
+	}
+	if len(model.ec2Browser.instances) != 1 {
+		t.Errorf("expected 1 instance, got %d", len(model.ec2Browser.instances))
+	}
+}
+
+func TestEC2BrowserListNavigationWraps(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenEC2InstanceBrowserList
+	m.ec2Browser.filtered = []awsservice.EC2Instance{
+		{InstanceID: "i-a"},
+		{InstanceID: "i-b"},
+	}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	model := updated.(Model)
+	if model.ec2Browser.idx != 1 {
+		t.Fatalf("expected up from first EC2 instance to wrap to last, got %d", model.ec2Browser.idx)
+	}
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	model = updated.(Model)
+	if model.ec2Browser.idx != 0 {
+		t.Fatalf("expected down from last EC2 instance to wrap to first, got %d", model.ec2Browser.idx)
+	}
+}
+
+func TestEC2BrowserListFilter(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenEC2InstanceBrowserList
+	m.ec2Browser.instances = []awsservice.EC2Instance{
+		{InstanceID: "i-prod", Name: "prod-web", State: "running", InstanceType: "t3.micro"},
+		{InstanceID: "i-dev", Name: "dev-web", State: "stopped", InstanceType: "t3.small"},
+	}
+	m.ec2Browser.filtered = m.ec2Browser.instances
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	model := updated.(Model)
+	for _, ch := range []rune("prod") {
+		updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{ch}})
+		model = updated.(Model)
+	}
+
+	if len(model.ec2Browser.filtered) != 1 {
+		t.Errorf("expected 1 filtered instance, got %d", len(model.ec2Browser.filtered))
+	}
+	if model.ec2Browser.filtered[0].InstanceID != "i-prod" {
+		t.Errorf("expected i-prod, got %q", model.ec2Browser.filtered[0].InstanceID)
+	}
+}
+
+func TestEC2BrowserListEnterGoesToDetail(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenEC2InstanceBrowserList
+	m.ec2Browser.instances = []awsservice.EC2Instance{
+		{InstanceID: "i-1", Name: "app-a"},
+	}
+	m.ec2Browser.filtered = m.ec2Browser.instances
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model := updated.(Model)
+	if model.screen != screenEC2InstanceBrowserDetail {
+		t.Errorf("expected EC2 browser detail screen, got %d", model.screen)
+	}
+	if model.ec2Browser.selected == nil {
+		t.Error("ec2Browser.selected should not be nil")
+	}
+}
+
+func TestEC2BrowserDetailViewShowsMetadata(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenEC2InstanceBrowserDetail
+	m.ec2Browser.selected = &awsservice.EC2Instance{
+		InstanceID:       "i-123",
+		Name:             "prod-web",
+		State:            "running",
+		InstanceType:     "m6i.large",
+		AvailabilityZone: "us-east-1a",
+		VPCID:            "vpc-123",
+		SubnetID:         "subnet-123",
+		PrivateIP:        "10.0.0.10",
+		PublicIP:         "203.0.113.10",
+		LaunchTime:       time.Date(2026, 4, 22, 12, 30, 0, 0, time.UTC),
+		PlatformDetails:  "Linux/UNIX",
+		IAMProfile:       "arn:aws:iam::123456789012:instance-profile/app",
+		Tags:             map[string]string{"Environment": "prod"},
+	}
+
+	view := m.View()
+	for _, want := range []string{
+		"EC2 Instance Detail",
+		"i-123",
+		"prod-web",
+		"running",
+		"m6i.large",
+		"us-east-1a",
+		"vpc-123",
+		"subnet-123",
+		"10.0.0.10",
+		"203.0.113.10",
+		"Linux/UNIX",
+		"instance-profile/app",
+		"Environment",
+		"prod",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected EC2 detail view to contain %q, got %q", want, view)
+		}
+	}
+}
+
 func TestReachabilityFeatureOpensRegionSelection(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenFeatureList

--- a/internal/app/feature_submodel.go
+++ b/internal/app/feature_submodel.go
@@ -10,5 +10,5 @@ type featureSubmodel interface {
 }
 
 func (m *Model) featureSubmodels() []featureSubmodel {
-	return []featureSubmodel{&m.cwMetrics, &m.cwLogs, &m.rds, &m.bedrock}
+	return []featureSubmodel{&m.ec2Browser, &m.cwMetrics, &m.cwLogs, &m.rds, &m.bedrock}
 }

--- a/internal/app/filter.go
+++ b/internal/app/filter.go
@@ -11,6 +11,7 @@ const (
 	filterNone filterTarget = iota
 	filterServices
 	filterInstances
+	filterEC2BrowserInstances
 	filterSubnetIPs
 	filterRDS
 	filterRoute53Zones

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -132,6 +132,12 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 		}
 	case screenInstanceList:
 		return listScreenShortcuts("connect to the selected instance", "go back to the feature list", true, true)
+	case screenEC2InstanceBrowserList:
+		return listScreenShortcuts("open the selected instance", "go back to the feature list", true, false)
+	case screenEC2InstanceBrowserDetail:
+		return []helpShortcut{
+			{"q / esc", "Go back to the instance list"},
+		}
 	case screenVPCList:
 		return []helpShortcut{
 			{"↑/↓, j/k", "Move between VPCs"},
@@ -674,7 +680,11 @@ func (m Model) helpScreenTitle() string {
 		}
 		return "Feature List"
 	case screenInstanceList:
-		return "EC2 Instances"
+		return "EC2 SSM Instances"
+	case screenEC2InstanceBrowserList:
+		return "EC2 Instance Browser"
+	case screenEC2InstanceBrowserDetail:
+		return "EC2 Instance Detail"
 	case screenVPCList:
 		return "VPC List"
 	case screenSubnetList:

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -11,6 +11,10 @@ type instancesLoadedMsg struct {
 	instances []awsservice.EC2Instance
 }
 
+type ec2BrowserInstancesLoadedMsg struct {
+	instances []awsservice.EC2Instance
+}
+
 type vpcsLoadedMsg struct {
 	vpcs []awsservice.VPC
 }

--- a/internal/app/screen_ec2_browser.go
+++ b/internal/app/screen_ec2_browser.go
@@ -118,7 +118,6 @@ func (em ec2InstanceBrowserModel) loadInstances(m Model) tea.Cmd {
 		if err != nil {
 			return errMsg{err: err}
 		}
-		m.awsRepo = repo
 
 		instances, err := repo.ListEC2Instances(ctx)
 		if err != nil {

--- a/internal/app/screen_ec2_browser.go
+++ b/internal/app/screen_ec2_browser.go
@@ -1,0 +1,252 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	awsservice "unic/internal/services/aws"
+)
+
+type ec2InstanceBrowserModel struct {
+	instances []awsservice.EC2Instance
+	filtered  []awsservice.EC2Instance
+	idx       int
+	selected  *awsservice.EC2Instance
+}
+
+func newEC2InstanceBrowserModel() ec2InstanceBrowserModel {
+	return ec2InstanceBrowserModel{}
+}
+
+func (em *ec2InstanceBrowserModel) Start(m *Model) (tea.Model, tea.Cmd) {
+	return m.startLoading(em.loadInstances(*m))
+}
+
+func (em *ec2InstanceBrowserModel) HandleMessage(m *Model, msg tea.Msg) (tea.Model, tea.Cmd, bool) {
+	switch msg := msg.(type) {
+	case ec2BrowserInstancesLoadedMsg:
+		em.instances = msg.instances
+		em.filtered = applyFilter(em.instances, m.filterValue(filterEC2BrowserInstances))
+		em.idx = 0
+		em.selected = nil
+		m.screen = screenEC2InstanceBrowserList
+		return *m, nil, true
+	}
+	return *m, nil, false
+}
+
+func (em *ec2InstanceBrowserModel) HandleKey(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
+	switch m.screen {
+	case screenEC2InstanceBrowserList:
+		newM, cmd := em.updateList(m, msg)
+		return newM, cmd, true
+	case screenEC2InstanceBrowserDetail:
+		newM, cmd := em.updateDetail(m, msg)
+		return newM, cmd, true
+	default:
+		return *m, nil, false
+	}
+}
+
+func (em ec2InstanceBrowserModel) View(m Model) (string, bool) {
+	switch m.screen {
+	case screenEC2InstanceBrowserList:
+		return em.viewList(m), true
+	case screenEC2InstanceBrowserDetail:
+		return em.viewDetail(m), true
+	default:
+		return "", false
+	}
+}
+
+func (em *ec2InstanceBrowserModel) ApplyFilter(m *Model, target filterTarget) bool {
+	if target != filterEC2BrowserInstances {
+		return false
+	}
+	em.filtered = applyFilter(em.instances, m.filterValue(target))
+	em.idx = 0
+	return true
+}
+
+func (em *ec2InstanceBrowserModel) updateList(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	key := msg.String()
+
+	if cmd, handled := m.updateSharedFilter(msg, filterEC2BrowserInstances); handled {
+		return *m, cmd
+	}
+
+	switch key {
+	case "q", "esc":
+		m.screen = screenFeatureList
+		m.resetFilter(filterEC2BrowserInstances)
+	case "up", "k":
+		em.idx = previousListIndex(em.idx, len(em.filtered))
+	case "down", "j":
+		em.idx = nextListIndex(em.idx, len(em.filtered))
+	case "/":
+		return *m, m.activateFilter(filterEC2BrowserInstances)
+	case "r":
+		m.resetFilter(filterEC2BrowserInstances)
+		return m.startLoading(em.loadInstances(*m))
+	case "enter":
+		if len(em.filtered) > 0 && em.idx < len(em.filtered) {
+			selected := em.filtered[em.idx]
+			em.selected = &selected
+			m.screen = screenEC2InstanceBrowserDetail
+		}
+	}
+	return *m, nil
+}
+
+func (em *ec2InstanceBrowserModel) updateDetail(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "esc":
+		m.screen = screenEC2InstanceBrowserList
+	}
+	return *m, nil
+}
+
+func (em ec2InstanceBrowserModel) loadInstances(m Model) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		m.awsRepo = repo
+
+		instances, err := repo.ListEC2Instances(ctx)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		return ec2BrowserInstancesLoadedMsg{instances: instances}
+	}
+}
+
+func (em ec2InstanceBrowserModel) viewList(m Model) string {
+	var b strings.Builder
+	var panel strings.Builder
+	b.WriteString(m.renderStatusBar())
+	b.WriteString(titleStyle.Render("EC2 Instance Browser"))
+	b.WriteString("\n")
+
+	b.WriteString(m.renderFilterValue(filterEC2BrowserInstances))
+	b.WriteString("\n\n")
+
+	if len(em.filtered) == 0 {
+		emptyText := "  No EC2 instances found"
+		if len(em.instances) > 0 {
+			emptyText = "  No matching instances"
+		}
+		panel.WriteString(dimStyle.Render(emptyText))
+		panel.WriteString("\n")
+	} else {
+		visibleLines := max(m.height-10, 5)
+		start := 0
+		if em.idx >= visibleLines {
+			start = em.idx - visibleLines + 1
+		}
+		end := min(start+visibleLines, len(em.filtered))
+
+		for i := start; i < end; i++ {
+			inst := em.filtered[i]
+			cursor := "  "
+			style := normalStyle
+			if i == em.idx {
+				cursor = "> "
+				style = selectedStyle
+			}
+			panel.WriteString(style.Render(cursor + m.renderHighlightedValue(filterEC2BrowserInstances, inst.DisplayTitle())))
+			panel.WriteString("\n")
+		}
+
+		panel.WriteString("\n")
+		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d instances", len(em.filtered), len(em.instances))))
+	}
+
+	b.WriteString(m.renderListPanel(panel.String()))
+	b.WriteString("\n\n")
+	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • r: refresh • enter: details • esc: back • H: home"))
+	return b.String()
+}
+
+func (em ec2InstanceBrowserModel) viewDetail(m Model) string {
+	if em.selected == nil {
+		return ""
+	}
+	inst := em.selected
+	var b strings.Builder
+	b.WriteString(m.renderStatusBar())
+	b.WriteString(titleStyle.Render("EC2 Instance Detail"))
+	b.WriteString("\n\n")
+
+	b.WriteString(renderDetailLine("Instance ID", normalStyle.Render(inst.InstanceID)))
+	b.WriteString(renderDetailLine("Name", normalStyle.Render(ec2ValueOrDash(inst.Name))))
+	b.WriteString(renderDetailLine("State", renderEC2InstanceState(inst.State)))
+	b.WriteString(renderDetailLine("Type", normalStyle.Render(ec2ValueOrDash(inst.InstanceType))))
+	b.WriteString(renderDetailLine("AZ", normalStyle.Render(ec2ValueOrDash(inst.AvailabilityZone))))
+	b.WriteString(renderDetailLine("VPC", normalStyle.Render(ec2ValueOrDash(inst.VPCID))))
+	b.WriteString(renderDetailLine("Subnet", normalStyle.Render(ec2ValueOrDash(inst.SubnetID))))
+	b.WriteString(renderDetailLine("Private IP", normalStyle.Render(ec2ValueOrDash(inst.PrivateIP))))
+	b.WriteString(renderDetailLine("Public IP", normalStyle.Render(ec2ValueOrDash(inst.PublicIP))))
+	b.WriteString(renderDetailLine("Launch Time", normalStyle.Render(formatEC2LaunchTime(inst.LaunchTime))))
+	b.WriteString(renderDetailLine("Platform", normalStyle.Render(ec2ValueOrDash(inst.PlatformDetails))))
+	b.WriteString(renderDetailLine("IAM Profile", normalStyle.Render(ec2ValueOrDash(inst.IAMProfile))))
+
+	b.WriteString("\n")
+	b.WriteString(titleStyle.Render("Tags"))
+	b.WriteString("\n")
+	if len(inst.Tags) == 0 {
+		b.WriteString(dimStyle.Render("  (none)"))
+		b.WriteString("\n")
+	} else {
+		for _, key := range sortedEC2TagKeys(inst.Tags) {
+			b.WriteString(renderDetailLine(key, normalStyle.Render(inst.Tags[key])))
+		}
+	}
+
+	b.WriteString("\n")
+	b.WriteString(m.renderHelpBar("esc: back • H: home"))
+	return b.String()
+}
+
+func renderEC2InstanceState(state string) string {
+	switch state {
+	case "running":
+		return selectedStyle.Render(state)
+	case "stopped", "terminated", "shutting-down":
+		return errorStyle.Render(ec2ValueOrDash(state))
+	case "":
+		return dimStyle.Render("-")
+	default:
+		return normalStyle.Render(state)
+	}
+}
+
+func formatEC2LaunchTime(t time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	return t.Local().Format("2006-01-02 15:04:05 MST")
+}
+
+func sortedEC2TagKeys(tags map[string]string) []string {
+	keys := make([]string, 0, len(tags))
+	for key := range tags {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func ec2ValueOrDash(value string) string {
+	if value == "" || value == "Unknown" {
+		return "-"
+	}
+	return value
+}

--- a/internal/domain/catalog.go
+++ b/internal/domain/catalog.go
@@ -11,6 +11,10 @@ func Catalog() []Service {
 					Description: "Start an SSM session to an EC2 instance",
 				},
 				{
+					Kind:        FeatureEC2InstanceBrowser,
+					Description: "Browse EC2 instances and inspect instance metadata",
+				},
+				{
 					Kind:        FeatureSecurityGroupBrowser,
 					Description: "Browse security groups and view inbound/outbound rules",
 				},

--- a/internal/domain/catalog_test.go
+++ b/internal/domain/catalog_test.go
@@ -36,6 +36,24 @@ func TestEC2HasSSMSessionFeature(t *testing.T) {
 	t.Error("EC2 service not found in catalog")
 }
 
+func TestEC2HasInstanceBrowserFeature(t *testing.T) {
+	services := Catalog()
+
+	for _, svc := range services {
+		if svc.Name == ServiceEC2 {
+			for _, feat := range svc.Features {
+				if feat.Kind == FeatureEC2InstanceBrowser {
+					return
+				}
+			}
+			t.Error("EC2 service should have EC2 Instance Browser feature")
+			return
+		}
+	}
+
+	t.Error("EC2 service not found in catalog")
+}
+
 func TestCatalogNotEmpty(t *testing.T) {
 	services := Catalog()
 	if len(services) == 0 {

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -25,6 +25,7 @@ type FeatureKind string
 
 const (
 	FeatureSSMSession            FeatureKind = "SSM Sessions Manager"
+	FeatureEC2InstanceBrowser    FeatureKind = "EC2 Instance Browser"
 	FeatureVPCBrowser            FeatureKind = "VPC Browser"
 	FeatureReachabilityAnalyzer  FeatureKind = "Reachability Analyzer"
 	FeatureRDSBrowser            FeatureKind = "RDS Browser"

--- a/internal/services/aws/ec2.go
+++ b/internal/services/aws/ec2.go
@@ -132,11 +132,9 @@ func ec2InstanceFromSDK(inst types.Instance) EC2Instance {
 		VPCID:           derefString(inst.VpcId),
 		SubnetID:        derefString(inst.SubnetId),
 		InstanceType:    string(inst.InstanceType),
+		State:           ec2InstanceStateName(inst.State),
 		PlatformDetails: derefString(inst.PlatformDetails),
 		Tags:            tagsToMap(inst.Tags),
-	}
-	if inst.State != nil {
-		instance.State = string(inst.State.Name)
 	}
 	if inst.Placement != nil {
 		instance.AvailabilityZone = derefString(inst.Placement.AvailabilityZone)
@@ -148,6 +146,13 @@ func ec2InstanceFromSDK(inst types.Instance) EC2Instance {
 		instance.IAMProfile = derefString(inst.IamInstanceProfile.Arn)
 	}
 	return instance
+}
+
+func ec2InstanceStateName(state *types.InstanceState) string {
+	if state == nil {
+		return ""
+	}
+	return string(state.Name)
 }
 
 func tagsToMap(tags []types.Tag) map[string]string {

--- a/internal/services/aws/ec2.go
+++ b/internal/services/aws/ec2.go
@@ -50,25 +50,37 @@ func (r *AwsRepository) ListRunningInstances(ctx context.Context) ([]EC2Instance
 
 		for _, reservation := range page.Reservations {
 			for _, inst := range reservation.Instances {
-				instances = append(instances, EC2Instance{
-					InstanceID: derefString(inst.InstanceId),
-					Name:       extractNameTag(inst.Tags),
-					PrivateIP:  derefString(inst.PrivateIpAddress),
-					State:      string(inst.State.Name),
-				})
+				instances = append(instances, ec2InstanceFromSDK(inst))
 			}
 		}
 	}
 
-	sort.Slice(instances, func(i, j int) bool {
-		left := normalizedSortKey(instances[i].Name, instances[i].InstanceID)
-		right := normalizedSortKey(instances[j].Name, instances[j].InstanceID)
-		if left == right {
-			return instances[i].InstanceID < instances[j].InstanceID
-		}
-		return left < right
-	})
+	sortEC2Instances(instances)
 
+	return instances, nil
+}
+
+// ListEC2Instances returns EC2 instances in the current account/region across states.
+func (r *AwsRepository) ListEC2Instances(ctx context.Context) ([]EC2Instance, error) {
+	uniclog.Debug("aws", "ListEC2Instances called")
+
+	var instances []EC2Instance
+	paginator := ec2.NewDescribeInstancesPaginator(r.EC2Client, &ec2.DescribeInstancesInput{})
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, reservation := range page.Reservations {
+			for _, inst := range reservation.Instances {
+				instances = append(instances, ec2InstanceFromSDK(inst))
+			}
+		}
+	}
+
+	sortEC2Instances(instances)
 	return instances, nil
 }
 
@@ -109,6 +121,59 @@ func extractNameTag(tags []types.Tag) string {
 		}
 	}
 	return "Unknown"
+}
+
+func ec2InstanceFromSDK(inst types.Instance) EC2Instance {
+	instance := EC2Instance{
+		InstanceID:      derefString(inst.InstanceId),
+		Name:            extractNameTag(inst.Tags),
+		PrivateIP:       derefString(inst.PrivateIpAddress),
+		PublicIP:        derefString(inst.PublicIpAddress),
+		VPCID:           derefString(inst.VpcId),
+		SubnetID:        derefString(inst.SubnetId),
+		InstanceType:    string(inst.InstanceType),
+		PlatformDetails: derefString(inst.PlatformDetails),
+		Tags:            tagsToMap(inst.Tags),
+	}
+	if inst.State != nil {
+		instance.State = string(inst.State.Name)
+	}
+	if inst.Placement != nil {
+		instance.AvailabilityZone = derefString(inst.Placement.AvailabilityZone)
+	}
+	if inst.LaunchTime != nil {
+		instance.LaunchTime = *inst.LaunchTime
+	}
+	if inst.IamInstanceProfile != nil {
+		instance.IAMProfile = derefString(inst.IamInstanceProfile.Arn)
+	}
+	return instance
+}
+
+func tagsToMap(tags []types.Tag) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(tags))
+	for _, tag := range tags {
+		key := derefString(tag.Key)
+		if key == "" {
+			continue
+		}
+		out[key] = derefString(tag.Value)
+	}
+	return out
+}
+
+func sortEC2Instances(instances []EC2Instance) {
+	sort.Slice(instances, func(i, j int) bool {
+		left := normalizedSortKey(instances[i].Name, instances[i].InstanceID)
+		right := normalizedSortKey(instances[j].Name, instances[j].InstanceID)
+		if left == right {
+			return instances[i].InstanceID < instances[j].InstanceID
+		}
+		return left < right
+	})
 }
 
 func derefString(s *string) string {

--- a/internal/services/aws/ec2_model.go
+++ b/internal/services/aws/ec2_model.go
@@ -3,23 +3,68 @@ package aws
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
-// EC2Instance holds the essential information about a running EC2 instance.
+// EC2Instance holds the essential information about an EC2 instance.
 type EC2Instance struct {
-	InstanceID string
-	Name       string
-	PrivateIP  string
-	State      string
+	InstanceID       string
+	Name             string
+	State            string
+	InstanceType     string
+	AvailabilityZone string
+	VPCID            string
+	SubnetID         string
+	PrivateIP        string
+	PublicIP         string
+	LaunchTime       time.Time
+	PlatformDetails  string
+	IAMProfile       string
+	Tags             map[string]string
 }
 
 // FilterText returns a lowercase string combining name, instance ID, and IP
 // for keyword matching.
 func (i EC2Instance) FilterText() string {
-	return strings.ToLower(fmt.Sprintf("%s %s %s", i.Name, i.InstanceID, i.PrivateIP))
+	parts := []string{
+		i.Name,
+		i.InstanceID,
+		i.State,
+		i.InstanceType,
+		i.AvailabilityZone,
+		i.VPCID,
+		i.SubnetID,
+		i.PrivateIP,
+		i.PublicIP,
+		i.PlatformDetails,
+		i.IAMProfile,
+	}
+	for key, value := range i.Tags {
+		parts = append(parts, key, value)
+	}
+	return strings.ToLower(strings.Join(parts, " "))
 }
 
 // DisplayTitle returns a formatted string for list display.
 func (i EC2Instance) DisplayTitle() string {
-	return fmt.Sprintf("%s (%s) - %s", i.Name, i.InstanceID, i.PrivateIP)
+	name := i.Name
+	if name == "" || name == "Unknown" {
+		name = "-"
+	}
+	network := i.PrivateIP
+	if network == "" {
+		network = i.PublicIP
+	}
+	if network == "" {
+		network = "-"
+	}
+	instanceType := i.InstanceType
+	if instanceType == "" {
+		instanceType = "-"
+	}
+	state := i.State
+	if state == "" {
+		state = "-"
+	}
+	return fmt.Sprintf("%s (%s) %s [%s] - %s", name, i.InstanceID, instanceType, state, network)
 }

--- a/internal/services/aws/ec2_test.go
+++ b/internal/services/aws/ec2_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -19,20 +20,45 @@ func TestFilterText(t *testing.T) {
 	}
 
 	got := inst.FilterText()
-	if got != "webserver i-1234567890abcdef0 10.0.1.50" {
-		t.Errorf("unexpected FilterText: %q", got)
+	for _, keyword := range []string{"webserver", "i-1234567890abcdef0", "10.0.1.50"} {
+		if !containsStr(got, keyword) {
+			t.Errorf("FilterText %q should contain %q", got, keyword)
+		}
 	}
 }
 
 func TestFilterTextContainsAllFields(t *testing.T) {
 	inst := EC2Instance{
-		InstanceID: "i-abc",
-		Name:       "MyApp",
-		PrivateIP:  "172.16.0.1",
+		InstanceID:       "i-abc",
+		Name:             "MyApp",
+		State:            "running",
+		InstanceType:     "t3.micro",
+		AvailabilityZone: "us-east-1a",
+		VPCID:            "vpc-123",
+		SubnetID:         "subnet-123",
+		PrivateIP:        "172.16.0.1",
+		PublicIP:         "203.0.113.10",
+		PlatformDetails:  "Linux/UNIX",
+		IAMProfile:       "arn:aws:iam::123456789012:instance-profile/app",
+		Tags:             map[string]string{"Environment": "prod"},
 	}
 
 	ft := inst.FilterText()
-	for _, keyword := range []string{"myapp", "i-abc", "172.16.0.1"} {
+	for _, keyword := range []string{
+		"myapp",
+		"i-abc",
+		"running",
+		"t3.micro",
+		"us-east-1a",
+		"vpc-123",
+		"subnet-123",
+		"172.16.0.1",
+		"203.0.113.10",
+		"linux/unix",
+		"instance-profile/app",
+		"environment",
+		"prod",
+	} {
 		if !containsStr(ft, keyword) {
 			t.Errorf("FilterText %q should contain %q", ft, keyword)
 		}
@@ -41,12 +67,14 @@ func TestFilterTextContainsAllFields(t *testing.T) {
 
 func TestDisplayTitle(t *testing.T) {
 	inst := EC2Instance{
-		InstanceID: "i-abc",
-		Name:       "MyApp",
-		PrivateIP:  "10.0.0.1",
+		InstanceID:   "i-abc",
+		Name:         "MyApp",
+		State:        "running",
+		InstanceType: "t3.micro",
+		PrivateIP:    "10.0.0.1",
 	}
 
-	expected := "MyApp (i-abc) - 10.0.0.1"
+	expected := "MyApp (i-abc) t3.micro [running] - 10.0.0.1"
 	if got := inst.DisplayTitle(); got != expected {
 		t.Errorf("expected %q, got %q", expected, got)
 	}
@@ -153,6 +181,98 @@ func TestListRunningInstances_SortedByName(t *testing.T) {
 	}
 	if instances[0].Name != "alpha-web" || instances[1].Name != "zeta-web" {
 		t.Fatalf("expected alphabetical EC2 order, got %+v", instances)
+	}
+}
+
+func TestListEC2Instances_MapsInventoryFields(t *testing.T) {
+	launch := time.Date(2026, 4, 22, 12, 30, 0, 0, time.UTC)
+	ec2Mock := &mockEC2Client{
+		describeInstancesFunc: func(_ context.Context, params *ec2.DescribeInstancesInput, _ ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+			if len(params.Filters) != 0 {
+				t.Fatalf("expected no filters for inventory browser, got %+v", params.Filters)
+			}
+			if len(params.InstanceIds) != 0 {
+				t.Fatalf("expected no instance IDs for inventory browser, got %+v", params.InstanceIds)
+			}
+			return &ec2.DescribeInstancesOutput{
+				Reservations: []types.Reservation{
+					{
+						Instances: []types.Instance{
+							{
+								InstanceId:       aws.String("i-2"),
+								InstanceType:     types.InstanceTypeM6iLarge,
+								PrivateIpAddress: aws.String("10.0.0.2"),
+								PublicIpAddress:  aws.String("203.0.113.2"),
+								State:            &types.InstanceState{Name: types.InstanceStateNameStopped},
+								Placement:        &types.Placement{AvailabilityZone: aws.String("us-east-1b")},
+								VpcId:            aws.String("vpc-2"),
+								SubnetId:         aws.String("subnet-2"),
+								LaunchTime:       &launch,
+								PlatformDetails:  aws.String("Linux/UNIX"),
+								IamInstanceProfile: &types.IamInstanceProfile{
+									Arn: aws.String("arn:aws:iam::123456789012:instance-profile/app"),
+								},
+								Tags: []types.Tag{
+									{Key: aws.String("Name"), Value: aws.String("zeta-web")},
+									{Key: aws.String("Environment"), Value: aws.String("prod")},
+								},
+							},
+							{
+								InstanceId:       aws.String("i-1"),
+								InstanceType:     types.InstanceTypeT3Micro,
+								PrivateIpAddress: aws.String("10.0.0.1"),
+								State:            &types.InstanceState{Name: types.InstanceStateNameRunning},
+								Tags:             []types.Tag{{Key: aws.String("Name"), Value: aws.String("alpha-web")}},
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	repo := &AwsRepository{EC2Client: ec2Mock}
+	instances, err := repo.ListEC2Instances(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(instances) != 2 {
+		t.Fatalf("expected 2 instances, got %d", len(instances))
+	}
+	if instances[0].InstanceID != "i-1" {
+		t.Fatalf("expected alpha-web to sort first, got %+v", instances)
+	}
+
+	inst := instances[1]
+	if inst.Name != "zeta-web" {
+		t.Fatalf("expected Name zeta-web, got %q", inst.Name)
+	}
+	if inst.State != "stopped" {
+		t.Fatalf("expected stopped state, got %q", inst.State)
+	}
+	if inst.InstanceType != "m6i.large" {
+		t.Fatalf("expected m6i.large instance type, got %q", inst.InstanceType)
+	}
+	if inst.AvailabilityZone != "us-east-1b" {
+		t.Fatalf("expected AZ us-east-1b, got %q", inst.AvailabilityZone)
+	}
+	if inst.VPCID != "vpc-2" || inst.SubnetID != "subnet-2" {
+		t.Fatalf("expected VPC/subnet IDs, got %q/%q", inst.VPCID, inst.SubnetID)
+	}
+	if inst.PrivateIP != "10.0.0.2" || inst.PublicIP != "203.0.113.2" {
+		t.Fatalf("expected private/public IPs, got %q/%q", inst.PrivateIP, inst.PublicIP)
+	}
+	if !inst.LaunchTime.Equal(launch) {
+		t.Fatalf("expected launch time %v, got %v", launch, inst.LaunchTime)
+	}
+	if inst.PlatformDetails != "Linux/UNIX" {
+		t.Fatalf("expected platform details, got %q", inst.PlatformDetails)
+	}
+	if inst.IAMProfile != "arn:aws:iam::123456789012:instance-profile/app" {
+		t.Fatalf("expected IAM profile ARN, got %q", inst.IAMProfile)
+	}
+	if inst.Tags["Environment"] != "prod" {
+		t.Fatalf("expected Environment tag prod, got %+v", inst.Tags)
 	}
 }
 

--- a/internal/services/aws/ec2_test.go
+++ b/internal/services/aws/ec2_test.go
@@ -276,6 +276,19 @@ func TestListEC2Instances_MapsInventoryFields(t *testing.T) {
 	}
 }
 
+func TestEC2InstanceFromSDKHandlesNilState(t *testing.T) {
+	inst := ec2InstanceFromSDK(types.Instance{
+		InstanceId: aws.String("i-no-state"),
+	})
+
+	if inst.InstanceID != "i-no-state" {
+		t.Fatalf("expected instance ID to be mapped, got %q", inst.InstanceID)
+	}
+	if inst.State != "" {
+		t.Fatalf("expected empty state for nil SDK state, got %q", inst.State)
+	}
+}
+
 func containsStr(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstr(s, substr))
 }


### PR DESCRIPTION
## Summary
- add an EC2 Instance Browser feature under EC2 while keeping the existing SSM session picker intact
- add all-state EC2 inventory loading via DescribeInstances with expanded instance metadata mapping
- add TUI list/detail screens with filtering, refresh, wrap navigation, empty states, and metadata/tag rendering
- update README feature and keybinding docs

Closes #173.

## Validation
- make test
- make build