### PR TITLE
refactor: extract standalone browser submodels

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -199,12 +199,6 @@ type Model struct {
 	iamOldKeyDeleted    bool
 	iamOldKeyInactive   bool
 
-	// Secrets Manager browser state
-	secrets         []awsservice.Secret
-	filteredSecrets []awsservice.Secret
-	secretIdx       int
-	selectedSecret  *awsservice.SecretDetail
-
 	// Security Group browser state
 	securityGroups         []awsservice.SecurityGroup
 	filteredSecurityGroups []awsservice.SecurityGroup
@@ -245,29 +239,9 @@ type Model struct {
 	cwLogs     cloudWatchLogsModel
 	rds        rdsModel
 	bedrock    bedrockModel
-
-	// S3 browser state
-	s3Buckets         []awsservice.S3Bucket
-	filteredS3Buckets []awsservice.S3Bucket
-	s3BucketIdx       int
-	selectedS3Bucket  *awsservice.S3Bucket
-	s3Objects         []awsservice.S3Object
-	filteredS3Objects []awsservice.S3Object
-	s3ObjectIdx       int
-	s3CurrentPrefix   string
-	s3PrefixStack     []string
-	selectedS3Object  *awsservice.S3ObjectDetail
-
-	// Lambda browser state
-	lambdaFunctions         []awsservice.LambdaFunction
-	filteredLambdaFunctions []awsservice.LambdaFunction
-	lambdaFunctionIdx       int
-	selectedLambdaFunction  *awsservice.LambdaFunction
-	lambdaInvokePayload     string
-	lambdaInvokeAsync       bool
-	lambdaInvokeResult      *awsservice.LambdaInvokeResult
-	lambdaPayloadSource     lambdaPayloadSource
-	lambdaInvokeStep        int // 0=source select, 1=text input
+	secrets    secretsModel
+	s3         s3Model
+	lambda     lambdaModel
 
 	// Inspector browser state
 	inspectorWorkflows        []inspector.Workflow
@@ -371,6 +345,9 @@ func New(cfg *config.Config, configPath string, version string, checklistPath ..
 	model.cwLogs = newCloudWatchLogsModel()
 	model.rds = newRDSModel()
 	model.bedrock = newBedrockModel()
+	model.secrets = newSecretsModel()
+	model.s3 = newS3Model()
+	model.lambda = newLambdaModel()
 	model.applyServiceListFilter()
 	return model
 }
@@ -470,10 +447,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.handleRoute53Msg,
 		m.handleSecurityGroupMsg,
 		m.handleIAMMsg,
-		m.handleSecretMsg,
 		m.handleECSMsg,
-		m.handleS3Msg,
-		m.handleLambdaMsg,
 		m.handleInspectorMsg,
 		m.handleContextMsg,
 	} {
@@ -569,24 +543,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateRoute53RecordEdit(msg)
 		case screenRoute53RecordDeleteConfirm:
 			return m.updateRoute53RecordDeleteConfirm(msg)
-		case screenSecretList:
-			return m.updateSecretList(msg)
-		case screenSecretDetail:
-			return m.updateSecretDetail(msg)
-		case screenS3BucketList:
-			return m.updateS3BucketList(msg)
-		case screenS3ObjectList:
-			return m.updateS3ObjectList(msg)
-		case screenS3ObjectDetail:
-			return m.updateS3ObjectDetail(msg)
-		case screenLambdaFunctionList:
-			return m.updateLambdaFunctionList(msg)
-		case screenLambdaFunctionDetail:
-			return m.updateLambdaFunctionDetail(msg)
-		case screenLambdaInvokeInput:
-			return m.updateLambdaInvokeInput(msg)
-		case screenLambdaInvokeResult:
-			return m.updateLambdaInvokeResult(msg)
 		case screenInspectorHome:
 			return m.updateInspectorHome(msg)
 		case screenInspectorWorkflowPlaceholder:
@@ -651,23 +607,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
-}
-
-// handleSecretMsg handles Secrets Manager messages.
-func (m Model) handleSecretMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
-	switch msg := msg.(type) {
-	case secretsLoadedMsg:
-		m.secrets = msg.secrets
-		m.filteredSecrets = msg.secrets
-		m.secretIdx = 0
-		m.screen = screenSecretList
-		return m, nil, true
-	case secretDetailLoadedMsg:
-		m.selectedSecret = msg.detail
-		m.screen = screenSecretDetail
-		return m, nil, true
-	}
-	return m, nil, false
 }
 
 func (m Model) updateServiceList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -753,13 +692,13 @@ func (m Model) updateFeatureList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			case domain.FeatureRoute53Browser:
 				return m.startLoading(m.loadRoute53Zones())
 			case domain.FeatureSecretsBrowser:
-				return m.startLoading(m.loadSecrets())
+				return m.secrets.Start(&m)
 			case domain.FeatureCloudWatchMetrics:
 				return m.cwMetrics.Start(&m)
 			case domain.FeatureCloudWatchLogsBrowser:
 				return m.cwLogs.Start(&m)
 			case domain.FeatureS3Browser:
-				return m.startLoading(m.loadS3Buckets())
+				return m.s3.Start(&m)
 			case domain.FeatureSecurityGroupBrowser:
 				return m.startLoading(m.loadSecurityGroups())
 			case domain.FeatureIAMUsersBrowser:
@@ -773,7 +712,7 @@ func (m Model) updateFeatureList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			case domain.FeatureECSExec:
 				return m.startLoading(m.loadECSClusters())
 			case domain.FeatureLambdaBrowser:
-				return m.startLoading(m.loadLambdaFunctions())
+				return m.lambda.Start(&m)
 			case domain.FeatureBedrockAPIKeys:
 				return m.bedrock.Start(&m)
 			}
@@ -844,24 +783,6 @@ func (m Model) View() string {
 		v = m.viewRoute53RecordEdit()
 	case screenRoute53RecordDeleteConfirm:
 		v = m.viewRoute53RecordDeleteConfirm()
-	case screenSecretList:
-		v = m.viewSecretList()
-	case screenSecretDetail:
-		v = m.viewSecretDetail()
-	case screenS3BucketList:
-		v = m.viewS3BucketList()
-	case screenS3ObjectList:
-		v = m.viewS3ObjectList()
-	case screenS3ObjectDetail:
-		v = m.viewS3ObjectDetail()
-	case screenLambdaFunctionList:
-		v = m.viewLambdaFunctionList()
-	case screenLambdaFunctionDetail:
-		v = m.viewLambdaFunctionDetail()
-	case screenLambdaInvokeInput:
-		v = m.viewLambdaInvokeInput()
-	case screenLambdaInvokeResult:
-		v = m.viewLambdaInvokeResult()
 	case screenInspectorHome:
 		v = m.viewInspectorHome()
 	case screenInspectorWorkflowPlaceholder:
@@ -1047,168 +968,5 @@ func (m Model) viewFeatureList() string {
 	b.WriteString(m.renderListPanel(panel.String()))
 	b.WriteString("\n\n")
 	b.WriteString(m.renderHelpBar("↑/↓: navigate • enter: select • esc: back"))
-	return b.String()
-}
-func (m Model) loadSecrets() tea.Cmd {
-	return func() tea.Msg {
-		ctx := context.Background()
-		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
-		if err != nil {
-			return errMsg{err: err}
-		}
-		secrets, err := repo.ListSecrets(ctx)
-		if err != nil {
-			return errMsg{err: err}
-		}
-		if len(secrets) == 0 {
-			return errMsg{err: fmt.Errorf("no secrets found")}
-		}
-		return secretsLoadedMsg{secrets: secrets}
-	}
-}
-
-func (m Model) loadSecretDetail(name string) tea.Cmd {
-	return func() tea.Msg {
-		ctx := context.Background()
-		repo := m.awsRepo
-		if repo == nil {
-			var err error
-			repo, err = awsservice.NewAwsRepository(ctx, m.cfg)
-			if err != nil {
-				return errMsg{err: err}
-			}
-		}
-		detail, err := repo.GetSecretDetail(ctx, name)
-		if err != nil {
-			return errMsg{err: err}
-		}
-		return secretDetailLoadedMsg{detail: detail}
-	}
-}
-
-func (m Model) updateSecretList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	key := msg.String()
-
-	if cmd, handled := m.updateSharedFilter(msg, filterSecrets); handled {
-		return m, cmd
-	}
-
-	switch key {
-	case "q", "esc":
-		m.screen = screenFeatureList
-		m.resetFilter(filterSecrets)
-	case "up", "k":
-		m.secretIdx = previousListIndex(m.secretIdx, len(m.filteredSecrets))
-	case "down", "j":
-		m.secretIdx = nextListIndex(m.secretIdx, len(m.filteredSecrets))
-	case "/":
-		return m, m.activateFilter(filterSecrets)
-	case "enter":
-		if len(m.filteredSecrets) > 0 && m.secretIdx < len(m.filteredSecrets) {
-			selected := m.filteredSecrets[m.secretIdx]
-			return m.startLoading(m.loadSecretDetail(selected.Name))
-		}
-	}
-	return m, nil
-}
-
-func (m Model) updateSecretDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case "q", "esc":
-		m.selectedSecret = nil
-		m.screen = screenSecretList
-	}
-	return m, nil
-}
-
-func (m Model) viewSecretList() string {
-	var b strings.Builder
-	var panel strings.Builder
-	b.WriteString(m.renderStatusBar())
-	b.WriteString(titleStyle.Render("Secrets Manager"))
-	b.WriteString("\n")
-
-	b.WriteString(m.renderFilterValue(filterSecrets))
-	b.WriteString("\n\n")
-
-	if len(m.filteredSecrets) == 0 {
-		panel.WriteString(dimStyle.Render("  No matching secrets"))
-		panel.WriteString("\n")
-	} else {
-		visibleLines := max(m.height-10, 5)
-		start := 0
-		if m.secretIdx >= visibleLines {
-			start = m.secretIdx - visibleLines + 1
-		}
-		end := min(start+visibleLines, len(m.filteredSecrets))
-
-		for i := start; i < end; i++ {
-			s := m.filteredSecrets[i]
-			cursor := "  "
-			style := normalStyle
-			if i == m.secretIdx {
-				cursor = "> "
-				style = selectedStyle
-			}
-			panel.WriteString(style.Render(cursor + m.renderHighlightedValue(filterSecrets, s.DisplayTitle())))
-			panel.WriteString("\n")
-		}
-
-		panel.WriteString("\n")
-		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d secrets", len(m.filteredSecrets), len(m.secrets))))
-	}
-
-	b.WriteString(m.renderListPanel(panel.String()))
-	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • enter: detail • esc: back • H: home"))
-	return b.String()
-}
-
-func (m Model) viewSecretDetail() string {
-	if m.selectedSecret == nil {
-		return ""
-	}
-	d := m.selectedSecret
-	var b strings.Builder
-	b.WriteString(m.renderStatusBar())
-	b.WriteString(titleStyle.Render("Secret Detail"))
-	b.WriteString("\n\n")
-
-	b.WriteString(renderDetailLine("Name", normalStyle.Render(d.Name)))
-	b.WriteString("\n")
-
-	kmsKey := d.KMSKeyID
-	if kmsKey == "" {
-		kmsKey = dimStyle.Render("(aws/secretsmanager)")
-	}
-	b.WriteString(renderDetailLine("Encryption Key", kmsKey))
-	b.WriteString("\n\n")
-
-	if len(d.Values) > 0 {
-		b.WriteString(titleStyle.Render("Key / Value"))
-		b.WriteString("\n\n")
-
-		keys := make([]string, 0, len(d.Values))
-		for k := range d.Values {
-			keys = append(keys, k)
-		}
-		for i := 1; i < len(keys); i++ {
-			for j := i; j > 0 && keys[j] < keys[j-1]; j-- {
-				keys[j], keys[j-1] = keys[j-1], keys[j]
-			}
-		}
-
-		for _, k := range keys {
-			b.WriteString(fmt.Sprintf("  %s  %s\n", dimStyle.Render(k), normalStyle.Render(d.Values[k])))
-		}
-	} else if d.Raw != "" {
-		b.WriteString(titleStyle.Render("Value"))
-		b.WriteString("\n\n")
-		b.WriteString(normalStyle.Render(fmt.Sprintf("  %s", d.Raw)))
-		b.WriteString("\n")
-	}
-
-	b.WriteString("\n")
-	b.WriteString(m.renderHelpBar("esc: back • H: home"))
 	return b.String()
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2296,8 +2296,8 @@ func TestInspectorChecklistResultsEnterShowsDetail(t *testing.T) {
 func TestS3ObjectListEscAtRootReturnsToBucketList(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenS3ObjectList
-	m.selectedS3Bucket = &awsservice.S3Bucket{Name: "my-bucket"}
-	m.s3CurrentPrefix = ""
+	m.s3.selectedBucket = &awsservice.S3Bucket{Name: "my-bucket"}
+	m.s3.currentPrefix = ""
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	model := updated.(Model)
@@ -2309,10 +2309,10 @@ func TestS3ObjectListEscAtRootReturnsToBucketList(t *testing.T) {
 func TestS3ObjectListShowsBreadcrumb(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenS3ObjectList
-	m.selectedS3Bucket = &awsservice.S3Bucket{Name: "my-bucket"}
-	m.s3CurrentPrefix = "logs/app/"
+	m.s3.selectedBucket = &awsservice.S3Bucket{Name: "my-bucket"}
+	m.s3.currentPrefix = "logs/app/"
 
-	view := m.viewS3ObjectList()
+	view := m.s3.viewObjectList(m)
 	if !strings.Contains(view, "Path: /logs/app") {
 		t.Fatalf("expected breadcrumb in S3 object list, got %q", view)
 	}

--- a/internal/app/feature_submodel.go
+++ b/internal/app/feature_submodel.go
@@ -10,5 +10,5 @@ type featureSubmodel interface {
 }
 
 func (m *Model) featureSubmodels() []featureSubmodel {
-	return []featureSubmodel{&m.ec2Browser, &m.cwMetrics, &m.cwLogs, &m.rds, &m.bedrock}
+	return []featureSubmodel{&m.ec2Browser, &m.cwMetrics, &m.cwLogs, &m.rds, &m.bedrock, &m.secrets, &m.s3, &m.lambda}
 }

--- a/internal/app/filter.go
+++ b/internal/app/filter.go
@@ -173,9 +173,6 @@ func (m *Model) applyFilterTarget(target filterTarget) {
 		m.route53RecordIdx = 0
 	case filterIAMUsers:
 		m.refreshIAMUserFilter()
-	case filterSecrets:
-		m.filteredSecrets = applyFilter(m.secrets, m.filterValue(target))
-		m.secretIdx = 0
 	case filterSecurityGroups:
 		m.filteredSecurityGroups = applyFilter(m.securityGroups, m.filterValue(target))
 		m.sgIdx = 0
@@ -185,12 +182,6 @@ func (m *Model) applyFilterTarget(target filterTarget) {
 	case filterECSServices:
 		m.filteredECSServices = applyFilter(m.ecsServices, m.filterValue(target))
 		m.ecsServiceIdx = 0
-	case filterS3Buckets:
-		m.filteredS3Buckets = applyFilter(m.s3Buckets, m.filterValue(target))
-		m.s3BucketIdx = 0
-	case filterS3Objects:
-		m.filteredS3Objects = applyFilter(m.s3Objects, m.filterValue(target))
-		m.s3ObjectIdx = 0
 	case filterContexts:
 		m.filteredCtxList = applyFilter(m.ctxList, m.filterValue(target))
 		m.ctxIdx = 0
@@ -204,9 +195,6 @@ func (m *Model) applyFilterTarget(target filterTarget) {
 	case filterInspectorChecklistFiles:
 		m.filteredChecklistFiles = applyFilter(m.inspectorChecklistFiles, m.filterValue(target))
 		m.inspectorChecklistFileIdx = 0
-	case filterLambdaFunctions:
-		m.filteredLambdaFunctions = applyFilter(m.lambdaFunctions, m.filterValue(target))
-		m.lambdaFunctionIdx = 0
 	}
 }
 

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -437,7 +437,7 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 			{"q / esc", "Go back to the function list"},
 		}
 	case screenLambdaInvokeInput:
-		if m.lambdaInvokeStep == 0 {
+		if m.lambda.invokeStep == 0 {
 			return []helpShortcut{
 				{"↑/↓, j/k", "Select payload source"},
 				{"enter", "Confirm the selected source"},

--- a/internal/app/screen_lambda.go
+++ b/internal/app/screen_lambda.go
@@ -23,68 +23,129 @@ const (
 	lambdaPayloadFile
 )
 
-// handleLambdaMsg routes Lambda messages to the correct screen.
-func (m Model) handleLambdaMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
+type lambdaModel struct {
+	functions     []awsservice.LambdaFunction
+	filtered      []awsservice.LambdaFunction
+	functionIdx   int
+	selected      *awsservice.LambdaFunction
+	invokePayload string
+	invokeResult  *awsservice.LambdaInvokeResult
+	payloadSource lambdaPayloadSource
+	invokeStep    int // 0=source select, 1=text input
+}
+
+func newLambdaModel() lambdaModel {
+	return lambdaModel{payloadSource: lambdaPayloadManual}
+}
+
+func (lm *lambdaModel) Start(m *Model) (tea.Model, tea.Cmd) {
+	return m.startLoading(lm.loadFunctions(*m))
+}
+
+func (lm *lambdaModel) HandleMessage(m *Model, msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 	switch msg := msg.(type) {
 	case lambdaFunctionsLoadedMsg:
-		m.lambdaFunctions = msg.functions
-		m.filteredLambdaFunctions = msg.functions
-		m.lambdaFunctionIdx = 0
+		lm.functions = msg.functions
+		lm.filtered = msg.functions
+		lm.functionIdx = 0
 		m.resetFilter(filterLambdaFunctions)
 		m.screen = screenLambdaFunctionList
-		return m, nil, true
+		return *m, nil, true
 	case lambdaInvokeResultMsg:
-		m.lambdaInvokeResult = msg.result
+		lm.invokeResult = msg.result
 		m.screen = screenLambdaInvokeResult
-		return m, nil, true
+		return *m, nil, true
 	}
-	return m, nil, false
+	return *m, nil, false
+}
+
+func (lm *lambdaModel) HandleKey(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
+	switch m.screen {
+	case screenLambdaFunctionList:
+		newM, cmd := lm.updateFunctionList(m, msg)
+		return newM, cmd, true
+	case screenLambdaFunctionDetail:
+		newM, cmd := lm.updateFunctionDetail(m, msg)
+		return newM, cmd, true
+	case screenLambdaInvokeInput:
+		newM, cmd := lm.updateInvokeInput(m, msg)
+		return newM, cmd, true
+	case screenLambdaInvokeResult:
+		newM, cmd := lm.updateInvokeResult(m, msg)
+		return newM, cmd, true
+	default:
+		return *m, nil, false
+	}
+}
+
+func (lm lambdaModel) View(m Model) (string, bool) {
+	switch m.screen {
+	case screenLambdaFunctionList:
+		return lm.viewFunctionList(m), true
+	case screenLambdaFunctionDetail:
+		return lm.viewFunctionDetail(m), true
+	case screenLambdaInvokeInput:
+		return lm.viewInvokeInput(m), true
+	case screenLambdaInvokeResult:
+		return lm.viewInvokeResult(m), true
+	default:
+		return "", false
+	}
+}
+
+func (lm *lambdaModel) ApplyFilter(m *Model, target filterTarget) bool {
+	if target != filterLambdaFunctions {
+		return false
+	}
+	lm.filtered = applyFilter(lm.functions, m.filterValue(target))
+	lm.functionIdx = 0
+	return true
 }
 
 // --- Function List ---
 
-func (m Model) updateLambdaFunctionList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (lm *lambdaModel) updateFunctionList(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if cmd, handled := m.updateSharedFilter(msg, filterLambdaFunctions); handled {
-		return m, cmd
+		return *m, cmd
 	}
 
 	switch msg.String() {
 	case "q", "esc":
 		m.screen = screenFeatureList
 	case "up", "k":
-		m.lambdaFunctionIdx = previousListIndex(m.lambdaFunctionIdx, len(m.filteredLambdaFunctions))
+		lm.functionIdx = previousListIndex(lm.functionIdx, len(lm.filtered))
 	case "down", "j":
-		m.lambdaFunctionIdx = nextListIndex(m.lambdaFunctionIdx, len(m.filteredLambdaFunctions))
+		lm.functionIdx = nextListIndex(lm.functionIdx, len(lm.filtered))
 	case "/":
-		return m, m.activateFilter(filterLambdaFunctions)
+		return *m, m.activateFilter(filterLambdaFunctions)
 	case "r":
-		return m.startLoading(m.loadLambdaFunctions())
+		return m.startLoading(lm.loadFunctions(*m))
 	case "d":
-		if len(m.filteredLambdaFunctions) > 0 && m.lambdaFunctionIdx < len(m.filteredLambdaFunctions) {
-			fn := m.filteredLambdaFunctions[m.lambdaFunctionIdx]
-			m.selectedLambdaFunction = &fn
+		if len(lm.filtered) > 0 && lm.functionIdx < len(lm.filtered) {
+			fn := lm.filtered[lm.functionIdx]
+			lm.selected = &fn
 			m.screen = screenLambdaFunctionDetail
 		}
 	case "l":
-		if len(m.filteredLambdaFunctions) > 0 && m.lambdaFunctionIdx < len(m.filteredLambdaFunctions) {
-			fn := m.filteredLambdaFunctions[m.lambdaFunctionIdx]
-			m.selectedLambdaFunction = &fn
-			return m.cwLogs.StartFromLambda(&m, fn.Name)
+		if len(lm.filtered) > 0 && lm.functionIdx < len(lm.filtered) {
+			fn := lm.filtered[lm.functionIdx]
+			lm.selected = &fn
+			return m.cwLogs.StartFromLambda(m, fn.Name)
 		}
 	case "enter":
-		if len(m.filteredLambdaFunctions) > 0 && m.lambdaFunctionIdx < len(m.filteredLambdaFunctions) {
-			fn := m.filteredLambdaFunctions[m.lambdaFunctionIdx]
-			m.selectedLambdaFunction = &fn
-			m.lambdaInvokePayload = ""
-			m.lambdaPayloadSource = lambdaPayloadManual
-			m.lambdaInvokeStep = 0
+		if len(lm.filtered) > 0 && lm.functionIdx < len(lm.filtered) {
+			fn := lm.filtered[lm.functionIdx]
+			lm.selected = &fn
+			lm.invokePayload = ""
+			lm.payloadSource = lambdaPayloadManual
+			lm.invokeStep = 0
 			m.screen = screenLambdaInvokeInput
 		}
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) viewLambdaFunctionList() string {
+func (lm lambdaModel) viewFunctionList(m Model) string {
 	var b strings.Builder
 	var panel strings.Builder
 	b.WriteString(m.renderStatusBar())
@@ -93,22 +154,22 @@ func (m Model) viewLambdaFunctionList() string {
 	b.WriteString(m.renderFilterValue(filterLambdaFunctions))
 	b.WriteString("\n\n")
 
-	if len(m.filteredLambdaFunctions) == 0 {
+	if len(lm.filtered) == 0 {
 		panel.WriteString(dimStyle.Render("  No functions found"))
 		panel.WriteString("\n")
 	} else {
 		visibleLines := max(m.height-10, 5)
 		start := 0
-		if m.lambdaFunctionIdx >= visibleLines {
-			start = m.lambdaFunctionIdx - visibleLines + 1
+		if lm.functionIdx >= visibleLines {
+			start = lm.functionIdx - visibleLines + 1
 		}
-		end := min(start+visibleLines, len(m.filteredLambdaFunctions))
+		end := min(start+visibleLines, len(lm.filtered))
 
 		for i := start; i < end; i++ {
-			fn := m.filteredLambdaFunctions[i]
+			fn := lm.filtered[i]
 			cursor := "  "
 			style := normalStyle
-			if i == m.lambdaFunctionIdx {
+			if i == lm.functionIdx {
 				cursor = "> "
 				style = selectedStyle
 			}
@@ -116,7 +177,7 @@ func (m Model) viewLambdaFunctionList() string {
 			panel.WriteString("\n")
 		}
 		panel.WriteString("\n")
-		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d functions", len(m.filteredLambdaFunctions), len(m.lambdaFunctions))))
+		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d functions", len(lm.filtered), len(lm.functions))))
 	}
 
 	b.WriteString(m.renderListPanel(panel.String()))
@@ -127,28 +188,28 @@ func (m Model) viewLambdaFunctionList() string {
 
 // --- Function Detail ---
 
-func (m Model) updateLambdaFunctionDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (lm *lambdaModel) updateFunctionDetail(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "q", "esc":
 		m.screen = screenLambdaFunctionList
 	case "i":
-		m.lambdaInvokePayload = ""
-		m.lambdaPayloadSource = lambdaPayloadManual
-		m.lambdaInvokeStep = 0
+		lm.invokePayload = ""
+		lm.payloadSource = lambdaPayloadManual
+		lm.invokeStep = 0
 		m.screen = screenLambdaInvokeInput
 	case "l":
-		if m.selectedLambdaFunction != nil {
-			return m.cwLogs.StartFromLambda(&m, m.selectedLambdaFunction.Name)
+		if lm.selected != nil {
+			return m.cwLogs.StartFromLambda(m, lm.selected.Name)
 		}
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) viewLambdaFunctionDetail() string {
+func (lm lambdaModel) viewFunctionDetail(m Model) string {
 	var b strings.Builder
 	b.WriteString(m.renderStatusBar())
 
-	fn := m.selectedLambdaFunction
+	fn := lm.selected
 	if fn == nil {
 		return b.String()
 	}
@@ -191,57 +252,57 @@ func (m Model) viewLambdaFunctionDetail() string {
 // Step 0: select payload source (manual / file)
 // Step 1: type payload or file path, then invoke
 
-func (m Model) updateLambdaInvokeInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (lm *lambdaModel) updateInvokeInput(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
 	// Step 0: source selection
-	if m.lambdaInvokeStep == 0 {
+	if lm.invokeStep == 0 {
 		switch key {
 		case "esc":
 			m.screen = screenLambdaFunctionList
 		case "up", "k":
-			m.lambdaPayloadSource = lambdaPayloadSource(previousListIndex(int(m.lambdaPayloadSource), 2))
+			lm.payloadSource = lambdaPayloadSource(previousListIndex(int(lm.payloadSource), 2))
 		case "down", "j":
-			m.lambdaPayloadSource = lambdaPayloadSource(nextListIndex(int(m.lambdaPayloadSource), 2))
+			lm.payloadSource = lambdaPayloadSource(nextListIndex(int(lm.payloadSource), 2))
 		case "enter":
-			m.lambdaInvokeStep = 1
-			m.lambdaInvokePayload = ""
+			lm.invokeStep = 1
+			lm.invokePayload = ""
 		}
-		return m, nil
+		return *m, nil
 	}
 
 	// Step 1: text input
 	switch key {
 	case "esc":
-		m.lambdaInvokeStep = 0
+		lm.invokeStep = 0
 	case "enter":
-		if m.selectedLambdaFunction != nil {
-			return m.startLoading(m.invokeLambdaFunction())
+		if lm.selected != nil {
+			return m.startLoading(lm.invokeFunction(*m))
 		}
 	case "backspace":
-		if len(m.lambdaInvokePayload) > 0 {
-			m.lambdaInvokePayload = m.lambdaInvokePayload[:len(m.lambdaInvokePayload)-1]
+		if len(lm.invokePayload) > 0 {
+			lm.invokePayload = lm.invokePayload[:len(lm.invokePayload)-1]
 		}
 	default:
 		if len(key) == 1 || key == " " {
-			m.lambdaInvokePayload += key
+			lm.invokePayload += key
 		}
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) viewLambdaInvokeInput() string {
+func (lm lambdaModel) viewInvokeInput(m Model) string {
 	var b strings.Builder
 	b.WriteString(m.renderStatusBar())
 
 	fnName := ""
-	if m.selectedLambdaFunction != nil {
-		fnName = m.selectedLambdaFunction.Name
+	if lm.selected != nil {
+		fnName = lm.selected.Name
 	}
 	b.WriteString(titleStyle.Render(fmt.Sprintf("Invoke — %s", fnName)))
 	b.WriteString("\n\n")
 
-	if m.lambdaInvokeStep == 0 {
+	if lm.invokeStep == 0 {
 		b.WriteString(normalStyle.Render("  Select payload source:"))
 		b.WriteString("\n\n")
 		sources := []struct {
@@ -254,7 +315,7 @@ func (m Model) viewLambdaInvokeInput() string {
 		for _, s := range sources {
 			cursor := "  "
 			style := normalStyle
-			if m.lambdaPayloadSource == s.src {
+			if lm.payloadSource == s.src {
 				cursor = "> "
 				style = selectedStyle
 			}
@@ -266,13 +327,13 @@ func (m Model) viewLambdaInvokeInput() string {
 	} else {
 		label := "Payload (JSON):"
 		hint := "(empty — press enter to invoke with no payload)"
-		if m.lambdaPayloadSource == lambdaPayloadFile {
+		if lm.payloadSource == lambdaPayloadFile {
 			label = "File path:"
 			hint = "(enter path to a local JSON file)"
 		}
 		b.WriteString(normalStyle.Render("  " + label))
 		b.WriteString("\n")
-		payload := m.lambdaInvokePayload
+		payload := lm.invokePayload
 		if payload == "" {
 			payload = dimStyle.Render(hint)
 		}
@@ -286,35 +347,35 @@ func (m Model) viewLambdaInvokeInput() string {
 
 // --- Invoke Result ---
 
-func (m Model) updateLambdaInvokeResult(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (lm *lambdaModel) updateInvokeResult(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "q", "esc":
 		m.screen = screenLambdaFunctionList
 	case "i":
-		m.lambdaInvokePayload = ""
-		m.lambdaPayloadSource = lambdaPayloadManual
-		m.lambdaInvokeStep = 0
+		lm.invokePayload = ""
+		lm.payloadSource = lambdaPayloadManual
+		lm.invokeStep = 0
 		m.screen = screenLambdaInvokeInput
 	case "l":
-		if m.selectedLambdaFunction != nil {
-			return m.cwLogs.StartFromLambda(&m, m.selectedLambdaFunction.Name)
+		if lm.selected != nil {
+			return m.cwLogs.StartFromLambda(m, lm.selected.Name)
 		}
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) viewLambdaInvokeResult() string {
+func (lm lambdaModel) viewInvokeResult(m Model) string {
 	var b strings.Builder
 	b.WriteString(m.renderStatusBar())
 
 	fnName := ""
-	if m.selectedLambdaFunction != nil {
-		fnName = m.selectedLambdaFunction.Name
+	if lm.selected != nil {
+		fnName = lm.selected.Name
 	}
 	b.WriteString(titleStyle.Render(fmt.Sprintf("Invoke Result — %s", fnName)))
 	b.WriteString("\n\n")
 
-	r := m.lambdaInvokeResult
+	r := lm.invokeResult
 	if r == nil {
 		return b.String()
 	}
@@ -354,7 +415,7 @@ func (m Model) viewLambdaInvokeResult() string {
 
 // --- Load Commands ---
 
-func (m Model) loadLambdaFunctions() tea.Cmd {
+func (lm lambdaModel) loadFunctions(m Model) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), lambdaAPITimeout)
 		defer cancel()
@@ -373,15 +434,15 @@ func (m Model) loadLambdaFunctions() tea.Cmd {
 	}
 }
 
-func (m Model) invokeLambdaFunction() tea.Cmd {
-	if m.selectedLambdaFunction == nil {
+func (lm lambdaModel) invokeFunction(m Model) tea.Cmd {
+	if lm.selected == nil {
 		return func() tea.Msg {
 			return errMsg{err: fmt.Errorf("no function selected")}
 		}
 	}
-	payloadSource := m.lambdaPayloadSource
-	payloadInput := m.lambdaInvokePayload
-	fnName := m.selectedLambdaFunction.Name
+	payloadSource := lm.payloadSource
+	payloadInput := lm.invokePayload
+	fnName := lm.selected.Name
 
 	return func() tea.Msg {
 		payload := payloadInput

--- a/internal/app/screen_s3.go
+++ b/internal/app/screen_s3.go
@@ -12,32 +12,97 @@ import (
 	awsservice "unic/internal/services/aws"
 )
 
-func (m Model) handleS3Msg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
+type s3Model struct {
+	buckets         []awsservice.S3Bucket
+	filteredBuckets []awsservice.S3Bucket
+	bucketIdx       int
+	selectedBucket  *awsservice.S3Bucket
+	objects         []awsservice.S3Object
+	filteredObjects []awsservice.S3Object
+	objectIdx       int
+	currentPrefix   string
+	prefixStack     []string
+	selectedObject  *awsservice.S3ObjectDetail
+}
+
+func newS3Model() s3Model {
+	return s3Model{}
+}
+
+func (s3m *s3Model) Start(m *Model) (tea.Model, tea.Cmd) {
+	return m.startLoading(s3m.loadBuckets(*m))
+}
+
+func (s3m *s3Model) HandleMessage(m *Model, msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 	switch msg := msg.(type) {
 	case s3BucketsLoadedMsg:
-		m.s3Buckets = msg.buckets
-		m.filteredS3Buckets = msg.buckets
-		m.s3BucketIdx = 0
+		s3m.buckets = msg.buckets
+		s3m.filteredBuckets = msg.buckets
+		s3m.bucketIdx = 0
 		m.resetFilter(filterS3Buckets)
 		m.screen = screenS3BucketList
-		return m, nil, true
+		return *m, nil, true
 	case s3ObjectsLoadedMsg:
-		if m.selectedS3Bucket == nil || m.selectedS3Bucket.Name != msg.bucket {
-			return m, nil, true
+		if s3m.selectedBucket == nil || s3m.selectedBucket.Name != msg.bucket {
+			return *m, nil, true
 		}
-		m.s3CurrentPrefix = msg.prefix
-		m.s3Objects = flattenS3Objects(msg.objects)
-		m.filteredS3Objects = m.s3Objects
-		m.s3ObjectIdx = 0
+		s3m.currentPrefix = msg.prefix
+		s3m.objects = flattenS3Objects(msg.objects)
+		s3m.filteredObjects = s3m.objects
+		s3m.objectIdx = 0
 		m.resetFilter(filterS3Objects)
 		m.screen = screenS3ObjectList
-		return m, nil, true
+		return *m, nil, true
 	case s3ObjectDetailLoadedMsg:
-		m.selectedS3Object = msg.detail
+		s3m.selectedObject = msg.detail
 		m.screen = screenS3ObjectDetail
-		return m, nil, true
+		return *m, nil, true
 	}
-	return m, nil, false
+	return *m, nil, false
+}
+
+func (s3m *s3Model) HandleKey(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
+	switch m.screen {
+	case screenS3BucketList:
+		newM, cmd := s3m.updateBucketList(m, msg)
+		return newM, cmd, true
+	case screenS3ObjectList:
+		newM, cmd := s3m.updateObjectList(m, msg)
+		return newM, cmd, true
+	case screenS3ObjectDetail:
+		newM, cmd := s3m.updateObjectDetail(m, msg)
+		return newM, cmd, true
+	default:
+		return *m, nil, false
+	}
+}
+
+func (s3m s3Model) View(m Model) (string, bool) {
+	switch m.screen {
+	case screenS3BucketList:
+		return s3m.viewBucketList(m), true
+	case screenS3ObjectList:
+		return s3m.viewObjectList(m), true
+	case screenS3ObjectDetail:
+		return s3m.viewObjectDetail(m), true
+	default:
+		return "", false
+	}
+}
+
+func (s3m *s3Model) ApplyFilter(m *Model, target filterTarget) bool {
+	switch target {
+	case filterS3Buckets:
+		s3m.filteredBuckets = applyFilter(s3m.buckets, m.filterValue(target))
+		s3m.bucketIdx = 0
+		return true
+	case filterS3Objects:
+		s3m.filteredObjects = applyFilter(s3m.objects, m.filterValue(target))
+		s3m.objectIdx = 0
+		return true
+	default:
+		return false
+	}
 }
 
 func flattenS3Objects(result awsservice.S3ListResult) []awsservice.S3Object {
@@ -47,7 +112,7 @@ func flattenS3Objects(result awsservice.S3ListResult) []awsservice.S3Object {
 	return items
 }
 
-func (m Model) loadS3Buckets() tea.Cmd {
+func (s3m s3Model) loadBuckets(m Model) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
@@ -68,7 +133,7 @@ func (m Model) loadS3Buckets() tea.Cmd {
 	}
 }
 
-func (m Model) loadS3Objects(bucketName, prefix string) tea.Cmd {
+func (s3m s3Model) loadObjects(m Model, bucketName, prefix string) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
 		repo := m.awsRepo
@@ -92,7 +157,7 @@ func (m Model) loadS3Objects(bucketName, prefix string) tea.Cmd {
 	}
 }
 
-func (m Model) loadS3ObjectDetail(bucketName, key string) tea.Cmd {
+func (s3m s3Model) loadObjectDetail(m Model, bucketName, key string) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
 		repo := m.awsRepo
@@ -112,11 +177,11 @@ func (m Model) loadS3ObjectDetail(bucketName, key string) tea.Cmd {
 	}
 }
 
-func (m Model) updateS3BucketList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (s3m *s3Model) updateBucketList(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
 	if cmd, handled := m.updateSharedFilter(msg, filterS3Buckets); handled {
-		return m, cmd
+		return *m, cmd
 	}
 
 	switch key {
@@ -124,75 +189,75 @@ func (m Model) updateS3BucketList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.screen = screenFeatureList
 		m.resetFilter(filterS3Buckets)
 	case "up", "k":
-		m.s3BucketIdx = previousListIndex(m.s3BucketIdx, len(m.filteredS3Buckets))
+		s3m.bucketIdx = previousListIndex(s3m.bucketIdx, len(s3m.filteredBuckets))
 	case "down", "j":
-		m.s3BucketIdx = nextListIndex(m.s3BucketIdx, len(m.filteredS3Buckets))
+		s3m.bucketIdx = nextListIndex(s3m.bucketIdx, len(s3m.filteredBuckets))
 	case "/":
-		return m, m.activateFilter(filterS3Buckets)
+		return *m, m.activateFilter(filterS3Buckets)
 	case "enter":
-		if len(m.filteredS3Buckets) > 0 && m.s3BucketIdx < len(m.filteredS3Buckets) {
-			selected := m.filteredS3Buckets[m.s3BucketIdx]
-			m.selectedS3Bucket = &selected
-			m.s3CurrentPrefix = ""
-			m.s3PrefixStack = nil
-			return m.startLoading(m.loadS3Objects(selected.Name, ""))
+		if len(s3m.filteredBuckets) > 0 && s3m.bucketIdx < len(s3m.filteredBuckets) {
+			selected := s3m.filteredBuckets[s3m.bucketIdx]
+			s3m.selectedBucket = &selected
+			s3m.currentPrefix = ""
+			s3m.prefixStack = nil
+			return m.startLoading(s3m.loadObjects(*m, selected.Name, ""))
 		}
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) updateS3ObjectList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (s3m *s3Model) updateObjectList(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
 	if cmd, handled := m.updateSharedFilter(msg, filterS3Objects); handled {
-		return m, cmd
+		return *m, cmd
 	}
 
 	switch key {
 	case "q":
 		m.screen = screenFeatureList
 	case "esc":
-		if m.selectedS3Bucket == nil {
+		if s3m.selectedBucket == nil {
 			m.screen = screenS3BucketList
-			return m, nil
+			return *m, nil
 		}
-		if m.s3CurrentPrefix == "" {
+		if s3m.currentPrefix == "" {
 			m.screen = screenS3BucketList
-			m.s3ObjectIdx = 0
-			return m, nil
+			s3m.objectIdx = 0
+			return *m, nil
 		}
-		nextPrefix := awsservice.ParentS3Prefix(m.s3CurrentPrefix)
-		return m.startLoading(m.loadS3Objects(m.selectedS3Bucket.Name, nextPrefix))
+		nextPrefix := awsservice.ParentS3Prefix(s3m.currentPrefix)
+		return m.startLoading(s3m.loadObjects(*m, s3m.selectedBucket.Name, nextPrefix))
 	case "up", "k":
-		m.s3ObjectIdx = previousListIndex(m.s3ObjectIdx, len(m.filteredS3Objects))
+		s3m.objectIdx = previousListIndex(s3m.objectIdx, len(s3m.filteredObjects))
 	case "down", "j":
-		m.s3ObjectIdx = nextListIndex(m.s3ObjectIdx, len(m.filteredS3Objects))
+		s3m.objectIdx = nextListIndex(s3m.objectIdx, len(s3m.filteredObjects))
 	case "/":
-		return m, m.activateFilter(filterS3Objects)
+		return *m, m.activateFilter(filterS3Objects)
 	case "enter":
-		if len(m.filteredS3Objects) == 0 || m.s3ObjectIdx >= len(m.filteredS3Objects) || m.selectedS3Bucket == nil {
-			return m, nil
+		if len(s3m.filteredObjects) == 0 || s3m.objectIdx >= len(s3m.filteredObjects) || s3m.selectedBucket == nil {
+			return *m, nil
 		}
-		selected := m.filteredS3Objects[m.s3ObjectIdx]
+		selected := s3m.filteredObjects[s3m.objectIdx]
 		if selected.IsPrefix {
-			return m.startLoading(m.loadS3Objects(m.selectedS3Bucket.Name, selected.Prefix))
+			return m.startLoading(s3m.loadObjects(*m, s3m.selectedBucket.Name, selected.Prefix))
 		}
-		return m.startLoading(m.loadS3ObjectDetail(m.selectedS3Bucket.Name, selected.Key))
+		return m.startLoading(s3m.loadObjectDetail(*m, s3m.selectedBucket.Name, selected.Key))
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) updateS3ObjectDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (s3m *s3Model) updateObjectDetail(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "q":
 		m.screen = screenFeatureList
 	case "esc":
 		m.screen = screenS3ObjectList
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) viewS3BucketList() string {
+func (s3m s3Model) viewBucketList(m Model) string {
 	var b strings.Builder
 	var panel strings.Builder
 	b.WriteString(m.renderStatusBar())
@@ -202,12 +267,12 @@ func (m Model) viewS3BucketList() string {
 	b.WriteString(m.renderFilterValue(filterS3Buckets))
 	b.WriteString("\n\n")
 
-	if len(m.filteredS3Buckets) == 0 {
+	if len(s3m.filteredBuckets) == 0 {
 		panel.WriteString(dimStyle.Render("  No matching buckets"))
 		panel.WriteString("\n")
 	} else {
 		maxName := 6
-		for _, bucket := range m.filteredS3Buckets {
+		for _, bucket := range s3m.filteredBuckets {
 			if len(bucket.Name) > maxName {
 				maxName = len(bucket.Name)
 			}
@@ -222,15 +287,15 @@ func (m Model) viewS3BucketList() string {
 
 		visibleLines := max(m.height-11, 5)
 		start := 0
-		if m.s3BucketIdx >= visibleLines {
-			start = m.s3BucketIdx - visibleLines + 1
+		if s3m.bucketIdx >= visibleLines {
+			start = s3m.bucketIdx - visibleLines + 1
 		}
-		end := min(start+visibleLines, len(m.filteredS3Buckets))
+		end := min(start+visibleLines, len(s3m.filteredBuckets))
 		for i := start; i < end; i++ {
-			bucket := m.filteredS3Buckets[i]
+			bucket := s3m.filteredBuckets[i]
 			cursor := "  "
 			style := normalStyle
-			if i == m.s3BucketIdx {
+			if i == s3m.bucketIdx {
 				cursor = "> "
 				style = selectedStyle
 			}
@@ -251,7 +316,7 @@ func (m Model) viewS3BucketList() string {
 		}
 
 		panel.WriteString("\n")
-		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d buckets", len(m.filteredS3Buckets), len(m.s3Buckets))))
+		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d buckets", len(s3m.filteredBuckets), len(s3m.buckets))))
 	}
 
 	b.WriteString(m.renderListPanel(panel.String()))
@@ -260,28 +325,28 @@ func (m Model) viewS3BucketList() string {
 	return b.String()
 }
 
-func (m Model) viewS3ObjectList() string {
+func (s3m s3Model) viewObjectList(m Model) string {
 	var b strings.Builder
 	var panel strings.Builder
 	b.WriteString(m.renderStatusBar())
 	bucketName := ""
-	if m.selectedS3Bucket != nil {
-		bucketName = m.selectedS3Bucket.Name
+	if s3m.selectedBucket != nil {
+		bucketName = s3m.selectedBucket.Name
 	}
 	b.WriteString(titleStyle.Render(fmt.Sprintf("S3 Objects — %s", bucketName)))
 	b.WriteString("\n")
-	b.WriteString(dimStyle.Render(fmt.Sprintf("Path: %s", awsservice.S3Breadcrumb(m.s3CurrentPrefix))))
+	b.WriteString(dimStyle.Render(fmt.Sprintf("Path: %s", awsservice.S3Breadcrumb(s3m.currentPrefix))))
 	b.WriteString("\n")
 
 	b.WriteString(m.renderFilterValue(filterS3Objects))
 	b.WriteString("\n\n")
 
-	if len(m.filteredS3Objects) == 0 {
+	if len(s3m.filteredObjects) == 0 {
 		panel.WriteString(dimStyle.Render("  No matching objects or prefixes"))
 		panel.WriteString("\n")
 	} else {
 		maxName := 6
-		for _, obj := range m.filteredS3Objects {
+		for _, obj := range s3m.filteredObjects {
 			if len(obj.Name) > maxName {
 				maxName = len(obj.Name)
 			}
@@ -297,15 +362,15 @@ func (m Model) viewS3ObjectList() string {
 
 		visibleLines := max(m.height-12, 5)
 		start := 0
-		if m.s3ObjectIdx >= visibleLines {
-			start = m.s3ObjectIdx - visibleLines + 1
+		if s3m.objectIdx >= visibleLines {
+			start = s3m.objectIdx - visibleLines + 1
 		}
-		end := min(start+visibleLines, len(m.filteredS3Objects))
+		end := min(start+visibleLines, len(s3m.filteredObjects))
 		for i := start; i < end; i++ {
-			obj := m.filteredS3Objects[i]
+			obj := s3m.filteredObjects[i]
 			cursor := "  "
 			style := normalStyle
-			if i == m.s3ObjectIdx {
+			if i == s3m.objectIdx {
 				cursor = "> "
 				style = selectedStyle
 			}
@@ -339,7 +404,7 @@ func (m Model) viewS3ObjectList() string {
 		}
 
 		panel.WriteString("\n")
-		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d items", len(m.filteredS3Objects))))
+		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d items", len(s3m.filteredObjects))))
 	}
 
 	b.WriteString(m.renderListPanel(panel.String()))
@@ -348,11 +413,11 @@ func (m Model) viewS3ObjectList() string {
 	return b.String()
 }
 
-func (m Model) viewS3ObjectDetail() string {
-	if m.selectedS3Object == nil {
+func (s3m s3Model) viewObjectDetail(m Model) string {
+	if s3m.selectedObject == nil {
 		return ""
 	}
-	o := m.selectedS3Object
+	o := s3m.selectedObject
 	var b strings.Builder
 	b.WriteString(m.renderStatusBar())
 	b.WriteString(titleStyle.Render("S3 Object Detail"))

--- a/internal/app/screen_secrets.go
+++ b/internal/app/screen_secrets.go
@@ -1,0 +1,239 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	awsservice "unic/internal/services/aws"
+)
+
+type secretsModel struct {
+	items    []awsservice.Secret
+	filtered []awsservice.Secret
+	idx      int
+	selected *awsservice.SecretDetail
+}
+
+func newSecretsModel() secretsModel {
+	return secretsModel{}
+}
+
+func (sm *secretsModel) Start(m *Model) (tea.Model, tea.Cmd) {
+	return m.startLoading(sm.loadSecrets(*m))
+}
+
+func (sm *secretsModel) HandleMessage(m *Model, msg tea.Msg) (tea.Model, tea.Cmd, bool) {
+	switch msg := msg.(type) {
+	case secretsLoadedMsg:
+		sm.items = msg.secrets
+		sm.filtered = applyFilter(sm.items, m.filterValue(filterSecrets))
+		sm.idx = 0
+		m.screen = screenSecretList
+		return *m, nil, true
+	case secretDetailLoadedMsg:
+		sm.selected = msg.detail
+		m.screen = screenSecretDetail
+		return *m, nil, true
+	}
+	return *m, nil, false
+}
+
+func (sm *secretsModel) HandleKey(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
+	switch m.screen {
+	case screenSecretList:
+		newM, cmd := sm.updateList(m, msg)
+		return newM, cmd, true
+	case screenSecretDetail:
+		newM, cmd := sm.updateDetail(m, msg)
+		return newM, cmd, true
+	default:
+		return *m, nil, false
+	}
+}
+
+func (sm secretsModel) View(m Model) (string, bool) {
+	switch m.screen {
+	case screenSecretList:
+		return sm.viewList(m), true
+	case screenSecretDetail:
+		return sm.viewDetail(m), true
+	default:
+		return "", false
+	}
+}
+
+func (sm *secretsModel) ApplyFilter(m *Model, target filterTarget) bool {
+	if target != filterSecrets {
+		return false
+	}
+	sm.filtered = applyFilter(sm.items, m.filterValue(target))
+	sm.idx = 0
+	return true
+}
+
+func (sm secretsModel) loadSecrets(m Model) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		secrets, err := repo.ListSecrets(ctx)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		if len(secrets) == 0 {
+			return errMsg{err: fmt.Errorf("no secrets found")}
+		}
+		return secretsLoadedMsg{secrets: secrets}
+	}
+}
+
+func (sm secretsModel) loadSecretDetail(m Model, name string) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		repo := m.awsRepo
+		if repo == nil {
+			var err error
+			repo, err = awsservice.NewAwsRepository(ctx, m.cfg)
+			if err != nil {
+				return errMsg{err: err}
+			}
+		}
+		detail, err := repo.GetSecretDetail(ctx, name)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		return secretDetailLoadedMsg{detail: detail}
+	}
+}
+
+func (sm *secretsModel) updateList(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	key := msg.String()
+
+	if cmd, handled := m.updateSharedFilter(msg, filterSecrets); handled {
+		return *m, cmd
+	}
+
+	switch key {
+	case "q", "esc":
+		m.screen = screenFeatureList
+		m.resetFilter(filterSecrets)
+	case "up", "k":
+		sm.idx = previousListIndex(sm.idx, len(sm.filtered))
+	case "down", "j":
+		sm.idx = nextListIndex(sm.idx, len(sm.filtered))
+	case "/":
+		return *m, m.activateFilter(filterSecrets)
+	case "enter":
+		if len(sm.filtered) > 0 && sm.idx < len(sm.filtered) {
+			selected := sm.filtered[sm.idx]
+			return m.startLoading(sm.loadSecretDetail(*m, selected.Name))
+		}
+	}
+	return *m, nil
+}
+
+func (sm *secretsModel) updateDetail(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "esc":
+		sm.selected = nil
+		m.screen = screenSecretList
+	}
+	return *m, nil
+}
+
+func (sm secretsModel) viewList(m Model) string {
+	var b strings.Builder
+	var panel strings.Builder
+	b.WriteString(m.renderStatusBar())
+	b.WriteString(titleStyle.Render("Secrets Manager"))
+	b.WriteString("\n")
+
+	b.WriteString(m.renderFilterValue(filterSecrets))
+	b.WriteString("\n\n")
+
+	if len(sm.filtered) == 0 {
+		panel.WriteString(dimStyle.Render("  No matching secrets"))
+		panel.WriteString("\n")
+	} else {
+		visibleLines := max(m.height-10, 5)
+		start := 0
+		if sm.idx >= visibleLines {
+			start = sm.idx - visibleLines + 1
+		}
+		end := min(start+visibleLines, len(sm.filtered))
+
+		for i := start; i < end; i++ {
+			s := sm.filtered[i]
+			cursor := "  "
+			style := normalStyle
+			if i == sm.idx {
+				cursor = "> "
+				style = selectedStyle
+			}
+			panel.WriteString(style.Render(cursor + m.renderHighlightedValue(filterSecrets, s.DisplayTitle())))
+			panel.WriteString("\n")
+		}
+
+		panel.WriteString("\n")
+		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d secrets", len(sm.filtered), len(sm.items))))
+	}
+
+	b.WriteString(m.renderListPanel(panel.String()))
+	b.WriteString("\n\n")
+	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • enter: detail • esc: back • H: home"))
+	return b.String()
+}
+
+func (sm secretsModel) viewDetail(m Model) string {
+	if sm.selected == nil {
+		return ""
+	}
+	d := sm.selected
+	var b strings.Builder
+	b.WriteString(m.renderStatusBar())
+	b.WriteString(titleStyle.Render("Secret Detail"))
+	b.WriteString("\n\n")
+
+	b.WriteString(renderDetailLine("Name", normalStyle.Render(d.Name)))
+	b.WriteString("\n")
+
+	kmsKey := d.KMSKeyID
+	if kmsKey == "" {
+		kmsKey = dimStyle.Render("(aws/secretsmanager)")
+	}
+	b.WriteString(renderDetailLine("Encryption Key", kmsKey))
+	b.WriteString("\n\n")
+
+	if len(d.Values) > 0 {
+		b.WriteString(titleStyle.Render("Key / Value"))
+		b.WriteString("\n\n")
+
+		keys := make([]string, 0, len(d.Values))
+		for k := range d.Values {
+			keys = append(keys, k)
+		}
+		for i := 1; i < len(keys); i++ {
+			for j := i; j > 0 && keys[j] < keys[j-1]; j-- {
+				keys[j], keys[j-1] = keys[j-1], keys[j]
+			}
+		}
+
+		for _, k := range keys {
+			b.WriteString(fmt.Sprintf("  %s  %s\n", dimStyle.Render(k), normalStyle.Render(d.Values[k])))
+		}
+	} else if d.Raw != "" {
+		b.WriteString(titleStyle.Render("Value"))
+		b.WriteString("\n\n")
+		b.WriteString(normalStyle.Render(fmt.Sprintf("  %s", d.Raw)))
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+	b.WriteString(m.renderHelpBar("esc: back • H: home"))
+	return b.String()
+}


### PR DESCRIPTION
## Summary
- extract Secrets Manager, S3, and Lambda browser state/update/view logic into feature submodels
- remove the corresponding root Model fields and app.go dispatch/view/filter branches
- preserve existing list/detail/invoke behavior and update tests for the new ownership

Progresses #107.

## Validation
- make test
- make build