### PR TITLE
docs: require main-based worktrees

### DIFF
--- a/.agents/skills/unic-implement-feature/SKILL.md
+++ b/.agents/skills/unic-implement-feature/SKILL.md
@@ -15,7 +15,16 @@ Treat the prompt as one of:
 
 ## Workflow
 
-1. Resolve scope first.
+1. Start from an isolated main-based worktree.
+- Before editing anything, fetch or verify the intended `main` base.
+- Create a fresh git worktree with a new task branch from `main` or
+  `origin/main`.
+- Do not implement in the primary checkout or on a pre-existing feature branch.
+- Use one worktree per issue or feature.
+- If the feature appears to depend on another unmerged branch, still start from
+  `main` and document the dependency before applying any stacked changes.
+
+2. Resolve scope first.
 - Before implementing anything, inspect open pull requests with
   `gh pr list --state open --limit 50`.
 - If the target issue or feature already has an open PR in progress, stop and
@@ -40,7 +49,7 @@ Treat the prompt as one of:
 - If multiple open issues fit equally well, ask only the minimum clarifying
   question needed to pick the right one.
 
-2. Gather repo context before editing.
+3. Gather repo context before editing.
 - Read `internal/domain/model.go` and `internal/domain/catalog.go`.
 - Read `internal/services/aws/repository.go`.
 - Use the RDS implementation in `internal/services/aws/rds.go`,
@@ -49,7 +58,7 @@ Treat the prompt as one of:
 - Read the owning TUI flow in `internal/app/app.go` and any extracted helper
   files nearby.
 
-3. Plan the change before writing code.
+4. Plan the change before writing code.
 - For new service work, prefer this order:
   1. domain model and catalog
   2. AWS service layer and models
@@ -60,13 +69,13 @@ Treat the prompt as one of:
 - Use `visibleLines := max(m.height-N, 5)` style windowing where applicable.
 - Destructive actions must use the existing type-to-confirm pattern.
 
-4. Implement with minimal divergence.
+5. Implement with minimal divergence.
 - Follow existing naming, layout, and error-handling patterns.
 - Use mock client interfaces in tests.
 - Avoid introducing new abstractions unless the surrounding code already points
   in that direction.
 
-5. Validate and sync docs.
+6. Validate and sync docs.
 - Run `make test`.
 - Run `make build`.
 - Update `README.md` when shipped behavior changes.

--- a/.agents/skills/unic-refactor-review/SKILL.md
+++ b/.agents/skills/unic-refactor-review/SKILL.md
@@ -8,12 +8,19 @@ behavior.
 
 ## Workflow
 
-1. Load the latest review report.
+1. Start from an isolated main-based worktree.
+- Before editing anything, fetch or verify the intended `main` base.
+- Create a fresh git worktree with a new task branch from `main` or
+  `origin/main`.
+- Do not refactor in the primary checkout or on a pre-existing feature branch.
+- Use one worktree per review finding, issue, or PR-sized refactor.
+
+2. Load the latest review report.
 - Prefer `.agents/reports/senior-review-*.md`.
 - Fall back to `.claude/reports/senior-review-*.md`.
 - If no report exists, tell the user to run `unic-senior-review` first.
 
-2. Select scope.
+3. Select scope.
 - If the user named a priority or finding, scope the work to that item.
 - If the user named a GitHub issue, read it with `gh issue view <number>`.
 - When GitHub access is available, search open issues with
@@ -21,18 +28,18 @@ behavior.
   already tracked before choosing scope.
 - If not, summarize the report priorities and ask which one to tackle.
 
-3. Plan before editing.
+4. Plan before editing.
 - Read every file referenced by the selected findings.
 - Preserve behavior; this is refactor-only work.
 - Do not change public APIs unless the finding specifically requires it.
 - If the change would touch more than 10 files, split it into smaller steps.
 
-4. Implement and validate incrementally.
+5. Implement and validate incrementally.
 - Make focused changes.
 - Run `make test` after each logical refactor group when practical.
 - Run `make test` and `make build` at the end.
 
-5. Update the report when appropriate.
+6. Update the report when appropriate.
 - Mark completed findings or note what changed.
 - If the work maps to an issue, note the issue number in the report update.
 - If a recommendation from the report turns out to be impractical, explain why

--- a/.agents/skills/unic-ship-pr/SKILL.md
+++ b/.agents/skills/unic-ship-pr/SKILL.md
@@ -8,11 +8,19 @@ commit, and PR flow.
 
 ## Workflow
 
-1. Validate first.
+1. Confirm main-based worktree isolation.
+- Ship only from a task branch in a fresh git worktree created from `main` or
+  `origin/main`.
+- If the current changes are in the primary checkout or on a branch that was not
+  created from `main`, create a new main-based worktree and port only the
+  intended changes before validating or opening a PR.
+- Keep one worktree per PR-sized change.
+
+2. Validate first.
 - Run `make test` and stop if it fails.
 - Run `make build` and stop if it fails.
 
-2. Inspect scope.
+3. Inspect scope.
 - Check `git status` and `git diff --stat`.
 - Confirm the changes are ready to ship and map to the intended issue.
 - If the issue number is known, read it with `gh issue view <number>`.
@@ -22,20 +30,20 @@ commit, and PR flow.
 - Do not open a PR without an issue reference unless the user explicitly
   approves that exception.
 
-3. Create the branch.
-- Branch from `main`.
+4. Create the branch.
+- Branch from `main` in a fresh worktree.
 - Use a conventional prefix such as `feat/`, `fix/`, or `docs/`.
 - Use the user hint when provided; otherwise infer a concise branch name from
   the change.
 
-4. Stage and commit carefully.
+5. Stage and commit carefully.
 - Stage only the relevant files by name.
 - Never use `git add .` or `git add -A`.
 - Use a conventional commit title consistent with recent history.
 - Include a short body with bullet points for key changes.
 - Do not add `Co-Authored-By` lines.
 
-5. Push and open the PR.
+6. Push and open the PR.
 - Push with `-u origin <branch>`.
 - Use `gh pr create` to open the PR.
 - If a PR already exists for the branch, inspect it with `gh pr view` and
@@ -44,7 +52,7 @@ commit, and PR flow.
 - Otherwise structure the PR body with: Summary, Related Issues, Validation,
   and Checklist.
 
-6. Wait for automated review.
+7. Wait for automated review.
 - After the PR is open, wait for required checks and Amazon Q Developer review
   to finish before reporting the PR as ready.
 - Read the latest Amazon Q top-level review/comments for the current head with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,16 @@ Examples:
 - `feature/58-s3-browser`
 - `bugfix/76-s3-region-error-handling`
 - `docs/79-documentation-harness`
+
+## Worktree Isolation Rule
+
+All repository work must start from `main` in a fresh git worktree.
+
+- Before editing files, fetch or otherwise verify the intended `main` base.
+- Create a new worktree and branch from `main` or `origin/main`.
+- Do not implement new work directly in the primary checkout or on an existing
+  feature branch.
+- Keep one worktree per task, issue, or PR-sized change.
+- If follow-up work appears to depend on another unmerged branch, still create a
+  fresh worktree from `main` first, then explicitly document and apply the
+  dependency only when it is unavoidable.

--- a/docs/development.md
+++ b/docs/development.md
@@ -18,6 +18,20 @@ Preferred format:
 <work-type>/<issue-number>-<short-description>
 ```
 
+## Worktree Isolation
+
+Always start repository work from `main` in a fresh git worktree.
+
+1. Fetch or verify the intended `main` base.
+2. Create a new worktree and task branch from `main` or `origin/main`.
+3. Make all edits for that task inside the new worktree.
+4. Keep one worktree per issue, feature, refactor, or PR-sized change.
+
+Do not implement new work directly in the primary checkout or on an existing
+feature branch. If a task appears to depend on another unmerged branch, still
+start from `main` first and document the dependency before applying any stacked
+changes.
+
 ## Adding a New AWS Feature
 
 1. Add service or feature constants in `internal/domain/model.go`


### PR DESCRIPTION
### Summary

Document the standing repository rule that all work starts from `main` in a fresh git worktree.

- adds the rule to `AGENTS.md` for agent-facing guidance
- updates feature, refactor, and PR shipping skills so workflows begin from a main-based worktree
- records the same contributor workflow in `docs/development.md`

### Related Issues

No issue. User requested this repository workflow rule directly.

### Validation

- [x] `env -u GOROOT make test`
- [x] `env -u GOROOT make build`
- [x] `git diff --check`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed
- [x] Relevant `docs/` pages updated if workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented

No breaking changes.