### PR TITLE
refactor: extract Route53 and IAM TUI submodels

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -157,48 +157,6 @@ type Model struct {
 	reachabilityConfigField     int
 	reachabilityResult          *awsservice.ReachabilityAnalysisResult
 	reachabilityScrollOffset    int
-	// Route53 browser state
-	route53Zones           []awsservice.HostedZone
-	filteredRoute53Zones   []awsservice.HostedZone
-	route53ZoneIdx         int
-	selectedRoute53Zone    *awsservice.HostedZone
-	route53Records         []awsservice.DNSRecord
-	filteredRoute53Records []awsservice.DNSRecord
-	route53RecordIdx       int
-	selectedRoute53Record  *awsservice.DNSRecord
-
-	// Route53 mutation state
-	route53Action        string            // "create", "edit", "delete"
-	route53ConfirmInput  string            // type-to-confirm for delete
-	route53EditField     int               // current form field index
-	route53EditValues    map[string]string // accumulated form values
-	route53EditInput     string            // current field text input
-	route53EditSelectIdx int               // index for select-type fields (record type)
-	route53ChangeID      string            // for status polling
-	route53ChangeStatus  string            // "PENDING" / "INSYNC"
-	route53Polling       bool              // polling active
-
-	// IAM credentials state
-	iamUsers            []awsservice.IAMUser
-	filteredIAMUsers    []awsservice.IAMUser
-	iamUserIdx          int
-	iamUserLoadingMore  bool
-	iamUserHasMore      bool
-	iamUserNextMarker   string
-	selectedIAMUser     *awsservice.IAMUserDetail
-	iamKeys             []awsservice.AccessKey
-	iamKeyIdx           int
-	selectedIAMKey      *awsservice.AccessKey
-	iamRotationEnabled  bool
-	iamRotateConfirm    string // typed input for rotate confirmation
-	iamRotationOldKeyID string
-	iamNewKey           *awsservice.NewAccessKey
-	iamCopyMsg          string // feedback message for clipboard copy
-	iamRotationStatus   string
-	iamNewKeyVerified   bool
-	iamOldKeyDeleted    bool
-	iamOldKeyInactive   bool
-
 	// Security Group browser state
 	securityGroups         []awsservice.SecurityGroup
 	filteredSecurityGroups []awsservice.SecurityGroup
@@ -238,6 +196,8 @@ type Model struct {
 	cwMetrics  cloudWatchMetricsModel
 	cwLogs     cloudWatchLogsModel
 	rds        rdsModel
+	route53    route53Model
+	iam        iamModel
 	bedrock    bedrockModel
 	secrets    secretsModel
 	s3         s3Model
@@ -344,6 +304,8 @@ func New(cfg *config.Config, configPath string, version string, checklistPath ..
 	model.cwMetrics = newCloudWatchMetricsModel()
 	model.cwLogs = newCloudWatchLogsModel()
 	model.rds = newRDSModel()
+	model.route53 = newRoute53Model()
+	model.iam = newIAMModel()
 	model.bedrock = newBedrockModel()
 	model.secrets = newSecretsModel()
 	model.s3 = newS3Model()
@@ -444,9 +406,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Domain message handlers
 	for _, h := range []func(tea.Msg) (tea.Model, tea.Cmd, bool){
 		m.handleEC2VPCMsg,
-		m.handleRoute53Msg,
 		m.handleSecurityGroupMsg,
-		m.handleIAMMsg,
 		m.handleECSMsg,
 		m.handleInspectorMsg,
 		m.handleContextMsg,
@@ -531,18 +491,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateReachabilityConfig(msg)
 		case screenReachabilityResult:
 			return m.updateReachabilityResult(msg)
-		case screenRoute53ZoneList:
-			return m.updateRoute53ZoneList(msg)
-		case screenRoute53RecordList:
-			return m.updateRoute53RecordList(msg)
-		case screenRoute53RecordDetail:
-			return m.updateRoute53RecordDetail(msg)
-		case screenRoute53RecordCreate:
-			return m.updateRoute53RecordCreate(msg)
-		case screenRoute53RecordEdit:
-			return m.updateRoute53RecordEdit(msg)
-		case screenRoute53RecordDeleteConfirm:
-			return m.updateRoute53RecordDeleteConfirm(msg)
 		case screenInspectorHome:
 			return m.updateInspectorHome(msg)
 		case screenInspectorWorkflowPlaceholder:
@@ -565,18 +513,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateSecurityGroupAddRule(msg)
 		case screenSecurityGroupDeleteConfirm:
 			return m.updateSecurityGroupDeleteConfirm(msg)
-		case screenIAMUserList:
-			return m.updateIAMUserList(msg)
-		case screenIAMUserDetail:
-			return m.updateIAMUserDetail(msg)
-		case screenIAMKeyList:
-			return m.updateIAMKeyList(msg)
-		case screenIAMKeyDetail:
-			return m.updateIAMKeyDetail(msg)
-		case screenIAMKeyRotateConfirm:
-			return m.updateIAMKeyRotateConfirm(msg)
-		case screenIAMKeyRotateResult:
-			return m.updateIAMKeyRotateResult(msg)
 		case screenECSClusterList:
 			return m.updateECSClusterList(msg)
 		case screenECSServiceList:
@@ -690,7 +626,7 @@ func (m Model) updateFeatureList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			case domain.FeatureRDSBrowser:
 				return m.rds.Start(&m)
 			case domain.FeatureRoute53Browser:
-				return m.startLoading(m.loadRoute53Zones())
+				return m.route53.Start(&m)
 			case domain.FeatureSecretsBrowser:
 				return m.secrets.Start(&m)
 			case domain.FeatureCloudWatchMetrics:
@@ -702,13 +638,11 @@ func (m Model) updateFeatureList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			case domain.FeatureSecurityGroupBrowser:
 				return m.startLoading(m.loadSecurityGroups())
 			case domain.FeatureIAMUsersBrowser:
-				return m.startLoading(m.loadIAMUsers())
+				return m.iam.StartUsers(&m)
 			case domain.FeatureListAccessKeys:
-				m.iamRotationEnabled = false
-				return m.startLoading(m.loadIAMKeys())
+				return m.iam.StartKeys(&m, false)
 			case domain.FeatureRotateAccessKey:
-				m.iamRotationEnabled = true
-				return m.startLoading(m.loadIAMKeys())
+				return m.iam.StartKeys(&m, true)
 			case domain.FeatureECSExec:
 				return m.startLoading(m.loadECSClusters())
 			case domain.FeatureLambdaBrowser:
@@ -771,18 +705,6 @@ func (m Model) View() string {
 		v = m.viewReachabilityConfig()
 	case screenReachabilityResult:
 		v = m.viewReachabilityResult()
-	case screenRoute53ZoneList:
-		v = m.viewRoute53ZoneList()
-	case screenRoute53RecordList:
-		v = m.viewRoute53RecordList()
-	case screenRoute53RecordDetail:
-		v = m.viewRoute53RecordDetail()
-	case screenRoute53RecordCreate:
-		v = m.viewRoute53RecordCreate()
-	case screenRoute53RecordEdit:
-		v = m.viewRoute53RecordEdit()
-	case screenRoute53RecordDeleteConfirm:
-		v = m.viewRoute53RecordDeleteConfirm()
 	case screenInspectorHome:
 		v = m.viewInspectorHome()
 	case screenInspectorWorkflowPlaceholder:
@@ -807,18 +729,6 @@ func (m Model) View() string {
 		v = m.viewSecurityGroupAddRule()
 	case screenSecurityGroupDeleteConfirm:
 		v = m.viewSecurityGroupDeleteConfirm()
-	case screenIAMUserList:
-		v = m.viewIAMUserList()
-	case screenIAMUserDetail:
-		v = m.viewIAMUserDetail()
-	case screenIAMKeyList:
-		v = m.viewIAMKeyList()
-	case screenIAMKeyDetail:
-		v = m.viewIAMKeyDetail()
-	case screenIAMKeyRotateConfirm:
-		v = m.viewIAMKeyRotateConfirm()
-	case screenIAMKeyRotateResult:
-		v = m.viewIAMKeyRotateResult()
 	case screenECSClusterList:
 		v = m.viewECSClusterList()
 	case screenECSServiceList:

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1607,10 +1607,10 @@ func TestIAMUserFeatureUsesUserBrowserFlow(t *testing.T) {
 func TestIAMUserListEnterGoesToDetailLoad(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenIAMUserList
-	m.iamUsers = []awsservice.IAMUser{
+	m.iam.users = []awsservice.IAMUser{
 		{UserName: "alice"},
 	}
-	m.filteredIAMUsers = m.iamUsers
+	m.iam.filteredUsers = m.iam.users
 
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	model := updated.(Model)
@@ -1625,14 +1625,14 @@ func TestIAMUserListEnterGoesToDetailLoad(t *testing.T) {
 func TestIAMUserListNextPageStartsIncrementalLoad(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenIAMUserList
-	m.iamUsers = []awsservice.IAMUser{{UserName: "alice"}}
-	m.filteredIAMUsers = m.iamUsers
-	m.iamUserHasMore = true
-	m.iamUserNextMarker = "page-2"
+	m.iam.users = []awsservice.IAMUser{{UserName: "alice"}}
+	m.iam.filteredUsers = m.iam.users
+	m.iam.userHasMore = true
+	m.iam.userNextMarker = "page-2"
 
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
 	model := updated.(Model)
-	if !model.iamUserLoadingMore {
+	if !model.iam.userLoadingMore {
 		t.Fatal("expected IAM user incremental loading to start")
 	}
 	if model.screen != screenIAMUserList {
@@ -1646,17 +1646,17 @@ func TestIAMUserListNextPageStartsIncrementalLoad(t *testing.T) {
 func TestIAMUserListFilterStartsBackgroundSummaryLoad(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenIAMUserList
-	m.iamUsers = []awsservice.IAMUser{{UserName: "alice"}}
-	m.filteredIAMUsers = m.iamUsers
-	m.iamUserHasMore = true
-	m.iamUserNextMarker = "page-2"
+	m.iam.users = []awsservice.IAMUser{{UserName: "alice"}}
+	m.iam.filteredUsers = m.iam.users
+	m.iam.userHasMore = true
+	m.iam.userNextMarker = "page-2"
 
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
 	model := updated.(Model)
 	if !model.isFiltering(filterIAMUsers) {
 		t.Fatal("expected IAM user filter to activate")
 	}
-	if !model.iamUserLoadingMore {
+	if !model.iam.userLoadingMore {
 		t.Fatal("expected background username loading for filter")
 	}
 	if cmd == nil {
@@ -1667,11 +1667,11 @@ func TestIAMUserListFilterStartsBackgroundSummaryLoad(t *testing.T) {
 func TestHandleIAMUsersLoadedMsgAppendsPage(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenIAMUserList
-	m.iamUsers = []awsservice.IAMUser{{UserName: "alice"}}
-	m.filteredIAMUsers = m.iamUsers
-	m.iamUserLoadingMore = true
+	m.iam.users = []awsservice.IAMUser{{UserName: "alice"}}
+	m.iam.filteredUsers = m.iam.users
+	m.iam.userLoadingMore = true
 
-	updated, _, handled := m.handleIAMMsg(iamUsersLoadedMsg{
+	updated, _, handled := m.iam.HandleMessage(&m, iamUsersLoadedMsg{
 		users:      []awsservice.IAMUser{{UserName: "bob"}},
 		append:     true,
 		hasMore:    true,
@@ -1682,24 +1682,24 @@ func TestHandleIAMUsersLoadedMsgAppendsPage(t *testing.T) {
 	}
 
 	model := updated.(Model)
-	if len(model.iamUsers) != 2 {
-		t.Fatalf("expected 2 IAM users after append, got %d", len(model.iamUsers))
+	if len(model.iam.users) != 2 {
+		t.Fatalf("expected 2 IAM users after append, got %d", len(model.iam.users))
 	}
-	if model.iamUserLoadingMore {
+	if model.iam.userLoadingMore {
 		t.Fatal("expected loading-more flag to be cleared")
 	}
-	if !model.iamUserHasMore {
+	if !model.iam.userHasMore {
 		t.Fatal("expected hasMore to remain true")
 	}
-	if model.iamUserNextMarker != "page-3" {
-		t.Fatalf("expected next marker page-3, got %q", model.iamUserNextMarker)
+	if model.iam.userNextMarker != "page-3" {
+		t.Fatalf("expected next marker page-3, got %q", model.iam.userNextMarker)
 	}
 }
 
 func TestIAMUserDetailShowsGroupsPoliciesAndKeys(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenIAMUserDetail
-	m.selectedIAMUser = &awsservice.IAMUserDetail{
+	m.iam.selectedUser = &awsservice.IAMUserDetail{
 		IAMUser: awsservice.IAMUser{
 			UserName:         "alice",
 			UserID:           "AIDA1234",
@@ -1722,7 +1722,7 @@ func TestIAMUserDetailShowsGroupsPoliciesAndKeys(t *testing.T) {
 		},
 	}
 
-	view := m.viewIAMUserDetail()
+	view := m.iam.viewUserDetail(m)
 	if !strings.Contains(view, "admins") {
 		t.Fatalf("expected groups in detail view, got %q", view)
 	}
@@ -1737,11 +1737,11 @@ func TestIAMUserDetailShowsGroupsPoliciesAndKeys(t *testing.T) {
 func TestIAMUserListShowsLoadMoreHint(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenIAMUserList
-	m.iamUsers = []awsservice.IAMUser{{UserName: "alice"}}
-	m.filteredIAMUsers = m.iamUsers
-	m.iamUserHasMore = true
+	m.iam.users = []awsservice.IAMUser{{UserName: "alice"}}
+	m.iam.filteredUsers = m.iam.users
+	m.iam.userHasMore = true
 
-	view := m.viewIAMUserList()
+	view := m.iam.viewUserList(m)
 	if !strings.Contains(view, "Press n to load the next page") {
 		t.Fatalf("expected load-more hint in IAM user list view, got %q", view)
 	}
@@ -1750,12 +1750,12 @@ func TestIAMUserListShowsLoadMoreHint(t *testing.T) {
 func TestIAMUserListShowsFilterBackgroundLoadHint(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenIAMUserList
-	m.iamUsers = []awsservice.IAMUser{{UserName: "alice"}}
-	m.filteredIAMUsers = m.iamUsers
+	m.iam.users = []awsservice.IAMUser{{UserName: "alice"}}
+	m.iam.filteredUsers = m.iam.users
 	m.storeFilterValue(filterIAMUsers, "ali")
-	m.iamUserLoadingMore = true
+	m.iam.userLoadingMore = true
 
-	view := m.viewIAMUserList()
+	view := m.iam.viewUserList(m)
 	if !strings.Contains(view, "Loading remaining IAM usernames for filter") {
 		t.Fatalf("expected filter background load hint, got %q", view)
 	}
@@ -1763,13 +1763,13 @@ func TestIAMUserListShowsFilterBackgroundLoadHint(t *testing.T) {
 
 func TestIAMKeyDetailHidesRotateActionInListMode(t *testing.T) {
 	m := New(testConfig(), "", "dev")
-	m.iamRotationEnabled = false
-	m.selectedIAMKey = &awsservice.AccessKey{
+	m.iam.rotationEnabled = false
+	m.iam.selectedKey = &awsservice.AccessKey{
 		AccessKeyID: "AKIATEST",
 		Status:      "Active",
 	}
 
-	view := m.viewIAMKeyDetail()
+	view := m.iam.viewKeyDetail(m)
 	if !strings.Contains(view, "RotateAccessKey feature") {
 		t.Fatalf("expected list mode detail view to hide direct rotate action, got %q", view)
 	}
@@ -1777,13 +1777,13 @@ func TestIAMKeyDetailHidesRotateActionInListMode(t *testing.T) {
 
 func TestIAMKeyDetailShowsRotateActionInRotateMode(t *testing.T) {
 	m := New(testConfig(), "", "dev")
-	m.iamRotationEnabled = true
-	m.selectedIAMKey = &awsservice.AccessKey{
+	m.iam.rotationEnabled = true
+	m.iam.selectedKey = &awsservice.AccessKey{
 		AccessKeyID: "AKIATEST",
 		Status:      "Active",
 	}
 
-	view := m.viewIAMKeyDetail()
+	view := m.iam.viewKeyDetail(m)
 	if !strings.Contains(view, "[r] Rotate key") {
 		t.Fatalf("expected rotate mode detail view to show rotate action, got %q", view)
 	}
@@ -1792,17 +1792,17 @@ func TestIAMKeyDetailShowsRotateActionInRotateMode(t *testing.T) {
 func TestIAMRotationResultRequiresApplyBeforeDeactivateForCredentialCurrentIdentity(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.cfg.AuthType = config.AuthTypeCredential
-	m.iamNewKey = &awsservice.NewAccessKey{
+	m.iam.newKey = &awsservice.NewAccessKey{
 		AccessKeyID:     "AKIANEWKEY",
 		SecretAccessKey: "secret",
 	}
-	m.iamRotationOldKeyID = "AKIAOLDKEY"
+	m.iam.rotationOldKeyID = "AKIAOLDKEY"
 
-	if m.canDeactivateIAMOldKey() {
+	if m.iam.canDeactivateOldKey(m) {
 		t.Fatal("expected deactivate to be blocked before apply/verify")
 	}
 
-	view := m.viewIAMKeyRotateResult()
+	view := m.iam.viewKeyRotateResult(m)
 	if !strings.Contains(view, "Apply to ~/.aws/credentials and verify") {
 		t.Fatalf("expected apply action in result view, got %q", view)
 	}
@@ -1814,14 +1814,14 @@ func TestIAMRotationResultRequiresApplyBeforeDeactivateForCredentialCurrentIdent
 func TestIAMRotationResultAllowsDeactivateAfterVerify(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.cfg.AuthType = config.AuthTypeCredential
-	m.iamNewKey = &awsservice.NewAccessKey{
+	m.iam.newKey = &awsservice.NewAccessKey{
 		AccessKeyID:     "AKIANEWKEY",
 		SecretAccessKey: "secret",
 	}
-	m.iamRotationOldKeyID = "AKIAOLDKEY"
-	m.iamNewKeyVerified = true
+	m.iam.rotationOldKeyID = "AKIAOLDKEY"
+	m.iam.newKeyVerified = true
 
-	if !m.canDeactivateIAMOldKey() {
+	if !m.iam.canDeactivateOldKey(m) {
 		t.Fatal("expected deactivate to be allowed after verification")
 	}
 }
@@ -1829,13 +1829,13 @@ func TestIAMRotationResultAllowsDeactivateAfterVerify(t *testing.T) {
 func TestIAMRotationResultRequiresNoApplyForSSOContext(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.cfg.AuthType = config.AuthTypeSSO
-	m.iamNewKey = &awsservice.NewAccessKey{
+	m.iam.newKey = &awsservice.NewAccessKey{
 		AccessKeyID:     "AKIANEWKEY",
 		SecretAccessKey: "secret",
 	}
-	m.iamRotationOldKeyID = "AKIAOLDKEY"
+	m.iam.rotationOldKeyID = "AKIAOLDKEY"
 
-	if !m.canDeactivateIAMOldKey() {
+	if !m.iam.canDeactivateOldKey(m) {
 		t.Fatal("expected non-credential flow to allow immediate deactivate")
 	}
 }
@@ -1848,17 +1848,17 @@ func TestIAMRotationResultShowsApplyForLegacyCredentialContext(t *testing.T) {
 	m.cfg.SSOStartURL = ""
 	m.cfg.SSOAccountID = ""
 	m.cfg.SSORoleName = ""
-	m.iamNewKey = &awsservice.NewAccessKey{
+	m.iam.newKey = &awsservice.NewAccessKey{
 		AccessKeyID:     "AKIANEWKEY",
 		SecretAccessKey: "secret",
 	}
-	m.iamRotationOldKeyID = "AKIAOLDKEY"
+	m.iam.rotationOldKeyID = "AKIAOLDKEY"
 
-	if !m.requiresIAMCredentialApplyBeforeDeactivate() {
+	if !m.iam.requiresCredentialApplyBeforeDeactivate(m) {
 		t.Fatal("expected legacy profile-based context to require apply/verify")
 	}
 
-	view := m.viewIAMKeyRotateResult()
+	view := m.iam.viewKeyRotateResult(m)
 	if !strings.Contains(view, "[a] Apply to ~/.aws/credentials and verify") {
 		t.Fatalf("expected apply action for legacy credential context, got %q", view)
 	}
@@ -1872,17 +1872,17 @@ func TestIAMRotationResultShowsApplyForImplicitDefaultProfile(t *testing.T) {
 	m.cfg.SSOStartURL = ""
 	m.cfg.SSOAccountID = ""
 	m.cfg.SSORoleName = ""
-	m.iamNewKey = &awsservice.NewAccessKey{
+	m.iam.newKey = &awsservice.NewAccessKey{
 		AccessKeyID:     "AKIANEWKEY",
 		SecretAccessKey: "secret",
 	}
-	m.iamRotationOldKeyID = "AKIAOLDKEY"
+	m.iam.rotationOldKeyID = "AKIAOLDKEY"
 
-	if !m.requiresIAMCredentialApplyBeforeDeactivate() {
+	if !m.iam.requiresCredentialApplyBeforeDeactivate(m) {
 		t.Fatal("expected implicit default profile to require apply/verify")
 	}
 
-	view := m.viewIAMKeyRotateResult()
+	view := m.iam.viewKeyRotateResult(m)
 	if !strings.Contains(view, "[a] Apply to ~/.aws/credentials and verify") {
 		t.Fatalf("expected apply action for implicit default profile, got %q", view)
 	}
@@ -1891,13 +1891,13 @@ func TestIAMRotationResultShowsApplyForImplicitDefaultProfile(t *testing.T) {
 func TestIAMRotationResultShowsDisabledApplyReasonForSSO(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.cfg.AuthType = config.AuthTypeSSO
-	m.iamNewKey = &awsservice.NewAccessKey{
+	m.iam.newKey = &awsservice.NewAccessKey{
 		AccessKeyID:     "AKIANEWKEY",
 		SecretAccessKey: "secret",
 	}
-	m.iamRotationOldKeyID = "AKIAOLDKEY"
+	m.iam.rotationOldKeyID = "AKIAOLDKEY"
 
-	view := m.viewIAMKeyRotateResult()
+	view := m.iam.viewKeyRotateResult(m)
 	if !strings.Contains(view, "disabled for auth:sso") {
 		t.Fatalf("expected disabled reason for sso flow, got %q", view)
 	}
@@ -1917,7 +1917,7 @@ func TestRotateAccessKeyFeatureUsesCurrentIdentityFlow(t *testing.T) {
 
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	model := updated.(Model)
-	if !model.iamRotationEnabled {
+	if !model.iam.rotationEnabled {
 		t.Fatal("expected IAM rotation mode to be enabled")
 	}
 	if model.screen != screenLoading {
@@ -2347,7 +2347,7 @@ func TestCWLogTailAppendClampsScrollOffsetForShortEventList(t *testing.T) {
 		{Timestamp: time.Unix(1, 0), Message: "two"},
 	}
 
-	updated, _, handled := m.handleCloudWatchLogsMsg(cwLogEventsLoadedMsg{
+	updated, _, handled := m.cwLogs.HandleMessage(&m, cwLogEventsLoadedMsg{
 		append: true,
 		events: []awsservice.LogEvent{
 			{Timestamp: time.Unix(2, 0), Message: "three"},
@@ -2368,7 +2368,7 @@ func TestCWLogTailTickSchedulesPollAndNextTick(t *testing.T) {
 	m.cwLogs.tailing = true
 	m.cwLogs.selectedGroup = &awsservice.LogGroup{Name: "/aws/lambda/test"}
 
-	updated, cmd, handled := m.handleCloudWatchLogsMsg(cwLogTailTickMsg{})
+	updated, cmd, handled := m.cwLogs.HandleMessage(&m, cwLogTailTickMsg{})
 	if !handled {
 		t.Fatal("expected CloudWatch logs tail tick to be handled")
 	}
@@ -2401,7 +2401,7 @@ func TestCWLogTailAppendDeduplicatesExistingEventIDs(t *testing.T) {
 		{EventID: "evt-2", Timestamp: time.Unix(1, 0), Message: "two"},
 	}
 
-	updated, _, handled := m.handleCloudWatchLogsMsg(cwLogEventsLoadedMsg{
+	updated, _, handled := m.cwLogs.HandleMessage(&m, cwLogEventsLoadedMsg{
 		append: true,
 		events: []awsservice.LogEvent{
 			{EventID: "evt-2", Timestamp: time.Unix(1, 0), Message: "two"},
@@ -2430,7 +2430,7 @@ func TestCWLogTailAppendDeduplicatesEventsWithoutEventIDs(t *testing.T) {
 		{Timestamp: time.Unix(1, 0), Message: "duplicate"},
 	}
 
-	updated, _, handled := m.handleCloudWatchLogsMsg(cwLogEventsLoadedMsg{
+	updated, _, handled := m.cwLogs.HandleMessage(&m, cwLogEventsLoadedMsg{
 		append: true,
 		events: []awsservice.LogEvent{
 			{Timestamp: time.Unix(1, 0), Message: "duplicate"},
@@ -2455,7 +2455,7 @@ func TestCWLogLoadMoreDoesNotOverwriteTailToken(t *testing.T) {
 	m.cwLogs.tailToken = stringPtr("tail-token")
 	m.cwLogs.nextToken = stringPtr("page-token")
 
-	updated, _, handled := m.handleCloudWatchLogsMsg(cwLogEventsLoadedMsg{
+	updated, _, handled := m.cwLogs.HandleMessage(&m, cwLogEventsLoadedMsg{
 		append:                true,
 		nextToken:             stringPtr("older-page-token"),
 		updatePaginationToken: true,
@@ -2479,7 +2479,7 @@ func TestCWLogTailAppendDoesNotOverwritePaginationToken(t *testing.T) {
 	m.cwLogs.nextToken = stringPtr("page-token")
 	m.cwLogs.tailToken = stringPtr("tail-token")
 
-	updated, _, handled := m.handleCloudWatchLogsMsg(cwLogEventsLoadedMsg{
+	updated, _, handled := m.cwLogs.HandleMessage(&m, cwLogEventsLoadedMsg{
 		append:          true,
 		nextToken:       stringPtr("new-tail-token"),
 		updateTailToken: true,
@@ -2501,7 +2501,7 @@ func TestCWLogTailAppendDoesNotOverwritePaginationToken(t *testing.T) {
 func TestCWLogGroupsLoadedReplacesInitialPageAndStoresNextToken(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 
-	updated, _, handled := m.handleCloudWatchLogsMsg(cwLogGroupsLoadedMsg{
+	updated, _, handled := m.cwLogs.HandleMessage(&m, cwLogGroupsLoadedMsg{
 		groups: []awsservice.LogGroup{
 			{Name: "/aws/lambda/a"},
 			{Name: "/aws/lambda/b"},
@@ -2525,7 +2525,7 @@ func TestCWLogGroupsLoadedAppendExtendsExistingList(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.cwLogs.groups = []awsservice.LogGroup{{Name: "/aws/lambda/a"}}
 
-	updated, _, handled := m.handleCloudWatchLogsMsg(cwLogGroupsLoadedMsg{
+	updated, _, handled := m.cwLogs.HandleMessage(&m, cwLogGroupsLoadedMsg{
 		append: true,
 		groups: []awsservice.LogGroup{
 			{Name: "/aws/lambda/b"},
@@ -2549,7 +2549,7 @@ func TestCWLogStreamsLoadedAppendExtendsExistingList(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.cwLogs.streams = []awsservice.LogStream{{Name: "stream-a"}}
 
-	updated, _, handled := m.handleCloudWatchLogsMsg(cwLogStreamsLoadedMsg{
+	updated, _, handled := m.cwLogs.HandleMessage(&m, cwLogStreamsLoadedMsg{
 		append: true,
 		streams: []awsservice.LogStream{
 			{Name: "stream-b"},

--- a/internal/app/feature_submodel.go
+++ b/internal/app/feature_submodel.go
@@ -10,5 +10,5 @@ type featureSubmodel interface {
 }
 
 func (m *Model) featureSubmodels() []featureSubmodel {
-	return []featureSubmodel{&m.ec2Browser, &m.cwMetrics, &m.cwLogs, &m.rds, &m.bedrock, &m.secrets, &m.s3, &m.lambda}
+	return []featureSubmodel{&m.ec2Browser, &m.cwMetrics, &m.cwLogs, &m.rds, &m.route53, &m.iam, &m.bedrock, &m.secrets, &m.s3, &m.lambda}
 }

--- a/internal/app/filter.go
+++ b/internal/app/filter.go
@@ -165,14 +165,6 @@ func (m *Model) applyFilterTarget(target filterTarget) {
 		m.instIdx = 0
 	case filterSubnetIPs:
 		m.applyIPFilter()
-	case filterRoute53Zones:
-		m.filteredRoute53Zones = applyFilter(m.route53Zones, m.filterValue(target))
-		m.route53ZoneIdx = 0
-	case filterRoute53Records:
-		m.filteredRoute53Records = applyFilter(m.route53Records, m.filterValue(target))
-		m.route53RecordIdx = 0
-	case filterIAMUsers:
-		m.refreshIAMUserFilter()
 	case filterSecurityGroups:
 		m.filteredSecurityGroups = applyFilter(m.securityGroups, m.filterValue(target))
 		m.sgIdx = 0

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -239,10 +239,10 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 			{"c", "Create a new DNS record"},
 			{"q / esc", "Go back to the record list"},
 		}
-		if m.selectedRoute53Record != nil {
-			canEdit := m.selectedRoute53Record.AliasTarget == "" &&
-				(m.selectedRoute53Record.Type == "A" || m.selectedRoute53Record.Type == "CNAME")
-			canDelete := m.selectedRoute53Record.Type != "NS" && m.selectedRoute53Record.Type != "SOA"
+		if m.route53.selectedRecord != nil {
+			canEdit := m.route53.selectedRecord.AliasTarget == "" &&
+				(m.route53.selectedRecord.Type == "A" || m.route53.selectedRecord.Type == "CNAME")
+			canDelete := m.route53.selectedRecord.Type != "NS" && m.route53.selectedRecord.Type != "SOA"
 			if canEdit {
 				shortcuts = append([]helpShortcut{{"e", "Edit the selected DNS record"}}, shortcuts...)
 			}
@@ -252,7 +252,7 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 		}
 		return shortcuts
 	case screenRoute53RecordCreate:
-		return route53FormShortcuts(m.route53EditField == 1)
+		return route53FormShortcuts(m.route53.editField == 1)
 	case screenRoute53RecordEdit:
 		return []helpShortcut{
 			{"type", "Edit the current record field"},
@@ -321,7 +321,7 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 		shortcuts := []helpShortcut{
 			{"q / esc", "Go back to the access key list"},
 		}
-		if m.iamRotationEnabled && m.selectedIAMKey != nil && m.selectedIAMKey.Status == "Active" {
+		if m.iam.rotationEnabled && m.iam.selectedKey != nil && m.iam.selectedKey.Status == "Active" {
 			shortcuts = append([]helpShortcut{{"r", "Start rotating the selected access key"}}, shortcuts...)
 		}
 		return shortcuts

--- a/internal/app/screen_cloudwatchlogs.go
+++ b/internal/app/screen_cloudwatchlogs.go
@@ -862,11 +862,3 @@ func (cw cloudWatchLogsModel) tickTail() tea.Cmd {
 		return cwLogTailTickMsg{}
 	})
 }
-
-func (m Model) handleCloudWatchLogsMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
-	return m.cwLogs.HandleMessage(&m, msg)
-}
-
-func (m Model) cwLogViewerLines() []string {
-	return m.cwLogs.viewerLines(m)
-}

--- a/internal/app/screen_cloudwatchlogs_test.go
+++ b/internal/app/screen_cloudwatchlogs_test.go
@@ -20,7 +20,7 @@ func TestCWLogViewerLinesWrapLongMessages(t *testing.T) {
 		},
 	}
 
-	lines := m.cwLogViewerLines()
+	lines := m.cwLogs.viewerLines(m)
 	if len(lines) < 2 {
 		t.Fatalf("expected wrapped lines, got %d: %#v", len(lines), lines)
 	}
@@ -39,7 +39,7 @@ func TestCWLogViewerLinesHorizontalOffsetWhenWrapDisabled(t *testing.T) {
 		},
 	}
 
-	lines := m.cwLogViewerLines()
+	lines := m.cwLogs.viewerLines(m)
 	if len(lines) != 1 {
 		t.Fatalf("expected a single rendered line, got %d", len(lines))
 	}

--- a/internal/app/screen_iam.go
+++ b/internal/app/screen_iam.go
@@ -19,90 +19,177 @@ import (
 const iamUserPageSize = 25
 const iamUserFilterPageSize = 100
 
-func (m Model) handleIAMMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
+type iamModel struct {
+	users            []awsservice.IAMUser
+	filteredUsers    []awsservice.IAMUser
+	userIdx          int
+	userLoadingMore  bool
+	userHasMore      bool
+	userNextMarker   string
+	selectedUser     *awsservice.IAMUserDetail
+	keys             []awsservice.AccessKey
+	keyIdx           int
+	selectedKey      *awsservice.AccessKey
+	rotationEnabled  bool
+	rotateConfirm    string // typed input for rotate confirmation
+	rotationOldKeyID string
+	newKey           *awsservice.NewAccessKey
+	copyMsg          string // feedback message for clipboard copy
+	rotationStatus   string
+	newKeyVerified   bool
+	oldKeyDeleted    bool
+	oldKeyInactive   bool
+}
+
+func newIAMModel() iamModel {
+	return iamModel{}
+}
+
+func (im *iamModel) StartUsers(m *Model) (tea.Model, tea.Cmd) {
+	return m.startLoading(im.loadUsers(*m))
+}
+
+func (im *iamModel) StartKeys(m *Model, rotationEnabled bool) (tea.Model, tea.Cmd) {
+	im.rotationEnabled = rotationEnabled
+	return m.startLoading(im.loadKeys(*m))
+}
+
+func (im *iamModel) HandleMessage(m *Model, msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 	switch msg := msg.(type) {
 	case iamUsersLoadedMsg:
 		if msg.append {
-			m.iamUsers = append(m.iamUsers, msg.users...)
+			im.users = append(im.users, msg.users...)
 		} else {
-			m.iamUsers = msg.users
-			m.iamUserIdx = 0
+			im.users = msg.users
+			im.userIdx = 0
 		}
-		sort.Slice(m.iamUsers, func(i, j int) bool {
-			return strings.ToLower(m.iamUsers[i].UserName) < strings.ToLower(m.iamUsers[j].UserName)
+		sort.Slice(im.users, func(i, j int) bool {
+			return strings.ToLower(im.users[i].UserName) < strings.ToLower(im.users[j].UserName)
 		})
-		m.iamUserLoadingMore = false
-		m.iamUserHasMore = msg.hasMore
-		m.iamUserNextMarker = msg.nextMarker
-		m.refreshIAMUserFilter()
+		im.userLoadingMore = false
+		im.userHasMore = msg.hasMore
+		im.userNextMarker = msg.nextMarker
+		im.refreshUserFilter(m)
 		m.screen = screenIAMUserList
-		return m, nil, true
+		return *m, nil, true
 
 	case iamUserDetailLoadedMsg:
-		m.selectedIAMUser = msg.user
+		im.selectedUser = msg.user
 		m.screen = screenIAMUserDetail
-		return m, nil, true
+		return *m, nil, true
 
 	case iamKeysLoadedMsg:
-		m.iamKeys = msg.keys
-		m.iamKeyIdx = 0
+		im.keys = msg.keys
+		im.keyIdx = 0
 		m.screen = screenIAMKeyList
-		return m, nil, true
+		return *m, nil, true
 
 	case iamKeyCreatedMsg:
 		if msg.err != nil {
 			m.errMsg = msg.err.Error()
 			m.screen = screenError
-			return m, nil, true
+			return *m, nil, true
 		}
-		m.iamNewKey = msg.newKey
-		m.iamCopyMsg = ""
-		m.iamRotationStatus = ""
-		m.iamNewKeyVerified = false
-		m.iamOldKeyInactive = false
-		m.iamOldKeyDeleted = false
+		im.newKey = msg.newKey
+		im.copyMsg = ""
+		im.rotationStatus = ""
+		im.newKeyVerified = false
+		im.oldKeyInactive = false
+		im.oldKeyDeleted = false
 		m.screen = screenIAMKeyRotateResult
-		return m, nil, true
+		return *m, nil, true
 
 	case iamKeyVerifiedMsg:
 		if msg.err != nil {
-			m.iamRotationStatus = fmt.Sprintf("Verification failed: %s", msg.err)
-			return m, nil, true
+			im.rotationStatus = fmt.Sprintf("Verification failed: %s", msg.err)
+			return *m, nil, true
 		}
-		m.iamNewKeyVerified = true
+		im.newKeyVerified = true
 		if msg.identity != nil {
-			m.iamRotationStatus = fmt.Sprintf("Verified new key as %s", msg.identity.Arn)
+			im.rotationStatus = fmt.Sprintf("Verified new key as %s", msg.identity.Arn)
 		} else {
-			m.iamRotationStatus = "Verified new key"
+			im.rotationStatus = "Verified new key"
 		}
-		return m, nil, true
+		return *m, nil, true
 
 	case iamKeyDeactivatedMsg:
 		if msg.err != nil {
-			m.iamRotationStatus = msg.err.Error()
-			return m, nil, true
+			im.rotationStatus = msg.err.Error()
+			return *m, nil, true
 		}
-		m.iamOldKeyInactive = true
-		m.iamRotationStatus = fmt.Sprintf("Old key %s marked Inactive", msg.keyID)
-		return m, nil, true
+		im.oldKeyInactive = true
+		im.rotationStatus = fmt.Sprintf("Old key %s marked Inactive", msg.keyID)
+		return *m, nil, true
 
 	case iamKeyDeletedMsg:
 		if msg.err != nil {
-			m.iamRotationStatus = msg.err.Error()
-			return m, nil, true
+			im.rotationStatus = msg.err.Error()
+			return *m, nil, true
 		}
-		m.iamOldKeyDeleted = true
-		m.iamRotationStatus = fmt.Sprintf("Old key %s deleted", msg.keyID)
-		return m, nil, true
+		im.oldKeyDeleted = true
+		im.rotationStatus = fmt.Sprintf("Old key %s deleted", msg.keyID)
+		return *m, nil, true
 	}
-	return m, nil, false
+	return *m, nil, false
 }
 
-func (m Model) loadIAMUsers() tea.Cmd {
-	return m.loadIAMUsersPage("", false)
+func (im *iamModel) HandleKey(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
+	switch m.screen {
+	case screenIAMUserList:
+		newM, cmd := im.updateUserList(m, msg)
+		return newM, cmd, true
+	case screenIAMUserDetail:
+		newM, cmd := im.updateUserDetail(m, msg)
+		return newM, cmd, true
+	case screenIAMKeyList:
+		newM, cmd := im.updateKeyList(m, msg)
+		return newM, cmd, true
+	case screenIAMKeyDetail:
+		newM, cmd := im.updateKeyDetail(m, msg)
+		return newM, cmd, true
+	case screenIAMKeyRotateConfirm:
+		newM, cmd := im.updateKeyRotateConfirm(m, msg)
+		return newM, cmd, true
+	case screenIAMKeyRotateResult:
+		newM, cmd := im.updateKeyRotateResult(m, msg)
+		return newM, cmd, true
+	default:
+		return *m, nil, false
+	}
 }
 
-func (m Model) loadIAMUsersPage(marker string, appendPage bool) tea.Cmd {
+func (im iamModel) View(m Model) (string, bool) {
+	switch m.screen {
+	case screenIAMUserList:
+		return im.viewUserList(m), true
+	case screenIAMUserDetail:
+		return im.viewUserDetail(m), true
+	case screenIAMKeyList:
+		return im.viewKeyList(m), true
+	case screenIAMKeyDetail:
+		return im.viewKeyDetail(m), true
+	case screenIAMKeyRotateConfirm:
+		return im.viewKeyRotateConfirm(m), true
+	case screenIAMKeyRotateResult:
+		return im.viewKeyRotateResult(m), true
+	default:
+		return "", false
+	}
+}
+
+func (im *iamModel) ApplyFilter(m *Model, target filterTarget) bool {
+	if target != filterIAMUsers {
+		return false
+	}
+	im.refreshUserFilter(m)
+	return true
+}
+
+func (im iamModel) loadUsers(m Model) tea.Cmd {
+	return im.loadUsersPage(m, "", false)
+}
+
+func (im iamModel) loadUsersPage(m Model, marker string, appendPage bool) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
 		repo := m.awsRepo
@@ -131,7 +218,7 @@ func (m Model) loadIAMUsersPage(marker string, appendPage bool) tea.Cmd {
 	}
 }
 
-func (m Model) loadAllIAMUserSummaries(marker string) tea.Cmd {
+func (im iamModel) loadAllUserSummaries(m Model, marker string) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
 		repo := m.awsRepo
@@ -168,7 +255,7 @@ func (m Model) loadAllIAMUserSummaries(marker string) tea.Cmd {
 	}
 }
 
-func (m Model) loadIAMUserDetail(userName string) tea.Cmd {
+func (im iamModel) loadUserDetail(m Model, userName string) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
 		repo := m.awsRepo
@@ -188,7 +275,7 @@ func (m Model) loadIAMUserDetail(userName string) tea.Cmd {
 	}
 }
 
-func (m Model) loadIAMKeys() tea.Cmd {
+func (im iamModel) loadKeys(m Model) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
@@ -208,7 +295,7 @@ func (m Model) loadIAMKeys() tea.Cmd {
 	}
 }
 
-func (m Model) createIAMKey() tea.Cmd {
+func (im iamModel) createKey(m Model) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
 		repo := m.awsRepo
@@ -225,13 +312,13 @@ func (m Model) createIAMKey() tea.Cmd {
 	}
 }
 
-func (m Model) verifyIAMKey() tea.Cmd {
+func (im iamModel) verifyKey(m Model) tea.Cmd {
 	return func() tea.Msg {
-		if m.iamNewKey == nil {
+		if im.newKey == nil {
 			return iamKeyVerifiedMsg{err: fmt.Errorf("no new key available to verify")}
 		}
 
-		if err := auth.UpdateSharedCredentialsProfile(m.cfg.Profile, m.iamNewKey.AccessKeyID, m.iamNewKey.SecretAccessKey); err != nil {
+		if err := auth.UpdateSharedCredentialsProfile(m.cfg.Profile, im.newKey.AccessKeyID, im.newKey.SecretAccessKey); err != nil {
 			return iamKeyVerifiedMsg{err: err}
 		}
 
@@ -245,12 +332,12 @@ func (m Model) verifyIAMKey() tea.Cmd {
 			}
 		}
 
-		identity, err := repo.VerifyAccessKey(ctx, m.iamNewKey)
+		identity, err := repo.VerifyAccessKey(ctx, im.newKey)
 		return iamKeyVerifiedMsg{identity: identity, err: err}
 	}
 }
 
-func (m Model) deactivateIAMKey(oldKeyID string) tea.Cmd {
+func (im iamModel) deactivateKey(m Model, oldKeyID string) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
 		repo := m.awsRepo
@@ -267,7 +354,7 @@ func (m Model) deactivateIAMKey(oldKeyID string) tea.Cmd {
 	}
 }
 
-func (m Model) deleteIAMKey(keyID string) tea.Cmd {
+func (im iamModel) deleteKey(m Model, keyID string) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
 		repo := m.awsRepo
@@ -284,7 +371,7 @@ func (m Model) deleteIAMKey(keyID string) tea.Cmd {
 	}
 }
 
-func (m Model) requiresIAMCredentialApplyBeforeDeactivate() bool {
+func (im iamModel) requiresCredentialApplyBeforeDeactivate(m Model) bool {
 	if m.cfg == nil {
 		return false
 	}
@@ -302,19 +389,19 @@ func (m Model) requiresIAMCredentialApplyBeforeDeactivate() bool {
 		m.cfg.SSORoleName == ""
 }
 
-func (m Model) canDeactivateIAMOldKey() bool {
-	if m.iamNewKey == nil || m.iamRotationOldKeyID == "" || m.iamOldKeyInactive {
+func (im iamModel) canDeactivateOldKey(m Model) bool {
+	if im.newKey == nil || im.rotationOldKeyID == "" || im.oldKeyInactive {
 		return false
 	}
-	if !m.requiresIAMCredentialApplyBeforeDeactivate() {
+	if !im.requiresCredentialApplyBeforeDeactivate(m) {
 		return true
 	}
-	return m.iamNewKeyVerified
+	return im.newKeyVerified
 }
 
-func (m Model) iamApplyActionLine() string {
-	if m.requiresIAMCredentialApplyBeforeDeactivate() {
-		if m.iamNewKeyVerified {
+func (im iamModel) applyActionLine(m Model) string {
+	if im.requiresCredentialApplyBeforeDeactivate(m) {
+		if im.newKeyVerified {
 			return selectedStyle.Render("  [a] Applied to ~/.aws/credentials and verified")
 		}
 		return normalStyle.Render("  [a] Apply to ~/.aws/credentials and verify")
@@ -326,181 +413,181 @@ func (m Model) iamApplyActionLine() string {
 	return dimStyle.Render(fmt.Sprintf("  [a] Apply to ~/.aws/credentials and verify (disabled for auth:%s)", authType))
 }
 
-func (m Model) updateIAMUserList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (im *iamModel) updateUserList(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
 	if cmd, handled := m.updateSharedFilter(msg, filterIAMUsers); handled {
-		return m, cmd
+		return *m, cmd
 	}
 
 	switch key {
 	case "q", "esc":
 		m.screen = screenFeatureList
-		m.selectedIAMUser = nil
+		im.selectedUser = nil
 		m.resetFilter(filterIAMUsers)
-		m.iamUserLoadingMore = false
-		m.iamUserHasMore = false
-		m.iamUserNextMarker = ""
-		m.filteredIAMUsers = nil
-		m.iamUserIdx = 0
+		im.userLoadingMore = false
+		im.userHasMore = false
+		im.userNextMarker = ""
+		im.filteredUsers = nil
+		im.userIdx = 0
 	case "up", "k":
-		m.iamUserIdx = previousListIndex(m.iamUserIdx, len(m.filteredIAMUsers))
+		im.userIdx = previousListIndex(im.userIdx, len(im.filteredUsers))
 	case "down", "j":
-		m.iamUserIdx = nextListIndex(m.iamUserIdx, len(m.filteredIAMUsers))
+		im.userIdx = nextListIndex(im.userIdx, len(im.filteredUsers))
 	case "/":
 		filterCmd := m.activateFilter(filterIAMUsers)
-		if m.iamUserHasMore && !m.iamUserLoadingMore {
-			m.iamUserLoadingMore = true
-			return m, tea.Batch(filterCmd, m.loadAllIAMUserSummaries(m.iamUserNextMarker))
+		if im.userHasMore && !im.userLoadingMore {
+			im.userLoadingMore = true
+			return *m, tea.Batch(filterCmd, im.loadAllUserSummaries(*m, im.userNextMarker))
 		}
-		return m, filterCmd
+		return *m, filterCmd
 	case "enter":
-		if len(m.filteredIAMUsers) > 0 && m.iamUserIdx < len(m.filteredIAMUsers) {
-			selected := m.filteredIAMUsers[m.iamUserIdx]
-			return m.startLoading(m.loadIAMUserDetail(selected.UserName))
+		if len(im.filteredUsers) > 0 && im.userIdx < len(im.filteredUsers) {
+			selected := im.filteredUsers[im.userIdx]
+			return m.startLoading(im.loadUserDetail(*m, selected.UserName))
 		}
 	case "n":
-		if m.iamUserHasMore && !m.iamUserLoadingMore {
-			m.iamUserLoadingMore = true
-			return m, m.loadIAMUsersPage(m.iamUserNextMarker, true)
+		if im.userHasMore && !im.userLoadingMore {
+			im.userLoadingMore = true
+			return *m, im.loadUsersPage(*m, im.userNextMarker, true)
 		}
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m *Model) refreshIAMUserFilter() {
+func (im *iamModel) refreshUserFilter(m *Model) {
 	query := m.filterValue(filterIAMUsers)
 	if query == "" {
-		m.filteredIAMUsers = m.iamUsers
+		im.filteredUsers = im.users
 	} else {
-		m.filteredIAMUsers = applyFilter(m.iamUsers, query)
+		im.filteredUsers = applyFilter(im.users, query)
 	}
 
-	if len(m.filteredIAMUsers) == 0 {
-		m.iamUserIdx = 0
+	if len(im.filteredUsers) == 0 {
+		im.userIdx = 0
 		return
 	}
-	if m.iamUserIdx >= len(m.filteredIAMUsers) {
-		m.iamUserIdx = len(m.filteredIAMUsers) - 1
+	if im.userIdx >= len(im.filteredUsers) {
+		im.userIdx = len(im.filteredUsers) - 1
 	}
 }
 
-func (m Model) updateIAMUserDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (im *iamModel) updateUserDetail(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "q", "esc":
-		m.selectedIAMUser = nil
+		im.selectedUser = nil
 		m.screen = screenIAMUserList
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) updateIAMKeyList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (im *iamModel) updateKeyList(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "q", "esc":
 		m.screen = screenFeatureList
-		m.iamKeyIdx = 0
+		im.keyIdx = 0
 	case "up", "k":
-		m.iamKeyIdx = previousListIndex(m.iamKeyIdx, len(m.iamKeys))
+		im.keyIdx = previousListIndex(im.keyIdx, len(im.keys))
 	case "down", "j":
-		m.iamKeyIdx = nextListIndex(m.iamKeyIdx, len(m.iamKeys))
+		im.keyIdx = nextListIndex(im.keyIdx, len(im.keys))
 	case "enter":
-		if len(m.iamKeys) > 0 && m.iamKeyIdx < len(m.iamKeys) {
-			selected := m.iamKeys[m.iamKeyIdx]
-			m.selectedIAMKey = &selected
+		if len(im.keys) > 0 && im.keyIdx < len(im.keys) {
+			selected := im.keys[im.keyIdx]
+			im.selectedKey = &selected
 			m.screen = screenIAMKeyDetail
 		}
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) updateIAMKeyDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (im *iamModel) updateKeyDetail(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "q", "esc":
 		m.screen = screenIAMKeyList
 	case "r":
-		if m.iamRotationEnabled && m.selectedIAMKey != nil && m.selectedIAMKey.Status == "Active" {
-			m.iamRotateConfirm = ""
-			m.iamRotationOldKeyID = m.selectedIAMKey.AccessKeyID
-			m.iamNewKey = nil
-			m.iamCopyMsg = ""
-			m.iamRotationStatus = ""
-			m.iamNewKeyVerified = false
-			m.iamOldKeyInactive = false
-			m.iamOldKeyDeleted = false
+		if im.rotationEnabled && im.selectedKey != nil && im.selectedKey.Status == "Active" {
+			im.rotateConfirm = ""
+			im.rotationOldKeyID = im.selectedKey.AccessKeyID
+			im.newKey = nil
+			im.copyMsg = ""
+			im.rotationStatus = ""
+			im.newKeyVerified = false
+			im.oldKeyInactive = false
+			im.oldKeyDeleted = false
 			m.screen = screenIAMKeyRotateConfirm
 		}
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) updateIAMKeyRotateConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (im *iamModel) updateKeyRotateConfirm(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	confirmTarget := ""
-	if m.selectedIAMKey != nil {
-		confirmTarget = m.selectedIAMKey.AccessKeyID
+	if im.selectedKey != nil {
+		confirmTarget = im.selectedKey.AccessKeyID
 	}
 
 	switch msg.String() {
 	case "esc":
 		m.screen = screenIAMKeyDetail
 	case "enter":
-		if m.selectedIAMKey != nil && m.iamRotateConfirm == confirmTarget {
-			return m.startLoading(m.createIAMKey())
+		if im.selectedKey != nil && im.rotateConfirm == confirmTarget {
+			return m.startLoading(im.createKey(*m))
 		}
 	case "backspace":
-		if len(m.iamRotateConfirm) > 0 {
-			m.iamRotateConfirm = m.iamRotateConfirm[:len(m.iamRotateConfirm)-1]
+		if len(im.rotateConfirm) > 0 {
+			im.rotateConfirm = im.rotateConfirm[:len(im.rotateConfirm)-1]
 		}
 	default:
 		if runes := msg.Runes; len(runes) > 0 {
-			m.iamRotateConfirm += string(runes)
+			im.rotateConfirm += string(runes)
 		}
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) updateIAMKeyRotateResult(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (im *iamModel) updateKeyRotateResult(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "c":
-		if m.iamNewKey != nil {
+		if im.newKey != nil {
 			exportStr := fmt.Sprintf(
 				"export AWS_ACCESS_KEY_ID=%s\nexport AWS_SECRET_ACCESS_KEY=%s",
-				m.iamNewKey.AccessKeyID, m.iamNewKey.SecretAccessKey,
+				im.newKey.AccessKeyID, im.newKey.SecretAccessKey,
 			)
 			if err := clipboard.Copy(exportStr); err != nil {
-				m.iamCopyMsg = fmt.Sprintf("Clipboard error: %s", err)
+				im.copyMsg = fmt.Sprintf("Clipboard error: %s", err)
 			} else {
-				m.iamCopyMsg = "Copied to clipboard!"
+				im.copyMsg = "Copied to clipboard!"
 			}
 		}
 	case "a":
-		if m.requiresIAMCredentialApplyBeforeDeactivate() && m.iamNewKey != nil && !m.iamNewKeyVerified {
-			m.iamRotationStatus = "Applying new key to ~/.aws/credentials and verifying..."
-			return m, m.verifyIAMKey()
+		if im.requiresCredentialApplyBeforeDeactivate(*m) && im.newKey != nil && !im.newKeyVerified {
+			im.rotationStatus = "Applying new key to ~/.aws/credentials and verifying..."
+			return *m, im.verifyKey(*m)
 		}
 	case "d":
-		if m.canDeactivateIAMOldKey() {
-			return m, m.deactivateIAMKey(m.iamRotationOldKeyID)
+		if im.canDeactivateOldKey(*m) {
+			return *m, im.deactivateKey(*m, im.rotationOldKeyID)
 		}
 	case "x":
-		if m.iamOldKeyInactive && !m.iamOldKeyDeleted && m.iamRotationOldKeyID != "" {
-			return m, m.deleteIAMKey(m.iamRotationOldKeyID)
+		if im.oldKeyInactive && !im.oldKeyDeleted && im.rotationOldKeyID != "" {
+			return *m, im.deleteKey(*m, im.rotationOldKeyID)
 		}
 	case "q", "esc":
-		m.iamRotationOldKeyID = ""
-		m.iamNewKey = nil
-		m.iamCopyMsg = ""
-		m.iamRotationStatus = ""
-		m.iamNewKeyVerified = false
-		m.iamOldKeyInactive = false
-		m.iamOldKeyDeleted = false
-		return m.startLoading(m.loadIAMKeys())
+		im.rotationOldKeyID = ""
+		im.newKey = nil
+		im.copyMsg = ""
+		im.rotationStatus = ""
+		im.newKeyVerified = false
+		im.oldKeyInactive = false
+		im.oldKeyDeleted = false
+		return m.startLoading(im.loadKeys(*m))
 	}
-	return m, nil
+	return *m, nil
 }
 
 // --- View functions ---
 
-func (m Model) viewIAMUserList() string {
+func (im iamModel) viewUserList(m Model) string {
 	var b strings.Builder
 	var panel strings.Builder
 	b.WriteString(m.renderStatusBar())
@@ -510,12 +597,12 @@ func (m Model) viewIAMUserList() string {
 	b.WriteString(m.renderFilterValue(filterIAMUsers))
 	b.WriteString("\n\n")
 
-	if len(m.filteredIAMUsers) == 0 {
+	if len(im.filteredUsers) == 0 {
 		panel.WriteString(dimStyle.Render("  No matching IAM users"))
 		panel.WriteString("\n")
 	} else {
 		maxName := len("USERNAME")
-		for _, user := range m.filteredIAMUsers {
+		for _, user := range im.filteredUsers {
 			if len(user.UserName) > maxName {
 				maxName = len(user.UserName)
 			}
@@ -535,16 +622,16 @@ func (m Model) viewIAMUserList() string {
 
 		visibleLines := max(m.height-11, 5)
 		start := 0
-		if m.iamUserIdx >= visibleLines {
-			start = m.iamUserIdx - visibleLines + 1
+		if im.userIdx >= visibleLines {
+			start = im.userIdx - visibleLines + 1
 		}
-		end := min(start+visibleLines, len(m.filteredIAMUsers))
+		end := min(start+visibleLines, len(im.filteredUsers))
 
 		for i := start; i < end; i++ {
-			user := m.filteredIAMUsers[i]
+			user := im.filteredUsers[i]
 			cursor := "  "
 			style := normalStyle
-			if i == m.iamUserIdx {
+			if i == im.userIdx {
 				cursor = "> "
 				style = selectedStyle
 			}
@@ -558,21 +645,21 @@ func (m Model) viewIAMUserList() string {
 		}
 
 		panel.WriteString("\n")
-		status := fmt.Sprintf("  %d/%d loaded IAM users", len(m.filteredIAMUsers), len(m.iamUsers))
-		if m.iamUserHasMore {
+		status := fmt.Sprintf("  %d/%d loaded IAM users", len(im.filteredUsers), len(im.users))
+		if im.userHasMore {
 			status += " • more available"
 		}
 		panel.WriteString(dimStyle.Render(status))
 	}
 
-	if m.iamUserLoadingMore {
+	if im.userLoadingMore {
 		panel.WriteString("\n")
 		if m.isFiltering(filterIAMUsers) || m.filterValue(filterIAMUsers) != "" {
 			panel.WriteString(filterStyle.Render("  Loading remaining IAM usernames for filter..."))
 		} else {
 			panel.WriteString(filterStyle.Render("  Loading more IAM users..."))
 		}
-	} else if m.iamUserHasMore {
+	} else if im.userHasMore {
 		panel.WriteString("\n")
 		if m.isFiltering(filterIAMUsers) || m.filterValue(filterIAMUsers) != "" {
 			panel.WriteString(dimStyle.Render("  Continue typing to filter loaded usernames"))
@@ -587,12 +674,12 @@ func (m Model) viewIAMUserList() string {
 	return b.String()
 }
 
-func (m Model) viewIAMUserDetail() string {
-	if m.selectedIAMUser == nil {
+func (im iamModel) viewUserDetail(m Model) string {
+	if im.selectedUser == nil {
 		return ""
 	}
 
-	u := m.selectedIAMUser
+	u := im.selectedUser
 	var b strings.Builder
 	b.WriteString(m.renderStatusBar())
 	b.WriteString(titleStyle.Render("IAM User Detail"))
@@ -641,38 +728,38 @@ func (m Model) viewIAMUserDetail() string {
 	return b.String()
 }
 
-func (m Model) viewIAMKeyList() string {
+func (im iamModel) viewKeyList(m Model) string {
 	var b strings.Builder
 	var panel strings.Builder
 	b.WriteString(m.renderStatusBar())
 	title := "IAM Access Keys"
-	if m.iamRotationEnabled {
+	if im.rotationEnabled {
 		title = "Rotate IAM Access Key"
 	}
 	b.WriteString(titleStyle.Render(title))
 	b.WriteString("\n\n")
 
-	if m.iamRotationEnabled {
+	if im.rotationEnabled {
 		b.WriteString(dimStyle.Render("  User: Current identity"))
 		b.WriteString("\n\n")
 	}
 
-	if len(m.iamKeys) == 0 {
+	if len(im.keys) == 0 {
 		panel.WriteString(dimStyle.Render("  No access keys found"))
 		panel.WriteString("\n")
 	} else {
 		visibleLines := max(m.height-10, 5)
 		start := 0
-		if m.iamKeyIdx >= visibleLines {
-			start = m.iamKeyIdx - visibleLines + 1
+		if im.keyIdx >= visibleLines {
+			start = im.keyIdx - visibleLines + 1
 		}
-		end := min(start+visibleLines, len(m.iamKeys))
+		end := min(start+visibleLines, len(im.keys))
 
 		for i := start; i < end; i++ {
-			key := m.iamKeys[i]
+			key := im.keys[i]
 			cursor := "  "
 			style := normalStyle
-			if i == m.iamKeyIdx {
+			if i == im.keyIdx {
 				cursor = "> "
 				style = selectedStyle
 			}
@@ -681,7 +768,7 @@ func (m Model) viewIAMKeyList() string {
 				title = errorStyle.Render(title)
 				cursor = errorStyle.Render(cursor)
 			}
-			if i == m.iamKeyIdx && !key.IsAged() {
+			if i == im.keyIdx && !key.IsAged() {
 				title = style.Render(fmt.Sprintf("%s%s", cursor, key.DisplayTitle()))
 			} else if key.IsAged() {
 				title = fmt.Sprintf("%s%s", cursor, title)
@@ -693,7 +780,7 @@ func (m Model) viewIAMKeyList() string {
 		}
 
 		panel.WriteString("\n")
-		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d keys", len(m.iamKeys))))
+		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d keys", len(im.keys))))
 	}
 
 	b.WriteString(m.renderListPanel(panel.String()))
@@ -702,11 +789,11 @@ func (m Model) viewIAMKeyList() string {
 	return b.String()
 }
 
-func (m Model) viewIAMKeyDetail() string {
-	if m.selectedIAMKey == nil {
+func (im iamModel) viewKeyDetail(m Model) string {
+	if im.selectedKey == nil {
 		return ""
 	}
-	k := m.selectedIAMKey
+	k := im.selectedKey
 	var b strings.Builder
 	b.WriteString(m.renderStatusBar())
 	b.WriteString(titleStyle.Render("Access Key Detail"))
@@ -749,7 +836,7 @@ func (m Model) viewIAMKeyDetail() string {
 	b.WriteString("\n")
 	b.WriteString(titleStyle.Render("Actions"))
 	b.WriteString("\n")
-	if !m.iamRotationEnabled {
+	if !im.rotationEnabled {
 		b.WriteString(dimStyle.Render("  Rotation is available from the RotateAccessKey feature"))
 		b.WriteString("\n")
 	} else if k.Status == "Active" {
@@ -765,11 +852,11 @@ func (m Model) viewIAMKeyDetail() string {
 	return b.String()
 }
 
-func (m Model) viewIAMKeyRotateConfirm() string {
-	if m.selectedIAMKey == nil {
+func (im iamModel) viewKeyRotateConfirm(m Model) string {
+	if im.selectedKey == nil {
 		return ""
 	}
-	k := m.selectedIAMKey
+	k := im.selectedKey
 
 	var b strings.Builder
 	b.WriteString(m.renderStatusBar())
@@ -790,14 +877,14 @@ func (m Model) viewIAMKeyRotateConfirm() string {
 	b.WriteString("\n\n")
 	b.WriteString(normalStyle.Render("  Type the access key ID to confirm:"))
 	b.WriteString("\n")
-	b.WriteString(filterStyle.Render(fmt.Sprintf("  %s▏", m.iamRotateConfirm)))
+	b.WriteString(filterStyle.Render(fmt.Sprintf("  %s▏", im.rotateConfirm)))
 	b.WriteString("\n\n")
 	b.WriteString(m.renderHelpBar("enter: confirm • esc: cancel"))
 	return b.String()
 }
 
-func (m Model) viewIAMKeyRotateResult() string {
-	if m.iamNewKey == nil {
+func (im iamModel) viewKeyRotateResult(m Model) string {
+	if im.newKey == nil {
 		return ""
 	}
 	var b strings.Builder
@@ -808,32 +895,32 @@ func (m Model) viewIAMKeyRotateResult() string {
 	b.WriteString(normalStyle.Render("  New credentials (shown once only):"))
 	b.WriteString("\n\n")
 
-	b.WriteString(renderDetailLine("Access Key ID", normalStyle.Render(m.iamNewKey.AccessKeyID)))
+	b.WriteString(renderDetailLine("Access Key ID", normalStyle.Render(im.newKey.AccessKeyID)))
 	b.WriteString("\n")
-	b.WriteString(renderDetailLine("Secret Access Key", normalStyle.Render(m.iamNewKey.SecretAccessKey)))
+	b.WriteString(renderDetailLine("Secret Access Key", normalStyle.Render(im.newKey.SecretAccessKey)))
 	b.WriteString("\n\n")
 
-	if m.iamRotationOldKeyID != "" {
+	if im.rotationOldKeyID != "" {
 		oldKeyStatus := "Pending"
-		if m.iamOldKeyInactive {
+		if im.oldKeyInactive {
 			oldKeyStatus = "Inactive"
 		}
-		if m.iamOldKeyDeleted {
+		if im.oldKeyDeleted {
 			oldKeyStatus = "Deleted"
 		}
-		b.WriteString(renderDetailLine("Old Key", normalStyle.Render(m.iamRotationOldKeyID)))
+		b.WriteString(renderDetailLine("Old Key", normalStyle.Render(im.rotationOldKeyID)))
 		b.WriteString("\n")
 		b.WriteString(renderDetailLine("Old Key Status", normalStyle.Render(oldKeyStatus)))
 		b.WriteString("\n\n")
 	}
 
-	if m.iamCopyMsg != "" {
-		b.WriteString(selectedStyle.Render(fmt.Sprintf("  %s", m.iamCopyMsg)))
+	if im.copyMsg != "" {
+		b.WriteString(selectedStyle.Render(fmt.Sprintf("  %s", im.copyMsg)))
 		b.WriteString("\n\n")
 	}
 
-	if m.iamRotationStatus != "" {
-		b.WriteString(selectedStyle.Render(fmt.Sprintf("  %s", m.iamRotationStatus)))
+	if im.rotationStatus != "" {
+		b.WriteString(selectedStyle.Render(fmt.Sprintf("  %s", im.rotationStatus)))
 		b.WriteString("\n\n")
 	}
 
@@ -841,21 +928,21 @@ func (m Model) viewIAMKeyRotateResult() string {
 	b.WriteString("\n")
 	b.WriteString(normalStyle.Render("  [c] Copy as export commands"))
 	b.WriteString("\n")
-	b.WriteString(m.iamApplyActionLine())
+	b.WriteString(im.applyActionLine(m))
 	b.WriteString("\n")
-	if m.canDeactivateIAMOldKey() {
+	if im.canDeactivateOldKey(m) {
 		b.WriteString(normalStyle.Render("  [d] Deactivate old key"))
-	} else if m.iamOldKeyInactive {
+	} else if im.oldKeyInactive {
 		b.WriteString(dimStyle.Render("  [d] Old key already inactive"))
-	} else if m.requiresIAMCredentialApplyBeforeDeactivate() {
+	} else if im.requiresCredentialApplyBeforeDeactivate(m) {
 		b.WriteString(dimStyle.Render("  [d] Deactivate old key (available after apply + verify)"))
 	} else {
 		b.WriteString(dimStyle.Render("  [d] Deactivate old key"))
 	}
 	b.WriteString("\n")
-	if m.iamOldKeyInactive && !m.iamOldKeyDeleted {
+	if im.oldKeyInactive && !im.oldKeyDeleted {
 		b.WriteString(normalStyle.Render("  [x] Delete old inactive key"))
-	} else if m.iamOldKeyDeleted {
+	} else if im.oldKeyDeleted {
 		b.WriteString(dimStyle.Render("  [x] Old key already deleted"))
 	} else {
 		b.WriteString(dimStyle.Render("  [x] Delete old key (available after deactivation)"))

--- a/internal/app/screen_route53.go
+++ b/internal/app/screen_route53.go
@@ -12,66 +12,153 @@ import (
 	awsservice "unic/internal/services/aws"
 )
 
-func (m Model) handleRoute53Msg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
+type route53Model struct {
+	zones           []awsservice.HostedZone
+	filteredZones   []awsservice.HostedZone
+	zoneIdx         int
+	selectedZone    *awsservice.HostedZone
+	records         []awsservice.DNSRecord
+	filteredRecords []awsservice.DNSRecord
+	recordIdx       int
+	selectedRecord  *awsservice.DNSRecord
+	action          string            // "create", "edit", "delete"
+	confirmInput    string            // type-to-confirm for delete
+	editField       int               // current form field index
+	editValues      map[string]string // accumulated form values
+	editInput       string            // current field text input
+	editSelectIdx   int               // index for select-type fields (record type)
+	changeID        string            // for status polling
+	changeStatus    string            // "PENDING" / "INSYNC"
+	polling         bool              // polling active
+}
+
+func newRoute53Model() route53Model {
+	return route53Model{}
+}
+
+func (rm *route53Model) Start(m *Model) (tea.Model, tea.Cmd) {
+	return m.startLoading(rm.loadZones(*m))
+}
+
+func (rm *route53Model) HandleMessage(m *Model, msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 	switch msg := msg.(type) {
 	case route53ZonesLoadedMsg:
-		m.route53Zones = msg.zones
-		m.filteredRoute53Zones = msg.zones
-		m.route53ZoneIdx = 0
+		rm.zones = msg.zones
+		rm.filteredZones = applyFilter(rm.zones, m.filterValue(filterRoute53Zones))
+		rm.zoneIdx = 0
 		m.screen = screenRoute53ZoneList
-		return m, nil, true
+		return *m, nil, true
 
 	case route53RecordsLoadedMsg:
-		m.route53Records = msg.records
-		m.filteredRoute53Records = msg.records
-		m.route53RecordIdx = 0
+		rm.records = msg.records
+		rm.filteredRecords = applyFilter(rm.records, m.filterValue(filterRoute53Records))
+		rm.recordIdx = 0
 		m.screen = screenRoute53RecordList
-		return m, nil, true
+		return *m, nil, true
 
 	case route53ActionDoneMsg:
 		if msg.err != nil {
 			m.errMsg = msg.err.Error()
 			m.screen = screenError
-			return m, nil, true
+			return *m, nil, true
 		}
-		m.route53ChangeID = msg.changeID
-		m.route53ChangeStatus = "PENDING"
-		m.route53Polling = true
-		if m.selectedRoute53Zone != nil {
-			return m, tea.Batch(
-				m.loadRoute53Records(m.selectedRoute53Zone.ID),
-				m.pollRoute53ChangeStatus(),
+		rm.changeID = msg.changeID
+		rm.changeStatus = "PENDING"
+		rm.polling = true
+		if rm.selectedZone != nil {
+			return *m, tea.Batch(
+				rm.loadRecords(*m, rm.selectedZone.ID),
+				rm.pollChangeStatus(*m),
 			), true
 		}
 		m.screen = screenRoute53RecordList
-		return m, nil, true
+		return *m, nil, true
 
 	case route53ChangeStatusMsg:
 		if msg.err != nil {
-			m.route53Polling = false
-			return m, nil, true
+			rm.polling = false
+			return *m, nil, true
 		}
-		m.route53ChangeStatus = msg.status
+		rm.changeStatus = msg.status
 		if msg.status == "INSYNC" {
-			m.route53Polling = false
-			return m, nil, true
+			rm.polling = false
+			return *m, nil, true
 		}
-		return m, m.tickRoute53Poll(), true
+		return *m, rm.tickPoll(), true
 
 	case route53PollTickMsg:
-		if m.route53Polling {
-			return m, m.pollRoute53ChangeStatus(), true
+		if rm.polling {
+			return *m, rm.pollChangeStatus(*m), true
 		}
-		return m, nil, true
+		return *m, nil, true
 	}
-	return m, nil, false
+	return *m, nil, false
 }
 
-func (m Model) updateRoute53ZoneList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (rm *route53Model) HandleKey(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
+	switch m.screen {
+	case screenRoute53ZoneList:
+		newM, cmd := rm.updateZoneList(m, msg)
+		return newM, cmd, true
+	case screenRoute53RecordList:
+		newM, cmd := rm.updateRecordList(m, msg)
+		return newM, cmd, true
+	case screenRoute53RecordDetail:
+		newM, cmd := rm.updateRecordDetail(m, msg)
+		return newM, cmd, true
+	case screenRoute53RecordCreate:
+		newM, cmd := rm.updateRecordCreate(m, msg)
+		return newM, cmd, true
+	case screenRoute53RecordEdit:
+		newM, cmd := rm.updateRecordEdit(m, msg)
+		return newM, cmd, true
+	case screenRoute53RecordDeleteConfirm:
+		newM, cmd := rm.updateRecordDeleteConfirm(m, msg)
+		return newM, cmd, true
+	default:
+		return *m, nil, false
+	}
+}
+
+func (rm route53Model) View(m Model) (string, bool) {
+	switch m.screen {
+	case screenRoute53ZoneList:
+		return rm.viewZoneList(m), true
+	case screenRoute53RecordList:
+		return rm.viewRecordList(m), true
+	case screenRoute53RecordDetail:
+		return rm.viewRecordDetail(m), true
+	case screenRoute53RecordCreate:
+		return rm.viewRecordCreate(m), true
+	case screenRoute53RecordEdit:
+		return rm.viewRecordEdit(m), true
+	case screenRoute53RecordDeleteConfirm:
+		return rm.viewRecordDeleteConfirm(m), true
+	default:
+		return "", false
+	}
+}
+
+func (rm *route53Model) ApplyFilter(m *Model, target filterTarget) bool {
+	switch target {
+	case filterRoute53Zones:
+		rm.filteredZones = applyFilter(rm.zones, m.filterValue(target))
+		rm.zoneIdx = 0
+		return true
+	case filterRoute53Records:
+		rm.filteredRecords = applyFilter(rm.records, m.filterValue(target))
+		rm.recordIdx = 0
+		return true
+	default:
+		return false
+	}
+}
+
+func (rm *route53Model) updateZoneList(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
 	if cmd, handled := m.updateSharedFilter(msg, filterRoute53Zones); handled {
-		return m, cmd
+		return *m, cmd
 	}
 
 	switch key {
@@ -79,26 +166,26 @@ func (m Model) updateRoute53ZoneList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.screen = screenFeatureList
 		m.resetFilter(filterRoute53Zones)
 	case "up", "k":
-		m.route53ZoneIdx = previousListIndex(m.route53ZoneIdx, len(m.filteredRoute53Zones))
+		rm.zoneIdx = previousListIndex(rm.zoneIdx, len(rm.filteredZones))
 	case "down", "j":
-		m.route53ZoneIdx = nextListIndex(m.route53ZoneIdx, len(m.filteredRoute53Zones))
+		rm.zoneIdx = nextListIndex(rm.zoneIdx, len(rm.filteredZones))
 	case "/":
-		return m, m.activateFilter(filterRoute53Zones)
+		return *m, m.activateFilter(filterRoute53Zones)
 	case "enter":
-		if len(m.filteredRoute53Zones) > 0 && m.route53ZoneIdx < len(m.filteredRoute53Zones) {
-			selected := m.filteredRoute53Zones[m.route53ZoneIdx]
-			m.selectedRoute53Zone = &selected
-			return m.startLoading(m.loadRoute53Records(selected.ID))
+		if len(rm.filteredZones) > 0 && rm.zoneIdx < len(rm.filteredZones) {
+			selected := rm.filteredZones[rm.zoneIdx]
+			rm.selectedZone = &selected
+			return m.startLoading(rm.loadRecords(*m, selected.ID))
 		}
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) updateRoute53RecordList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (rm *route53Model) updateRecordList(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
 	if cmd, handled := m.updateSharedFilter(msg, filterRoute53Records); handled {
-		return m, cmd
+		return *m, cmd
 	}
 
 	switch key {
@@ -106,65 +193,65 @@ func (m Model) updateRoute53RecordList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.screen = screenRoute53ZoneList
 		m.resetFilter(filterRoute53Records)
 	case "up", "k":
-		m.route53RecordIdx = previousListIndex(m.route53RecordIdx, len(m.filteredRoute53Records))
+		rm.recordIdx = previousListIndex(rm.recordIdx, len(rm.filteredRecords))
 	case "down", "j":
-		m.route53RecordIdx = nextListIndex(m.route53RecordIdx, len(m.filteredRoute53Records))
+		rm.recordIdx = nextListIndex(rm.recordIdx, len(rm.filteredRecords))
 	case "/":
-		return m, m.activateFilter(filterRoute53Records)
+		return *m, m.activateFilter(filterRoute53Records)
 	case "c":
-		m.route53Action = "create"
-		m.route53EditField = 0
-		m.route53EditValues = map[string]string{}
-		m.route53EditInput = ""
-		m.route53EditSelectIdx = 0
+		rm.action = "create"
+		rm.editField = 0
+		rm.editValues = map[string]string{}
+		rm.editInput = ""
+		rm.editSelectIdx = 0
 		m.screen = screenRoute53RecordCreate
 	case "enter":
-		if len(m.filteredRoute53Records) > 0 && m.route53RecordIdx < len(m.filteredRoute53Records) {
-			selected := m.filteredRoute53Records[m.route53RecordIdx]
-			m.selectedRoute53Record = &selected
+		if len(rm.filteredRecords) > 0 && rm.recordIdx < len(rm.filteredRecords) {
+			selected := rm.filteredRecords[rm.recordIdx]
+			rm.selectedRecord = &selected
 			m.screen = screenRoute53RecordDetail
 		}
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) updateRoute53RecordDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (rm *route53Model) updateRecordDetail(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "q", "esc":
 		m.screen = screenRoute53RecordList
 	case "e":
 		// Edit only for A/CNAME non-alias records
-		if m.selectedRoute53Record != nil && m.selectedRoute53Record.AliasTarget == "" &&
-			(m.selectedRoute53Record.Type == "A" || m.selectedRoute53Record.Type == "CNAME") {
-			m.route53Action = "edit"
-			m.route53EditField = 0
-			m.route53EditValues = map[string]string{
-				"value": strings.Join(m.selectedRoute53Record.Values, ","),
-				"ttl":   fmt.Sprintf("%d", m.selectedRoute53Record.TTL),
+		if rm.selectedRecord != nil && rm.selectedRecord.AliasTarget == "" &&
+			(rm.selectedRecord.Type == "A" || rm.selectedRecord.Type == "CNAME") {
+			rm.action = "edit"
+			rm.editField = 0
+			rm.editValues = map[string]string{
+				"value": strings.Join(rm.selectedRecord.Values, ","),
+				"ttl":   fmt.Sprintf("%d", rm.selectedRecord.TTL),
 			}
-			m.route53EditInput = strings.Join(m.selectedRoute53Record.Values, ",")
+			rm.editInput = strings.Join(rm.selectedRecord.Values, ",")
 			m.screen = screenRoute53RecordEdit
 		}
 	case "d":
 		// Delete allowed for non-NS/SOA records
-		if m.selectedRoute53Record != nil &&
-			m.selectedRoute53Record.Type != "NS" && m.selectedRoute53Record.Type != "SOA" {
-			m.route53Action = "delete"
-			m.route53ConfirmInput = ""
+		if rm.selectedRecord != nil &&
+			rm.selectedRecord.Type != "NS" && rm.selectedRecord.Type != "SOA" {
+			rm.action = "delete"
+			rm.confirmInput = ""
 			m.screen = screenRoute53RecordDeleteConfirm
 		}
 	case "c":
-		m.route53Action = "create"
-		m.route53EditField = 0
-		m.route53EditValues = map[string]string{}
-		m.route53EditInput = ""
-		m.route53EditSelectIdx = 0
+		rm.action = "create"
+		rm.editField = 0
+		rm.editValues = map[string]string{}
+		rm.editInput = ""
+		rm.editSelectIdx = 0
 		m.screen = screenRoute53RecordCreate
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) loadRoute53Zones() tea.Cmd {
+func (rm route53Model) loadZones(m Model) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
@@ -184,7 +271,7 @@ func (m Model) loadRoute53Zones() tea.Cmd {
 	}
 }
 
-func (m Model) loadRoute53Records(zoneID string) tea.Cmd {
+func (rm route53Model) loadRecords(m Model, zoneID string) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
 		repo := m.awsRepo
@@ -207,7 +294,7 @@ func (m Model) loadRoute53Records(zoneID string) tea.Cmd {
 	}
 }
 
-func (m Model) viewRoute53ZoneList() string {
+func (rm route53Model) viewZoneList(m Model) string {
 	var b strings.Builder
 	var panel strings.Builder
 	b.WriteString(m.renderStatusBar())
@@ -217,13 +304,13 @@ func (m Model) viewRoute53ZoneList() string {
 	b.WriteString(m.renderFilterValue(filterRoute53Zones))
 	b.WriteString("\n\n")
 
-	if len(m.filteredRoute53Zones) == 0 {
+	if len(rm.filteredZones) == 0 {
 		panel.WriteString(dimStyle.Render("  No matching hosted zones"))
 		panel.WriteString("\n")
 	} else {
 		// Measure max widths for column alignment
 		maxName, maxID := 4, 2 // "NAME", "ID"
-		for _, zone := range m.filteredRoute53Zones {
+		for _, zone := range rm.filteredZones {
 			if len(zone.Name) > maxName {
 				maxName = len(zone.Name)
 			}
@@ -241,16 +328,16 @@ func (m Model) viewRoute53ZoneList() string {
 
 		visibleLines := max(m.height-11, 5)
 		start := 0
-		if m.route53ZoneIdx >= visibleLines {
-			start = m.route53ZoneIdx - visibleLines + 1
+		if rm.zoneIdx >= visibleLines {
+			start = rm.zoneIdx - visibleLines + 1
 		}
-		end := min(start+visibleLines, len(m.filteredRoute53Zones))
+		end := min(start+visibleLines, len(rm.filteredZones))
 
 		for i := start; i < end; i++ {
-			zone := m.filteredRoute53Zones[i]
+			zone := rm.filteredZones[i]
 			cursor := "  "
 			style := normalStyle
-			if i == m.route53ZoneIdx {
+			if i == rm.zoneIdx {
 				cursor = "> "
 				style = selectedStyle
 			}
@@ -268,7 +355,7 @@ func (m Model) viewRoute53ZoneList() string {
 		}
 
 		panel.WriteString("\n")
-		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d zones", len(m.filteredRoute53Zones), len(m.route53Zones))))
+		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d zones", len(rm.filteredZones), len(rm.zones))))
 	}
 
 	b.WriteString(m.renderListPanel(panel.String()))
@@ -277,13 +364,13 @@ func (m Model) viewRoute53ZoneList() string {
 	return b.String()
 }
 
-func (m Model) viewRoute53RecordList() string {
+func (rm route53Model) viewRecordList(m Model) string {
 	var b strings.Builder
 	var panel strings.Builder
 	b.WriteString(m.renderStatusBar())
 	zoneName := ""
-	if m.selectedRoute53Zone != nil {
-		zoneName = m.selectedRoute53Zone.Name
+	if rm.selectedZone != nil {
+		zoneName = rm.selectedZone.Name
 	}
 	b.WriteString(titleStyle.Render(fmt.Sprintf("DNS Records — %s", zoneName)))
 	b.WriteString("\n")
@@ -291,13 +378,13 @@ func (m Model) viewRoute53RecordList() string {
 	b.WriteString(m.renderFilterValue(filterRoute53Records))
 	b.WriteString("\n\n")
 
-	if len(m.filteredRoute53Records) == 0 {
+	if len(rm.filteredRecords) == 0 {
 		panel.WriteString(dimStyle.Render("  No matching records"))
 		panel.WriteString("\n")
 	} else {
 		// Measure max widths for column alignment
 		maxName, maxType := 4, 4 // "NAME", "TYPE"
-		for _, rec := range m.filteredRoute53Records {
+		for _, rec := range rm.filteredRecords {
 			if len(rec.Name) > maxName {
 				maxName = len(rec.Name)
 			}
@@ -314,16 +401,16 @@ func (m Model) viewRoute53RecordList() string {
 
 		visibleLines := max(m.height-11, 5)
 		start := 0
-		if m.route53RecordIdx >= visibleLines {
-			start = m.route53RecordIdx - visibleLines + 1
+		if rm.recordIdx >= visibleLines {
+			start = rm.recordIdx - visibleLines + 1
 		}
-		end := min(start+visibleLines, len(m.filteredRoute53Records))
+		end := min(start+visibleLines, len(rm.filteredRecords))
 
 		for i := start; i < end; i++ {
-			rec := m.filteredRoute53Records[i]
+			rec := rm.filteredRecords[i]
 			cursor := "  "
 			style := normalStyle
-			if i == m.route53RecordIdx {
+			if i == rm.recordIdx {
 				cursor = "> "
 				style = selectedStyle
 			}
@@ -346,15 +433,15 @@ func (m Model) viewRoute53RecordList() string {
 		}
 
 		panel.WriteString("\n")
-		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d records", len(m.filteredRoute53Records), len(m.route53Records))))
+		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d records", len(rm.filteredRecords), len(rm.records))))
 	}
 
 	// Show change status if polling
-	if m.route53Polling {
+	if rm.polling {
 		panel.WriteString("\n")
-		panel.WriteString(filterStyle.Render(fmt.Sprintf("  Change: %s...", m.route53ChangeStatus)))
+		panel.WriteString(filterStyle.Render(fmt.Sprintf("  Change: %s...", rm.changeStatus)))
 		panel.WriteString("\n")
-	} else if m.route53ChangeStatus == "INSYNC" {
+	} else if rm.changeStatus == "INSYNC" {
 		panel.WriteString("\n")
 		panel.WriteString(dimStyle.Render("  Change: INSYNC"))
 		panel.WriteString("\n")
@@ -366,11 +453,11 @@ func (m Model) viewRoute53RecordList() string {
 	return b.String()
 }
 
-func (m Model) viewRoute53RecordDetail() string {
-	if m.selectedRoute53Record == nil {
+func (rm route53Model) viewRecordDetail(m Model) string {
+	if rm.selectedRecord == nil {
 		return ""
 	}
-	r := m.selectedRoute53Record
+	r := rm.selectedRecord
 	var b strings.Builder
 	b.WriteString(m.renderStatusBar())
 	b.WriteString(titleStyle.Render("DNS Record Detail"))
@@ -400,10 +487,10 @@ func (m Model) viewRoute53RecordDetail() string {
 
 	b.WriteString("\n")
 	hints := "esc: back • H: home"
-	if m.selectedRoute53Record != nil {
-		canEdit := m.selectedRoute53Record.AliasTarget == "" &&
-			(m.selectedRoute53Record.Type == "A" || m.selectedRoute53Record.Type == "CNAME")
-		canDelete := m.selectedRoute53Record.Type != "NS" && m.selectedRoute53Record.Type != "SOA"
+	if rm.selectedRecord != nil {
+		canEdit := rm.selectedRecord.AliasTarget == "" &&
+			(rm.selectedRecord.Type == "A" || rm.selectedRecord.Type == "CNAME")
+		canDelete := rm.selectedRecord.Type != "NS" && rm.selectedRecord.Type != "SOA"
 		if canEdit {
 			hints = "e: edit • " + hints
 		}
@@ -421,134 +508,134 @@ func (m Model) viewRoute53RecordDetail() string {
 var route53CreateFieldLabels = []string{"Name", "Type", "Value", "TTL"}
 var route53TypeOptions = []string{"A", "CNAME"}
 
-func (m Model) updateRoute53RecordCreate(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (rm *route53Model) updateRecordCreate(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
-	switch m.route53EditField {
+	switch rm.editField {
 	case 0: // Name (text input)
-		return m.updateRoute53TextInput(key, screenRoute53RecordList)
+		return rm.updateTextInput(m, key, screenRoute53RecordList)
 	case 1: // Type (select)
-		return m.updateRoute53TypeSelect(key)
+		return rm.updateTypeSelect(m, key)
 	case 2: // Value (text input)
-		return m.updateRoute53TextInput(key, screenRoute53RecordList)
+		return rm.updateTextInput(m, key, screenRoute53RecordList)
 	case 3: // TTL (text input, last field → execute)
-		return m.updateRoute53CreateTTL(key)
+		return rm.updateCreateTTL(m, key)
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) updateRoute53TypeSelect(key string) (tea.Model, tea.Cmd) {
+func (rm *route53Model) updateTypeSelect(m *Model, key string) (tea.Model, tea.Cmd) {
 	switch key {
 	case "esc":
 		m.screen = screenRoute53RecordList
 	case "up", "k":
-		m.route53EditSelectIdx = previousListIndex(m.route53EditSelectIdx, len(route53TypeOptions))
+		rm.editSelectIdx = previousListIndex(rm.editSelectIdx, len(route53TypeOptions))
 	case "down", "j":
-		m.route53EditSelectIdx = nextListIndex(m.route53EditSelectIdx, len(route53TypeOptions))
+		rm.editSelectIdx = nextListIndex(rm.editSelectIdx, len(route53TypeOptions))
 	case "enter":
-		m.route53EditValues["type"] = route53TypeOptions[m.route53EditSelectIdx]
-		m.route53EditField++
-		m.route53EditInput = ""
+		rm.editValues["type"] = route53TypeOptions[rm.editSelectIdx]
+		rm.editField++
+		rm.editInput = ""
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) updateRoute53TextInput(key string, cancelScreen screen) (tea.Model, tea.Cmd) {
+func (rm *route53Model) updateTextInput(m *Model, key string, cancelScreen screen) (tea.Model, tea.Cmd) {
 	switch key {
 	case "esc":
 		m.screen = cancelScreen
 	case "enter":
-		if m.route53EditInput == "" {
-			return m, nil // required field
+		if rm.editInput == "" {
+			return *m, nil // required field
 		}
-		switch m.route53EditField {
+		switch rm.editField {
 		case 0:
-			m.route53EditValues["name"] = m.route53EditInput
+			rm.editValues["name"] = rm.editInput
 		case 2:
-			m.route53EditValues["value"] = m.route53EditInput
+			rm.editValues["value"] = rm.editInput
 		}
-		m.route53EditField++
-		m.route53EditInput = ""
+		rm.editField++
+		rm.editInput = ""
 		// Pre-fill TTL default
-		if m.route53EditField == 3 {
-			m.route53EditInput = "300"
+		if rm.editField == 3 {
+			rm.editInput = "300"
 		}
 	case "backspace":
-		if len(m.route53EditInput) > 0 {
-			m.route53EditInput = m.route53EditInput[:len(m.route53EditInput)-1]
+		if len(rm.editInput) > 0 {
+			rm.editInput = rm.editInput[:len(rm.editInput)-1]
 		}
 	default:
 		if len(key) == 1 {
-			m.route53EditInput += key
+			rm.editInput += key
 		}
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) updateRoute53CreateTTL(key string) (tea.Model, tea.Cmd) {
+func (rm *route53Model) updateCreateTTL(m *Model, key string) (tea.Model, tea.Cmd) {
 	switch key {
 	case "esc":
 		m.screen = screenRoute53RecordList
 	case "enter":
-		if m.route53EditInput == "" {
-			m.route53EditInput = "300"
+		if rm.editInput == "" {
+			rm.editInput = "300"
 		}
-		m.route53EditValues["ttl"] = m.route53EditInput
+		rm.editValues["ttl"] = rm.editInput
 		// Execute create
-		return m.startLoading(m.executeRoute53Create())
+		return m.startLoading(rm.executeCreate(*m))
 	case "backspace":
-		if len(m.route53EditInput) > 0 {
-			m.route53EditInput = m.route53EditInput[:len(m.route53EditInput)-1]
+		if len(rm.editInput) > 0 {
+			rm.editInput = rm.editInput[:len(rm.editInput)-1]
 		}
 	default:
 		if len(key) == 1 && key >= "0" && key <= "9" {
-			m.route53EditInput += key
+			rm.editInput += key
 		}
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) viewRoute53RecordCreate() string {
+func (rm route53Model) viewRecordCreate(m Model) string {
 	var b strings.Builder
 	b.WriteString(m.renderStatusBar())
 	b.WriteString(titleStyle.Render("Create DNS Record"))
 	b.WriteString("\n\n")
 
-	if m.selectedRoute53Zone != nil {
-		b.WriteString(dimStyle.Render(fmt.Sprintf("  Zone: %s (%s)", m.selectedRoute53Zone.Name, m.selectedRoute53Zone.ID)))
+	if rm.selectedZone != nil {
+		b.WriteString(dimStyle.Render(fmt.Sprintf("  Zone: %s (%s)", rm.selectedZone.Name, rm.selectedZone.ID)))
 		b.WriteString("\n\n")
 	}
 
 	// Show completed fields
-	for i := 0; i < m.route53EditField; i++ {
+	for i := 0; i < rm.editField; i++ {
 		label := route53CreateFieldLabels[i]
 		val := ""
 		switch i {
 		case 0:
-			val = m.route53EditValues["name"]
+			val = rm.editValues["name"]
 		case 1:
-			val = m.route53EditValues["type"]
+			val = rm.editValues["type"]
 		case 2:
-			val = m.route53EditValues["value"]
+			val = rm.editValues["value"]
 		case 3:
-			val = m.route53EditValues["ttl"]
+			val = rm.editValues["ttl"]
 		}
 		b.WriteString(dimStyle.Render(fmt.Sprintf("  %s: %s", label, val)))
 		b.WriteString("\n")
 	}
 
 	// Show current field
-	if m.route53EditField < len(route53CreateFieldLabels) {
-		label := route53CreateFieldLabels[m.route53EditField]
+	if rm.editField < len(route53CreateFieldLabels) {
+		label := route53CreateFieldLabels[rm.editField]
 		b.WriteString("\n")
 		b.WriteString(normalStyle.Render(fmt.Sprintf("  %s:", label)))
 		b.WriteString("\n")
 
-		if m.route53EditField == 1 { // Type select
+		if rm.editField == 1 { // Type select
 			for i, opt := range route53TypeOptions {
 				cursor := "  "
 				style := normalStyle
-				if i == m.route53EditSelectIdx {
+				if i == rm.editSelectIdx {
 					cursor = "> "
 					style = selectedStyle
 				}
@@ -556,7 +643,7 @@ func (m Model) viewRoute53RecordCreate() string {
 				b.WriteString("\n")
 			}
 		} else {
-			b.WriteString(filterStyle.Render(fmt.Sprintf("  %s▏", m.route53EditInput)))
+			b.WriteString(filterStyle.Render(fmt.Sprintf("  %s▏", rm.editInput)))
 			b.WriteString("\n")
 		}
 	}
@@ -568,28 +655,28 @@ func (m Model) viewRoute53RecordCreate() string {
 
 // --- Edit record form ---
 
-func (m Model) updateRoute53RecordEdit(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (rm *route53Model) updateRecordEdit(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
-	switch m.route53EditField {
+	switch rm.editField {
 	case 0: // Value (text input)
 		switch key {
 		case "esc":
 			m.screen = screenRoute53RecordDetail
 		case "enter":
-			if m.route53EditInput == "" {
-				return m, nil
+			if rm.editInput == "" {
+				return *m, nil
 			}
-			m.route53EditValues["value"] = m.route53EditInput
-			m.route53EditField++
-			m.route53EditInput = m.route53EditValues["ttl"]
+			rm.editValues["value"] = rm.editInput
+			rm.editField++
+			rm.editInput = rm.editValues["ttl"]
 		case "backspace":
-			if len(m.route53EditInput) > 0 {
-				m.route53EditInput = m.route53EditInput[:len(m.route53EditInput)-1]
+			if len(rm.editInput) > 0 {
+				rm.editInput = rm.editInput[:len(rm.editInput)-1]
 			}
 		default:
 			if len(key) == 1 {
-				m.route53EditInput += key
+				rm.editInput += key
 			}
 		}
 	case 1: // TTL (text input, last field → execute)
@@ -597,29 +684,29 @@ func (m Model) updateRoute53RecordEdit(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "esc":
 			m.screen = screenRoute53RecordDetail
 		case "enter":
-			if m.route53EditInput == "" {
-				return m, nil
+			if rm.editInput == "" {
+				return *m, nil
 			}
-			m.route53EditValues["ttl"] = m.route53EditInput
-			return m.startLoading(m.executeRoute53Update())
+			rm.editValues["ttl"] = rm.editInput
+			return m.startLoading(rm.executeUpdate(*m))
 		case "backspace":
-			if len(m.route53EditInput) > 0 {
-				m.route53EditInput = m.route53EditInput[:len(m.route53EditInput)-1]
+			if len(rm.editInput) > 0 {
+				rm.editInput = rm.editInput[:len(rm.editInput)-1]
 			}
 		default:
 			if len(key) == 1 && key >= "0" && key <= "9" {
-				m.route53EditInput += key
+				rm.editInput += key
 			}
 		}
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) viewRoute53RecordEdit() string {
-	if m.selectedRoute53Record == nil {
+func (rm route53Model) viewRecordEdit(m Model) string {
+	if rm.selectedRecord == nil {
 		return ""
 	}
-	r := m.selectedRoute53Record
+	r := rm.selectedRecord
 	var b strings.Builder
 	b.WriteString(m.renderStatusBar())
 	b.WriteString(titleStyle.Render("Edit DNS Record"))
@@ -634,26 +721,26 @@ func (m Model) viewRoute53RecordEdit() string {
 	editFields := []string{"Value", "TTL"}
 
 	// Show completed edit fields
-	for i := 0; i < m.route53EditField; i++ {
+	for i := 0; i < rm.editField; i++ {
 		label := editFields[i]
 		val := ""
 		switch i {
 		case 0:
-			val = m.route53EditValues["value"]
+			val = rm.editValues["value"]
 		case 1:
-			val = m.route53EditValues["ttl"]
+			val = rm.editValues["ttl"]
 		}
 		b.WriteString(dimStyle.Render(fmt.Sprintf("  %s: %s", label, val)))
 		b.WriteString("\n")
 	}
 
 	// Show current edit field
-	if m.route53EditField < len(editFields) {
-		label := editFields[m.route53EditField]
+	if rm.editField < len(editFields) {
+		label := editFields[rm.editField]
 		b.WriteString("\n")
 		b.WriteString(normalStyle.Render(fmt.Sprintf("  %s:", label)))
 		b.WriteString("\n")
-		b.WriteString(filterStyle.Render(fmt.Sprintf("  %s▏", m.route53EditInput)))
+		b.WriteString(filterStyle.Render(fmt.Sprintf("  %s▏", rm.editInput)))
 		b.WriteString("\n")
 	}
 
@@ -664,37 +751,37 @@ func (m Model) viewRoute53RecordEdit() string {
 
 // --- Delete record confirm ---
 
-func (m Model) updateRoute53RecordDeleteConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if m.selectedRoute53Record == nil {
+func (rm *route53Model) updateRecordDeleteConfirm(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if rm.selectedRecord == nil {
 		m.screen = screenRoute53RecordList
-		return m, nil
+		return *m, nil
 	}
-	confirmTarget := m.selectedRoute53Record.Name
+	confirmTarget := rm.selectedRecord.Name
 
 	switch msg.String() {
 	case "esc":
 		m.screen = screenRoute53RecordDetail
 	case "enter":
-		if m.route53ConfirmInput == confirmTarget {
-			return m.startLoading(m.executeRoute53Delete())
+		if rm.confirmInput == confirmTarget {
+			return m.startLoading(rm.executeDelete(*m))
 		}
 	case "backspace":
-		if len(m.route53ConfirmInput) > 0 {
-			m.route53ConfirmInput = m.route53ConfirmInput[:len(m.route53ConfirmInput)-1]
+		if len(rm.confirmInput) > 0 {
+			rm.confirmInput = rm.confirmInput[:len(rm.confirmInput)-1]
 		}
 	default:
 		if runes := msg.Runes; len(runes) > 0 {
-			m.route53ConfirmInput += string(runes)
+			rm.confirmInput += string(runes)
 		}
 	}
-	return m, nil
+	return *m, nil
 }
 
-func (m Model) viewRoute53RecordDeleteConfirm() string {
-	if m.selectedRoute53Record == nil {
+func (rm route53Model) viewRecordDeleteConfirm(m Model) string {
+	if rm.selectedRecord == nil {
 		return ""
 	}
-	r := m.selectedRoute53Record
+	r := rm.selectedRecord
 	var b strings.Builder
 	b.WriteString(m.renderStatusBar())
 	b.WriteString(titleStyle.Render("Delete DNS Record"))
@@ -717,7 +804,7 @@ func (m Model) viewRoute53RecordDeleteConfirm() string {
 
 	b.WriteString(normalStyle.Render("  Type the record name to confirm:"))
 	b.WriteString("\n")
-	b.WriteString(filterStyle.Render(fmt.Sprintf("  %s▏", m.route53ConfirmInput)))
+	b.WriteString(filterStyle.Render(fmt.Sprintf("  %s▏", rm.confirmInput)))
 	b.WriteString("\n\n")
 	b.WriteString(m.renderHelpBar("enter: confirm • esc: cancel"))
 	return b.String()
@@ -725,7 +812,7 @@ func (m Model) viewRoute53RecordDeleteConfirm() string {
 
 // --- Execution commands ---
 
-func (m Model) executeRoute53Create() tea.Cmd {
+func (rm route53Model) executeCreate(m Model) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
 		repo := m.awsRepo
@@ -737,10 +824,10 @@ func (m Model) executeRoute53Create() tea.Cmd {
 			}
 		}
 
-		name := m.route53EditValues["name"]
-		recordType := m.route53EditValues["type"]
-		value := m.route53EditValues["value"]
-		ttlStr := m.route53EditValues["ttl"]
+		name := rm.editValues["name"]
+		recordType := rm.editValues["type"]
+		value := rm.editValues["value"]
+		ttlStr := rm.editValues["ttl"]
 		ttl := parseTTL(ttlStr)
 
 		values := strings.Split(value, ",")
@@ -749,8 +836,8 @@ func (m Model) executeRoute53Create() tea.Cmd {
 		}
 
 		zoneID := ""
-		if m.selectedRoute53Zone != nil {
-			zoneID = m.selectedRoute53Zone.ID
+		if rm.selectedZone != nil {
+			zoneID = rm.selectedZone.ID
 		}
 
 		info, err := repo.CreateRecord(ctx, zoneID, name, recordType, values, ttl)
@@ -765,7 +852,7 @@ func (m Model) executeRoute53Create() tea.Cmd {
 	}
 }
 
-func (m Model) executeRoute53Update() tea.Cmd {
+func (rm route53Model) executeUpdate(m Model) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
 		repo := m.awsRepo
@@ -777,12 +864,12 @@ func (m Model) executeRoute53Update() tea.Cmd {
 			}
 		}
 
-		if m.selectedRoute53Record == nil || m.selectedRoute53Zone == nil {
+		if rm.selectedRecord == nil || rm.selectedZone == nil {
 			return route53ActionDoneMsg{err: fmt.Errorf("no record selected")}
 		}
 
-		value := m.route53EditValues["value"]
-		ttlStr := m.route53EditValues["ttl"]
+		value := rm.editValues["value"]
+		ttlStr := rm.editValues["ttl"]
 		ttl := parseTTL(ttlStr)
 
 		values := strings.Split(value, ",")
@@ -790,7 +877,7 @@ func (m Model) executeRoute53Update() tea.Cmd {
 			values[i] = strings.TrimSpace(values[i])
 		}
 
-		info, err := repo.UpdateRecord(ctx, m.selectedRoute53Zone.ID, *m.selectedRoute53Record, values, ttl)
+		info, err := repo.UpdateRecord(ctx, rm.selectedZone.ID, *rm.selectedRecord, values, ttl)
 		if err != nil {
 			return route53ActionDoneMsg{action: "edit", err: err}
 		}
@@ -802,7 +889,7 @@ func (m Model) executeRoute53Update() tea.Cmd {
 	}
 }
 
-func (m Model) executeRoute53Delete() tea.Cmd {
+func (rm route53Model) executeDelete(m Model) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
 		repo := m.awsRepo
@@ -814,11 +901,11 @@ func (m Model) executeRoute53Delete() tea.Cmd {
 			}
 		}
 
-		if m.selectedRoute53Record == nil || m.selectedRoute53Zone == nil {
+		if rm.selectedRecord == nil || rm.selectedZone == nil {
 			return route53ActionDoneMsg{err: fmt.Errorf("no record selected")}
 		}
 
-		info, err := repo.DeleteRecord(ctx, m.selectedRoute53Zone.ID, *m.selectedRoute53Record)
+		info, err := repo.DeleteRecord(ctx, rm.selectedZone.ID, *rm.selectedRecord)
 		if err != nil {
 			return route53ActionDoneMsg{action: "delete", err: err}
 		}
@@ -832,7 +919,7 @@ func (m Model) executeRoute53Delete() tea.Cmd {
 
 // --- Change status polling ---
 
-func (m Model) pollRoute53ChangeStatus() tea.Cmd {
+func (rm route53Model) pollChangeStatus(m Model) tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
 		repo := m.awsRepo
@@ -844,12 +931,12 @@ func (m Model) pollRoute53ChangeStatus() tea.Cmd {
 			}
 		}
 
-		status, err := repo.GetChangeStatus(ctx, m.route53ChangeID)
+		status, err := repo.GetChangeStatus(ctx, rm.changeID)
 		return route53ChangeStatusMsg{status: status, err: err}
 	}
 }
 
-func (m Model) tickRoute53Poll() tea.Cmd {
+func (rm route53Model) tickPoll() tea.Cmd {
 	return tea.Tick(2*time.Second, func(_ time.Time) tea.Msg {
 		return route53PollTickMsg{}
 	})


### PR DESCRIPTION
### Summary

Refactors the TUI root model by moving Route53 and IAM feature state, message handling, key handling, filtering, commands, and views behind dedicated feature submodels. Also removes the remaining CloudWatch Logs root-model compatibility wrappers so tests exercise the submodel directly.

This is a focused slice of the broader root model split; additional feature submodels remain for #107.

### Related Issues

Refs #107

### Validation

- [x] make test
- [x] make build

### Checklist

- [x] Scope is focused
- [x] Branch name follows docs/branch-naming-harness.md
- [x] Documentation harness reviewed (docs/documentation-harness.md)
- [x] README updated if user-facing behavior changed
- [x] Relevant docs/ pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented