### PR TITLE
feat: add EKS upgrade readiness view

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ checks:
 | ECR Login | CLI helper: `unic ecr login [--runtime docker|podman] [--copy]` |
 | ECS Exec | `r` refresh, `Enter` drill down / exec |
 | ECS Rollout / Exec | cluster/service lists support refresh and drill-down, service detail shows deployments/task definition images/events, `Enter` continues into tasks and exec |
-| EKS Browser | cluster/node group/add-on lists support `/` filter and `r` refresh, cluster view shows version/status/endpoint visibility/ARN summary, `a` opens managed add-ons, node group detail shows desired/min/max scaling plus health issues |
+| EKS Browser | cluster/node group/add-on lists support `/` filter and `r` refresh, cluster view shows version/status/endpoint visibility/ARN summary, `a` opens managed add-ons, `U` opens current-version upgrade readiness, node group detail shows desired/min/max scaling plus health issues |
 | Inspector Mode | `i` open mode from the service list, `Enter` open the selected workflow, `l` open the checklist file picker |
 | Security Inspector | `r` run/rescan, `1`-`5` severity filter, `Enter` finding detail |
 | Checklist Inspector | `l` load or switch checklist files, `r` run/rerun the loaded checklist, `Enter` result detail |
@@ -355,6 +355,8 @@ The service list defaults to favorites first, then alphabetical order. Press `f`
 The EKS Browser includes a managed add-on status view for each cluster. Add-on rows show the installed version, status, and health summary, with degraded or unhealthy add-ons highlighted so core components such as CoreDNS, kube-proxy, VPC CNI, and CSI drivers are easy to spot.
 
 The ECR Repository Browser opens image/tag lists from each repository. Image rows include tags, digest, pushed time, and size, and mark untagged images or images older than 90 days as cleanup candidates. Image detail exposes digest and tag values for clipboard copy.
+
+The EKS Browser includes a current-version upgrade readiness view for each selected cluster. It compares the control plane version with managed node group versions, checks installed managed add-on versions against EKS compatibility metadata for the current cluster version, includes EKS `UPGRADE_READINESS` insights, and highlights blockers or warnings before planning a target-version upgrade.
 
 The EC2 Instance Browser lists EC2 instances across available states for the active context and region, separate from the SSM session picker that only lists connectable running instances. The detail screen shows core metadata including instance ID, name tag, state, instance type, AZ, VPC, subnet, private and public IPs, launch time, platform details, IAM profile, and tags.
 

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -194,7 +194,7 @@ Current screen families include:
 - CloudWatch metric list/detail flows
 - CloudWatch Logs group/stream/viewer flows
 - ECS cluster/service/rollout detail/task/container flows
-- EKS cluster/node group/add-on status flows
+- EKS cluster/node group/add-on status and upgrade readiness flows
 - ECR repository/image/detail flows
 - S3 bucket/object/detail flows
 - Inspector mode home, checklist setup, security findings/detail, and checklist results/detail flows

--- a/docs/architecture.ko.md
+++ b/docs/architecture.ko.md
@@ -194,7 +194,7 @@ UNIC은 현재 세 가지 인증 모드를 지원한다.
 - CloudWatch metric list/detail
 - CloudWatch Logs group/stream/viewer
 - ECS cluster/service/rollout detail/task/container
-- EKS cluster/node group/add-on status
+- EKS cluster/node group/add-on status, upgrade readiness
 - ECR repository/image/detail
 - S3 bucket/object/detail
 - Inspector mode home, checklist setup, security findings/detail, checklist results/detail

--- a/docs/project-overview.en.md
+++ b/docs/project-overview.en.md
@@ -24,7 +24,7 @@ Implemented service areas currently include:
 - Lambda
 - Inspector mode
 
-The application already includes interactive mutation flows, polling-based status flows, context helpers, and per-service drill-down screens. CloudWatch Metrics now includes resource-centric preset groups plus time-range, period, and statistic controls for faster terminal triage. EKS includes managed add-on status review so operators can spot degraded core components from the cluster view. ECR includes repository and image/tag browsing with cleanup-oriented untagged and stale image signals.
+The application already includes interactive mutation flows, polling-based status flows, context helpers, and per-service drill-down screens. CloudWatch Metrics now includes resource-centric preset groups plus time-range, period, and statistic controls for faster terminal triage. EKS includes managed add-on status review plus current-version upgrade readiness checks that compare control plane, managed node group, managed add-on version alignment, and EKS upgrade insights before a target upgrade is planned. ECR includes repository and image/tag browsing with cleanup-oriented untagged and stale image signals.
 Inspector mode now includes built-in security scans plus checklist-driven readiness checks for RDS, security groups, secrets, Route53, VPCs/subnets, CloudWatch Logs, and baseline posture wrappers.
 
 ## Primary User Flows

--- a/docs/project-overview.ko.md
+++ b/docs/project-overview.ko.md
@@ -24,7 +24,7 @@ UNIC은 다음 세 가지를 결합한 Go 기반 AWS 터미널 콘솔이다.
 - Lambda
 - Inspector mode
 
-애플리케이션은 이미 상호작용형 변경 작업 플로우, polling 기반 상태 확인, context helper, 서비스별 drill-down 화면을 포함한다. CloudWatch Metrics는 이제 resource-centric preset 그룹과 time-range / period / statistic control을 제공해 터미널에서 더 빠르게 triage할 수 있다. EKS는 cluster 화면에서 managed add-on 상태를 확인해 저하된 핵심 컴포넌트를 빠르게 찾을 수 있다. ECR은 repository와 image/tag 탐색을 제공하고, untagged image와 오래된 image를 cleanup 후보로 드러낸다.
+애플리케이션은 이미 상호작용형 변경 작업 플로우, polling 기반 상태 확인, context helper, 서비스별 drill-down 화면을 포함한다. CloudWatch Metrics는 이제 resource-centric preset 그룹과 time-range / period / statistic control을 제공해 터미널에서 더 빠르게 triage할 수 있다. EKS는 cluster 화면에서 managed add-on 상태를 확인하고, target upgrade를 계획하기 전에 control plane, managed node group, managed add-on의 current-version alignment와 EKS upgrade insight를 함께 확인하는 upgrade readiness check를 포함한다. ECR은 repository와 image/tag 탐색을 제공하고, untagged image와 오래된 image를 cleanup 후보로 드러낸다.
 Inspector mode는 이제 built-in security scan과 함께 RDS, security group, secret, Route53, VPC/subnet, CloudWatch Logs, baseline posture wrapper를 다루는 checklist 기반 readiness check도 포함한다.
 
 ## 주요 사용자 흐름

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -65,6 +65,7 @@ const (
 	screenECSTaskList
 	screenECSContainerList
 	screenEKSClusterList
+	screenEKSUpgradeReadiness
 	screenEKSNodeGroupList
 	screenEKSNodeGroupDetail
 	screenEKSAddonList
@@ -205,6 +206,8 @@ type Model struct {
 	filteredEKSClusters []awsservice.EKSCluster
 	eksClusterIdx       int
 	selectedEKSCluster  *awsservice.EKSCluster
+	eksUpgradeReadiness *awsservice.EKSUpgradeReadiness
+	eksUpgradeScroll    int
 
 	eksNodeGroups         []awsservice.EKSNodeGroup
 	filteredEKSNodeGroups []awsservice.EKSNodeGroup
@@ -565,6 +568,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateECSContainerList(msg)
 		case screenEKSClusterList:
 			return m.updateEKSClusterList(msg)
+		case screenEKSUpgradeReadiness:
+			return m.updateEKSUpgradeReadiness(msg)
 		case screenEKSNodeGroupList:
 			return m.updateEKSNodeGroupList(msg)
 		case screenEKSNodeGroupDetail:
@@ -803,6 +808,8 @@ func (m Model) View() string {
 		v = m.viewECSContainerList()
 	case screenEKSClusterList:
 		v = m.viewEKSClusterList()
+	case screenEKSUpgradeReadiness:
+		v = m.viewEKSUpgradeReadiness()
 	case screenEKSNodeGroupList:
 		v = m.viewEKSNodeGroupList()
 	case screenEKSNodeGroupDetail:

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -406,7 +406,22 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 			{"q / esc", "Go back to the task list"},
 		}
 	case screenEKSClusterList:
-		return listScreenShortcuts("open managed node groups for the selected cluster", "go back to the feature list", true, true)
+		return []helpShortcut{
+			{"↑/↓, j/k", "Move between clusters"},
+			{"/", "Filter clusters"},
+			{"r", "Refresh clusters"},
+			{"enter", "Open managed node groups for the selected cluster"},
+			{"U", "Open current-version upgrade readiness for the selected cluster"},
+			{"q / esc", "Go back to the feature list"},
+		}
+	case screenEKSUpgradeReadiness:
+		return []helpShortcut{
+			{"↑/↓, j/k", "Scroll the readiness report"},
+			{"pgup / pgdn", "Scroll by one page"},
+			{"r", "Refresh readiness data"},
+			{"esc", "Go back to the cluster list"},
+			{"q", "Go back to the feature list"},
+		}
 	case screenEKSNodeGroupList:
 		return listScreenShortcuts("open the selected node group", "go back to the cluster list", true, true)
 	case screenEKSNodeGroupDetail:
@@ -802,6 +817,8 @@ func (m Model) helpScreenTitle() string {
 		return "ECS Containers"
 	case screenEKSClusterList:
 		return "EKS Clusters"
+	case screenEKSUpgradeReadiness:
+		return "EKS Upgrade Readiness"
 	case screenEKSNodeGroupList:
 		return "EKS Node Groups"
 	case screenEKSNodeGroupDetail:

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -249,6 +249,10 @@ type eksAddonsLoadedMsg struct {
 	addons []awsservice.EKSAddon
 }
 
+type eksUpgradeReadinessLoadedMsg struct {
+	readiness *awsservice.EKSUpgradeReadiness
+}
+
 type ecrRepositoriesLoadedMsg struct {
 	repositories []awsservice.ECRRepository
 }

--- a/internal/app/screen_eks.go
+++ b/internal/app/screen_eks.go
@@ -20,6 +20,8 @@ func (m Model) handleEKSMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		m.filteredEKSClusters = msg.clusters
 		m.eksClusterIdx = 0
 		m.selectedEKSCluster = nil
+		m.eksUpgradeReadiness = nil
+		m.eksUpgradeScroll = 0
 		m.eksNodeGroups = nil
 		m.filteredEKSNodeGroups = nil
 		m.selectedEKSNodeGroup = nil
@@ -49,6 +51,11 @@ func (m Model) handleEKSMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		m.resetFilter(filterEKSAddons)
 		m.screen = screenEKSAddonList
 		return m, nil, true
+	case eksUpgradeReadinessLoadedMsg:
+		m.eksUpgradeReadiness = msg.readiness
+		m.eksUpgradeScroll = 0
+		m.screen = screenEKSUpgradeReadiness
+		return m, nil, true
 	}
 	return m, nil, false
 }
@@ -74,6 +81,12 @@ func (m Model) updateEKSClusterList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			cluster := m.filteredEKSClusters[m.eksClusterIdx]
 			m.selectedEKSCluster = &cluster
 			return m.startLoading(m.loadEKSAddons())
+		}
+	case "U":
+		if len(m.filteredEKSClusters) > 0 && m.eksClusterIdx < len(m.filteredEKSClusters) {
+			cluster := m.filteredEKSClusters[m.eksClusterIdx]
+			m.selectedEKSCluster = &cluster
+			return m.startLoading(m.loadEKSUpgradeReadiness())
 		}
 	case "enter":
 		if len(m.filteredEKSClusters) > 0 && m.eksClusterIdx < len(m.filteredEKSClusters) {
@@ -133,8 +146,135 @@ func (m Model) viewEKSClusterList() string {
 		b.WriteString(renderDetailLine("ARN", cluster.ARN))
 		b.WriteString("\n\n")
 	}
-	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • enter: node groups • a: add-ons • r: refresh • esc: back • H: home"))
+	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • enter: node groups • a: add-ons • U: readiness • r: refresh • esc: back • H: home"))
 	return b.String()
+}
+
+func (m Model) updateEKSUpgradeReadiness(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	lines := m.eksUpgradeReadinessLines()
+	visibleLines := max(m.height-9, 5)
+	maxOffset := max(len(lines)-visibleLines, 0)
+
+	switch msg.String() {
+	case "q":
+		m.screen = screenFeatureList
+	case "esc":
+		m.screen = screenEKSClusterList
+	case "r":
+		return m.startLoading(m.loadEKSUpgradeReadiness())
+	case "up", "k":
+		if m.eksUpgradeScroll > 0 {
+			m.eksUpgradeScroll--
+		}
+	case "down", "j":
+		if m.eksUpgradeScroll < maxOffset {
+			m.eksUpgradeScroll++
+		}
+	case "pgup":
+		m.eksUpgradeScroll -= visibleLines
+		if m.eksUpgradeScroll < 0 {
+			m.eksUpgradeScroll = 0
+		}
+	case "pgdown":
+		m.eksUpgradeScroll += visibleLines
+		if m.eksUpgradeScroll > maxOffset {
+			m.eksUpgradeScroll = maxOffset
+		}
+	}
+	return m, nil
+}
+
+func (m Model) viewEKSUpgradeReadiness() string {
+	var b strings.Builder
+	b.WriteString(m.renderStatusBar())
+	title := "EKS Upgrade Readiness"
+	if m.eksUpgradeReadiness != nil {
+		title = fmt.Sprintf("EKS Upgrade Readiness — %s", m.eksUpgradeReadiness.ClusterName)
+	}
+	b.WriteString(titleStyle.Render(title))
+	b.WriteString("\n\n")
+
+	lines := m.eksUpgradeReadinessLines()
+	visibleLines := max(m.height-9, 5)
+	start := min(m.eksUpgradeScroll, max(len(lines)-visibleLines, 0))
+	end := min(start+visibleLines, len(lines))
+
+	var panel strings.Builder
+	for _, line := range lines[start:end] {
+		panel.WriteString(line)
+		panel.WriteString("\n")
+	}
+	b.WriteString(m.renderListPanel(panel.String()))
+	b.WriteString("\n\n")
+	b.WriteString(m.renderHelpBar("↑/↓: scroll • pgup/pgdn: page • r: refresh • esc: clusters • q: feature list • H: home"))
+	return b.String()
+}
+
+func (m Model) eksUpgradeReadinessLines() []string {
+	if m.eksUpgradeReadiness == nil {
+		return []string{dimStyle.Render("No readiness data loaded")}
+	}
+	readiness := m.eksUpgradeReadiness
+	summary := readiness.Summary()
+	if readiness.HasBlockers() {
+		summary = warningStyle.Render(summary)
+	} else if summary == "ready" {
+		summary = successStyle.Render(summary)
+	} else {
+		summary = warningStyle.Render(summary)
+	}
+	lines := []string{
+		renderDetailLine("Cluster", readiness.ClusterName),
+		renderDetailLine("Control Plane", firstNonEmpty(readiness.ClusterVersion, "-")),
+		renderDetailLine("Check", "current version alignment"),
+		renderDetailLine("Summary", summary),
+		"",
+		titleStyle.Render("Node Groups"),
+	}
+	if len(readiness.NodeGroups) == 0 {
+		lines = append(lines, "  "+dimStyle.Render("No managed node groups found"))
+	} else {
+		for _, nodeGroup := range readiness.NodeGroups {
+			line := fmt.Sprintf("  %s  version:%s  status:%s", nodeGroup.Name, firstNonEmpty(nodeGroup.Version, "-"), firstNonEmpty(nodeGroup.Status, "-"))
+			if nodeGroup.Version != readiness.ClusterVersion {
+				line = warningStyle.Render(line)
+			}
+			lines = append(lines, line)
+		}
+	}
+	lines = append(lines, "", titleStyle.Render("Add-ons"))
+	if len(readiness.Addons) == 0 {
+		lines = append(lines, "  "+dimStyle.Render("No managed add-ons found"))
+	} else {
+		for _, addon := range readiness.Addons {
+			lines = append(lines, fmt.Sprintf("  %s  version:%s  status:%s", addon.Name, firstNonEmpty(addon.Version, "-"), firstNonEmpty(addon.Status, "-")))
+		}
+	}
+	lines = append(lines, "", titleStyle.Render("Upgrade Insights"))
+	if len(readiness.Insights) == 0 {
+		lines = append(lines, "  "+dimStyle.Render("No EKS upgrade insights returned"))
+	} else {
+		for _, insight := range readiness.Insights {
+			line := fmt.Sprintf("  %s  status:%s  version:%s", firstNonEmpty(insight.Name, insight.ID), firstNonEmpty(insight.Status, "-"), firstNonEmpty(insight.KubernetesVersion, "-"))
+			if !strings.EqualFold(insight.Status, "PASSING") {
+				line = warningStyle.Render(line)
+			}
+			lines = append(lines, line)
+		}
+	}
+	lines = append(lines, "", titleStyle.Render("Findings"))
+	if len(readiness.Findings) == 0 {
+		lines = append(lines, "  "+successStyle.Render("No version alignment blockers found"))
+		return lines
+	}
+	for _, finding := range readiness.Findings {
+		line := fmt.Sprintf("  [%s] %s", strings.ToUpper(finding.Severity), finding.Summary())
+		if strings.EqualFold(finding.Severity, "blocker") || strings.EqualFold(finding.Severity, "warning") {
+			line = warningStyle.Render(line)
+		}
+		lines = append(lines, line)
+	}
+	return lines
 }
 
 func (m Model) updateEKSNodeGroupList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -572,6 +712,28 @@ func (m Model) loadEKSAddons() tea.Cmd {
 			return errMsg{err}
 		}
 		return eksAddonsLoadedMsg{addons: addons}
+	}
+}
+
+func (m Model) loadEKSUpgradeReadiness() tea.Cmd {
+	return func() tea.Msg {
+		cfg := m.cfg
+		cluster := m.selectedEKSCluster
+		if cluster == nil {
+			return errMsg{fmt.Errorf("no EKS cluster selected")}
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), eksAPITimeout)
+		defer cancel()
+
+		repo, err := awsservice.NewAwsRepository(ctx, cfg)
+		if err != nil {
+			return errMsg{err}
+		}
+		readiness, err := repo.ListEKSUpgradeReadiness(ctx, *cluster)
+		if err != nil {
+			return errMsg{err}
+		}
+		return eksUpgradeReadinessLoadedMsg{readiness: readiness}
 	}
 }
 

--- a/internal/app/screen_eks_test.go
+++ b/internal/app/screen_eks_test.go
@@ -80,6 +80,25 @@ func TestEKSClusterListALoadsAddons(t *testing.T) {
 	}
 }
 
+func TestEKSClusterListULoadsUpgradeReadiness(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenEKSClusterList
+	m.eksClusters = []awsservice.EKSCluster{{Name: "prod-eks", ARN: "arn:aws:eks:ap-northeast-2:123456789012:cluster/prod-eks", Version: "1.32", Status: "ACTIVE"}}
+	m.filteredEKSClusters = m.eksClusters
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'U'}})
+	model := updated.(Model)
+	if cmd == nil {
+		t.Fatal("expected load command")
+	}
+	if model.selectedEKSCluster == nil || model.selectedEKSCluster.Name != "prod-eks" {
+		t.Fatalf("unexpected selected cluster: %+v", model.selectedEKSCluster)
+	}
+	if model.screen != screenLoading {
+		t.Fatalf("expected loading screen, got %v", model.screen)
+	}
+}
+
 func TestHandleEKSAddonsLoadedMsgShowsAddonList(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	addons := []awsservice.EKSAddon{{ClusterName: "prod-eks", Name: "coredns", Version: "v1.11.4-eksbuild.2", Status: "ACTIVE"}}
@@ -94,6 +113,66 @@ func TestHandleEKSAddonsLoadedMsgShowsAddonList(t *testing.T) {
 	}
 	if len(model.filteredEKSAddons) != 1 || model.filteredEKSAddons[0].Name != "coredns" {
 		t.Fatalf("unexpected add-ons: %+v", model.filteredEKSAddons)
+	}
+}
+
+func TestHandleEKSUpgradeReadinessLoadedMsgShowsReadiness(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	readiness := &awsservice.EKSUpgradeReadiness{ClusterName: "prod-eks", ClusterVersion: "1.32"}
+
+	updated, _, handled := m.handleEKSMsg(eksUpgradeReadinessLoadedMsg{readiness: readiness})
+	if !handled {
+		t.Fatal("expected message to be handled")
+	}
+	model := updated.(Model)
+	if model.screen != screenEKSUpgradeReadiness {
+		t.Fatalf("expected readiness screen, got %v", model.screen)
+	}
+	if model.eksUpgradeReadiness == nil || model.eksUpgradeReadiness.ClusterName != "prod-eks" {
+		t.Fatalf("unexpected readiness: %+v", model.eksUpgradeReadiness)
+	}
+}
+
+func TestEKSUpgradeReadinessViewShowsFindings(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.width = 120
+	m.height = 32
+	m.screen = screenEKSUpgradeReadiness
+	m.eksUpgradeReadiness = &awsservice.EKSUpgradeReadiness{
+		ClusterName:    "prod-eks",
+		ClusterVersion: "1.32",
+		NodeGroups: []awsservice.EKSNodeGroup{
+			{ClusterName: "prod-eks", Name: "blue", Version: "1.32", Status: "ACTIVE"},
+			{ClusterName: "prod-eks", Name: "green", Version: "1.31", Status: "ACTIVE"},
+		},
+		Addons: []awsservice.EKSAddon{
+			{ClusterName: "prod-eks", Name: "coredns", Version: "v1.11.4-eksbuild.2", Status: "ACTIVE"},
+		},
+		Insights: []awsservice.EKSUpgradeInsight{
+			{ID: "insight-1", Name: "Deprecated API usage", Status: "ERROR", KubernetesVersion: "1.33"},
+		},
+		Findings: []awsservice.EKSUpgradeFinding{{
+			Severity: "blocker",
+			Subject:  "node group green",
+			Current:  "1.31",
+			Expected: "1.32",
+			Message:  "node group version differs from control plane",
+		}},
+	}
+
+	view := stripANSI(m.viewEKSUpgradeReadiness())
+	for _, want := range []string{
+		"EKS Upgrade Readiness — prod-eks",
+		"current version alignment",
+		"1 blocker(s), 0 warning(s)",
+		"node group green",
+		"Deprecated API usage",
+		"1.31 -> 1.32",
+		"coredns",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected view to contain %q, got %q", want, view)
+		}
 	}
 }
 

--- a/internal/services/aws/eks.go
+++ b/internal/services/aws/eks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
@@ -144,6 +145,87 @@ func (r *AwsRepository) ListEKSAddons(ctx context.Context, clusterName string) (
 	return addons, nil
 }
 
+func (r *AwsRepository) ListEKSUpgradeReadiness(ctx context.Context, cluster EKSCluster) (*EKSUpgradeReadiness, error) {
+	nodeGroups, err := r.ListEKSNodeGroups(ctx, cluster.Name)
+	if err != nil {
+		return nil, err
+	}
+	addons, err := r.ListEKSAddons(ctx, cluster.Name)
+	if err != nil {
+		return nil, err
+	}
+	insights, err := r.ListEKSUpgradeInsights(ctx, cluster.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	compatibility := make(map[string]bool, len(addons))
+	for _, addon := range addons {
+		compatible, err := r.isEKSAddonVersionCompatible(ctx, addon, cluster.Version)
+		if err != nil {
+			return nil, err
+		}
+		compatibility[addon.Name] = compatible
+	}
+	readiness := BuildEKSUpgradeReadiness(cluster, nodeGroups, addons, insights, compatibility)
+	return &readiness, nil
+}
+
+func (r *AwsRepository) ListEKSUpgradeInsights(ctx context.Context, clusterName string) ([]EKSUpgradeInsight, error) {
+	uniclog.Debug("aws", "ListEKSUpgradeInsights called", "cluster", clusterName)
+
+	paginator := eks.NewListInsightsPaginator(r.EKSClient, &eks.ListInsightsInput{
+		ClusterName: awssdk.String(clusterName),
+		Filter: &ekstypes.InsightsFilter{
+			Categories: []ekstypes.Category{ekstypes.CategoryUpgradeReadiness},
+		},
+	})
+	insights := []EKSUpgradeInsight{}
+	for paginator.HasMorePages() {
+		out, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list EKS upgrade insights for %s: %w", clusterName, err)
+		}
+		for _, insight := range out.Insights {
+			insights = append(insights, mapEKSUpgradeInsight(insight))
+		}
+	}
+
+	sort.SliceStable(insights, func(i, j int) bool {
+		return normalizedSortKey(insights[i].Name, insights[i].ID) < normalizedSortKey(insights[j].Name, insights[j].ID)
+	})
+	return insights, nil
+}
+
+func (r *AwsRepository) isEKSAddonVersionCompatible(ctx context.Context, addon EKSAddon, clusterVersion string) (bool, error) {
+	if strings.TrimSpace(addon.Version) == "" {
+		return false, nil
+	}
+	var nextToken *string
+	for {
+		out, err := r.EKSClient.DescribeAddonVersions(ctx, &eks.DescribeAddonVersionsInput{
+			AddonName:         awssdk.String(addon.Name),
+			KubernetesVersion: awssdk.String(clusterVersion),
+			NextToken:         nextToken,
+		})
+		if err != nil {
+			return false, fmt.Errorf("failed to describe EKS add-on versions for %s: %w", addon.Name, err)
+		}
+		for _, info := range out.Addons {
+			for _, version := range info.AddonVersions {
+				if awssdk.ToString(version.AddonVersion) == addon.Version {
+					return true, nil
+				}
+			}
+		}
+		if out.NextToken == nil {
+			break
+		}
+		nextToken = out.NextToken
+	}
+	return false, nil
+}
+
 func mapEKSCluster(cluster *ekstypes.Cluster) EKSCluster {
 	item := EKSCluster{
 		Name:    awssdk.ToString(cluster.Name),
@@ -206,6 +288,20 @@ func mapEKSAddon(addon *ekstypes.Addon) EKSAddon {
 				ResourceIDs: append([]string(nil), issue.ResourceIds...),
 			})
 		}
+	}
+	return item
+}
+
+func mapEKSUpgradeInsight(insight ekstypes.InsightSummary) EKSUpgradeInsight {
+	item := EKSUpgradeInsight{
+		ID:                awssdk.ToString(insight.Id),
+		Name:              awssdk.ToString(insight.Name),
+		Category:          string(insight.Category),
+		KubernetesVersion: awssdk.ToString(insight.KubernetesVersion),
+	}
+	if insight.InsightStatus != nil {
+		item.Status = string(insight.InsightStatus.Status)
+		item.Reason = awssdk.ToString(insight.InsightStatus.Reason)
 	}
 	return item
 }

--- a/internal/services/aws/eks_model.go
+++ b/internal/services/aws/eks_model.go
@@ -88,6 +88,7 @@ func (n EKSNodeGroup) InstanceTypesLabel() string {
 	return strings.Join(n.InstanceTypes, ", ")
 }
 
+// EKSAddon captures managed add-on status for the TUI.
 // EKSAddonIssue describes one managed add-on health issue.
 type EKSAddonIssue struct {
 	Code        string
@@ -106,7 +107,7 @@ func (i EKSAddonIssue) Summary() string {
 	return strings.Join(parts, " • ")
 }
 
-// EKSAddon captures managed add-on status for the TUI.
+// EKSAddon captures managed add-on status for the TUI and upgrade readiness checks.
 type EKSAddon struct {
 	ClusterName           string
 	Name                  string
@@ -153,6 +154,150 @@ func (a EKSAddon) StatusSummary() string {
 		return strings.ToLower(a.Status)
 	}
 	return "healthy"
+}
+
+type EKSUpgradeInsight struct {
+	ID                string
+	Name              string
+	Category          string
+	KubernetesVersion string
+	Status            string
+	Reason            string
+}
+
+// EKSUpgradeFinding describes one readiness signal.
+type EKSUpgradeFinding struct {
+	Severity string
+	Subject  string
+	Current  string
+	Expected string
+	Message  string
+}
+
+func (f EKSUpgradeFinding) Summary() string {
+	parts := []string{f.Subject}
+	if strings.TrimSpace(f.Current) != "" || strings.TrimSpace(f.Expected) != "" {
+		parts = append(parts, fmt.Sprintf("%s -> %s", firstNonEmptyString(f.Current, "-"), firstNonEmptyString(f.Expected, "-")))
+	}
+	if strings.TrimSpace(f.Message) != "" {
+		parts = append(parts, f.Message)
+	}
+	return strings.Join(parts, " • ")
+}
+
+// EKSUpgradeReadiness summarizes control plane, node group, and add-on alignment.
+type EKSUpgradeReadiness struct {
+	ClusterName    string
+	ClusterVersion string
+	NodeGroups     []EKSNodeGroup
+	Addons         []EKSAddon
+	Insights       []EKSUpgradeInsight
+	Findings       []EKSUpgradeFinding
+}
+
+func (r EKSUpgradeReadiness) Summary() string {
+	blockers := 0
+	warnings := 0
+	for _, finding := range r.Findings {
+		switch strings.ToLower(finding.Severity) {
+		case "blocker":
+			blockers++
+		case "warning":
+			warnings++
+		}
+	}
+	if blockers > 0 {
+		return fmt.Sprintf("%d blocker(s), %d warning(s)", blockers, warnings)
+	}
+	if warnings > 0 {
+		return fmt.Sprintf("%d warning(s)", warnings)
+	}
+	return "ready"
+}
+
+func (r EKSUpgradeReadiness) HasBlockers() bool {
+	for _, finding := range r.Findings {
+		if strings.EqualFold(finding.Severity, "blocker") {
+			return true
+		}
+	}
+	return false
+}
+
+func BuildEKSUpgradeReadiness(cluster EKSCluster, nodeGroups []EKSNodeGroup, addons []EKSAddon, insights []EKSUpgradeInsight, addonCompatibility map[string]bool) EKSUpgradeReadiness {
+	result := EKSUpgradeReadiness{
+		ClusterName:    cluster.Name,
+		ClusterVersion: cluster.Version,
+		NodeGroups:     append([]EKSNodeGroup(nil), nodeGroups...),
+		Addons:         append([]EKSAddon(nil), addons...),
+		Insights:       append([]EKSUpgradeInsight(nil), insights...),
+	}
+	for _, nodeGroup := range nodeGroups {
+		if strings.TrimSpace(nodeGroup.Version) == "" {
+			result.Findings = append(result.Findings, EKSUpgradeFinding{
+				Severity: "warning",
+				Subject:  "node group " + nodeGroup.Name,
+				Expected: cluster.Version,
+				Message:  "node group version unavailable",
+			})
+			continue
+		}
+		if nodeGroup.Version != cluster.Version {
+			result.Findings = append(result.Findings, EKSUpgradeFinding{
+				Severity: "blocker",
+				Subject:  "node group " + nodeGroup.Name,
+				Current:  nodeGroup.Version,
+				Expected: cluster.Version,
+				Message:  "node group version differs from control plane",
+			})
+		}
+	}
+	for _, addon := range addons {
+		if !strings.EqualFold(strings.TrimSpace(addon.Status), "ACTIVE") {
+			severity := "warning"
+			if isBlockingAddonStatus(addon.Status) {
+				severity = "blocker"
+			}
+			result.Findings = append(result.Findings, EKSUpgradeFinding{
+				Severity: severity,
+				Subject:  "add-on " + addon.Name,
+				Current:  addon.Status,
+				Expected: "ACTIVE",
+				Message:  "add-on is not active",
+			})
+		}
+		if compatible, ok := addonCompatibility[addon.Name]; ok && !compatible {
+			result.Findings = append(result.Findings, EKSUpgradeFinding{
+				Severity: "blocker",
+				Subject:  "add-on " + addon.Name,
+				Current:  addon.Version,
+				Expected: "compatible with Kubernetes " + cluster.Version,
+				Message:  "installed add-on version is not listed as compatible",
+			})
+		}
+	}
+	for _, insight := range insights {
+		if strings.EqualFold(insight.Status, "PASSING") {
+			continue
+		}
+		severity := "warning"
+		if strings.EqualFold(insight.Status, "ERROR") {
+			severity = "blocker"
+		}
+		result.Findings = append(result.Findings, EKSUpgradeFinding{
+			Severity: severity,
+			Subject:  "insight " + firstNonEmptyString(insight.Name, insight.ID),
+			Current:  firstNonEmptyString(insight.Status, "-"),
+			Expected: "PASSING",
+			Message:  firstNonEmptyString(insight.Reason, "EKS upgrade insight is not passing"),
+		})
+	}
+	return result
+}
+
+func isBlockingAddonStatus(status string) bool {
+	normalized := strings.ToUpper(strings.TrimSpace(status))
+	return normalized == "DEGRADED" || strings.HasSuffix(normalized, "_FAILED")
 }
 
 func firstNonEmptyString(values ...string) string {

--- a/internal/services/aws/eks_test.go
+++ b/internal/services/aws/eks_test.go
@@ -11,12 +11,14 @@ import (
 )
 
 type mockEKSClient struct {
-	listClustersFunc      func(ctx context.Context, params *eks.ListClustersInput, optFns ...func(*eks.Options)) (*eks.ListClustersOutput, error)
-	describeClusterFunc   func(ctx context.Context, params *eks.DescribeClusterInput, optFns ...func(*eks.Options)) (*eks.DescribeClusterOutput, error)
-	listNodegroupsFunc    func(ctx context.Context, params *eks.ListNodegroupsInput, optFns ...func(*eks.Options)) (*eks.ListNodegroupsOutput, error)
-	describeNodegroupFunc func(ctx context.Context, params *eks.DescribeNodegroupInput, optFns ...func(*eks.Options)) (*eks.DescribeNodegroupOutput, error)
-	listAddonsFunc        func(ctx context.Context, params *eks.ListAddonsInput, optFns ...func(*eks.Options)) (*eks.ListAddonsOutput, error)
-	describeAddonFunc     func(ctx context.Context, params *eks.DescribeAddonInput, optFns ...func(*eks.Options)) (*eks.DescribeAddonOutput, error)
+	listClustersFunc          func(ctx context.Context, params *eks.ListClustersInput, optFns ...func(*eks.Options)) (*eks.ListClustersOutput, error)
+	describeClusterFunc       func(ctx context.Context, params *eks.DescribeClusterInput, optFns ...func(*eks.Options)) (*eks.DescribeClusterOutput, error)
+	listNodegroupsFunc        func(ctx context.Context, params *eks.ListNodegroupsInput, optFns ...func(*eks.Options)) (*eks.ListNodegroupsOutput, error)
+	describeNodegroupFunc     func(ctx context.Context, params *eks.DescribeNodegroupInput, optFns ...func(*eks.Options)) (*eks.DescribeNodegroupOutput, error)
+	listAddonsFunc            func(ctx context.Context, params *eks.ListAddonsInput, optFns ...func(*eks.Options)) (*eks.ListAddonsOutput, error)
+	describeAddonFunc         func(ctx context.Context, params *eks.DescribeAddonInput, optFns ...func(*eks.Options)) (*eks.DescribeAddonOutput, error)
+	describeAddonVersionsFunc func(ctx context.Context, params *eks.DescribeAddonVersionsInput, optFns ...func(*eks.Options)) (*eks.DescribeAddonVersionsOutput, error)
+	listInsightsFunc          func(ctx context.Context, params *eks.ListInsightsInput, optFns ...func(*eks.Options)) (*eks.ListInsightsOutput, error)
 }
 
 func (m *mockEKSClient) ListClusters(ctx context.Context, params *eks.ListClustersInput, optFns ...func(*eks.Options)) (*eks.ListClustersOutput, error) {
@@ -41,6 +43,14 @@ func (m *mockEKSClient) ListAddons(ctx context.Context, params *eks.ListAddonsIn
 
 func (m *mockEKSClient) DescribeAddon(ctx context.Context, params *eks.DescribeAddonInput, optFns ...func(*eks.Options)) (*eks.DescribeAddonOutput, error) {
 	return m.describeAddonFunc(ctx, params, optFns...)
+}
+
+func (m *mockEKSClient) DescribeAddonVersions(ctx context.Context, params *eks.DescribeAddonVersionsInput, optFns ...func(*eks.Options)) (*eks.DescribeAddonVersionsOutput, error) {
+	return m.describeAddonVersionsFunc(ctx, params, optFns...)
+}
+
+func (m *mockEKSClient) ListInsights(ctx context.Context, params *eks.ListInsightsInput, optFns ...func(*eks.Options)) (*eks.ListInsightsOutput, error) {
+	return m.listInsightsFunc(ctx, params, optFns...)
 }
 
 func TestListEKSClusters(t *testing.T) {
@@ -182,6 +192,105 @@ func TestListEKSAddons(t *testing.T) {
 	}
 	if addons[1].HealthIssues[0].Summary() == "" {
 		t.Fatal("expected add-on health issue summary")
+	}
+}
+
+func TestListEKSUpgradeReadiness(t *testing.T) {
+	mock := &mockEKSClient{
+		listNodegroupsFunc: func(_ context.Context, _ *eks.ListNodegroupsInput, _ ...func(*eks.Options)) (*eks.ListNodegroupsOutput, error) {
+			return &eks.ListNodegroupsOutput{Nodegroups: []string{"blue", "green"}}, nil
+		},
+		describeNodegroupFunc: func(_ context.Context, params *eks.DescribeNodegroupInput, _ ...func(*eks.Options)) (*eks.DescribeNodegroupOutput, error) {
+			name := awssdk.ToString(params.NodegroupName)
+			version := "1.32"
+			if name == "green" {
+				version = "1.31"
+			}
+			return &eks.DescribeNodegroupOutput{Nodegroup: &ekstypes.Nodegroup{
+				ClusterName:   awssdk.String("prod-eks"),
+				NodegroupName: awssdk.String(name),
+				Status:        ekstypes.NodegroupStatusActive,
+				Version:       awssdk.String(version),
+			}}, nil
+		},
+		listAddonsFunc: func(_ context.Context, _ *eks.ListAddonsInput, _ ...func(*eks.Options)) (*eks.ListAddonsOutput, error) {
+			return &eks.ListAddonsOutput{Addons: []string{"coredns", "vpc-cni"}}, nil
+		},
+		describeAddonFunc: func(_ context.Context, params *eks.DescribeAddonInput, _ ...func(*eks.Options)) (*eks.DescribeAddonOutput, error) {
+			name := awssdk.ToString(params.AddonName)
+			version := "v1.11.4-eksbuild.2"
+			status := ekstypes.AddonStatusActive
+			if name == "vpc-cni" {
+				version = "v1.12.0-eksbuild.1"
+				status = ekstypes.AddonStatusDegraded
+			}
+			return &eks.DescribeAddonOutput{Addon: &ekstypes.Addon{
+				ClusterName:  awssdk.String("prod-eks"),
+				AddonName:    awssdk.String(name),
+				AddonVersion: awssdk.String(version),
+				Status:       status,
+			}}, nil
+		},
+		describeAddonVersionsFunc: func(_ context.Context, params *eks.DescribeAddonVersionsInput, _ ...func(*eks.Options)) (*eks.DescribeAddonVersionsOutput, error) {
+			if got := awssdk.ToString(params.KubernetesVersion); got != "1.32" {
+				t.Fatalf("expected Kubernetes version 1.32, got %s", got)
+			}
+			name := awssdk.ToString(params.AddonName)
+			version := "v1.11.4-eksbuild.2"
+			if name == "vpc-cni" {
+				version = "v1.16.0-eksbuild.1"
+			}
+			return &eks.DescribeAddonVersionsOutput{
+				Addons: []ekstypes.AddonInfo{{
+					AddonName: awssdk.String(name),
+					AddonVersions: []ekstypes.AddonVersionInfo{{
+						AddonVersion: awssdk.String(version),
+					}},
+				}},
+			}, nil
+		},
+		listInsightsFunc: func(_ context.Context, params *eks.ListInsightsInput, _ ...func(*eks.Options)) (*eks.ListInsightsOutput, error) {
+			if got := awssdk.ToString(params.ClusterName); got != "prod-eks" {
+				t.Fatalf("expected cluster prod-eks, got %s", got)
+			}
+			if len(params.Filter.Categories) != 1 || params.Filter.Categories[0] != ekstypes.CategoryUpgradeReadiness {
+				t.Fatalf("expected upgrade readiness filter, got %+v", params.Filter.Categories)
+			}
+			return &eks.ListInsightsOutput{Insights: []ekstypes.InsightSummary{{
+				Id:   awssdk.String("insight-1"),
+				Name: awssdk.String("Deprecated API usage"),
+				InsightStatus: &ekstypes.InsightStatus{
+					Status: ekstypes.InsightStatusValueError,
+					Reason: awssdk.String("deprecated APIs detected"),
+				},
+				KubernetesVersion: awssdk.String("1.33"),
+			}}}, nil
+		},
+	}
+
+	repo := &AwsRepository{EKSClient: mock}
+	readiness, err := repo.ListEKSUpgradeReadiness(context.Background(), EKSCluster{Name: "prod-eks", Version: "1.32"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if readiness.Summary() != "4 blocker(s), 0 warning(s)" {
+		t.Fatalf("unexpected readiness summary: %s", readiness.Summary())
+	}
+	if !readiness.HasBlockers() {
+		t.Fatal("expected readiness blockers")
+	}
+}
+
+func TestBuildEKSUpgradeReadinessReady(t *testing.T) {
+	readiness := BuildEKSUpgradeReadiness(
+		EKSCluster{Name: "prod-eks", Version: "1.32"},
+		[]EKSNodeGroup{{ClusterName: "prod-eks", Name: "blue", Version: "1.32", Status: "ACTIVE"}},
+		[]EKSAddon{{ClusterName: "prod-eks", Name: "coredns", Version: "v1.11.4-eksbuild.2", Status: "ACTIVE"}},
+		[]EKSUpgradeInsight{{ID: "insight-1", Name: "Upgrade checks", Status: "PASSING"}},
+		map[string]bool{"coredns": true},
+	)
+	if readiness.Summary() != "ready" {
+		t.Fatalf("expected ready summary, got %s", readiness.Summary())
 	}
 }
 

--- a/internal/services/aws/repository.go
+++ b/internal/services/aws/repository.go
@@ -200,6 +200,8 @@ type EKSClientAPI interface {
 	DescribeNodegroup(ctx context.Context, params *eks.DescribeNodegroupInput, optFns ...func(*eks.Options)) (*eks.DescribeNodegroupOutput, error)
 	ListAddons(ctx context.Context, params *eks.ListAddonsInput, optFns ...func(*eks.Options)) (*eks.ListAddonsOutput, error)
 	DescribeAddon(ctx context.Context, params *eks.DescribeAddonInput, optFns ...func(*eks.Options)) (*eks.DescribeAddonOutput, error)
+	DescribeAddonVersions(ctx context.Context, params *eks.DescribeAddonVersionsInput, optFns ...func(*eks.Options)) (*eks.DescribeAddonVersionsOutput, error)
+	ListInsights(ctx context.Context, params *eks.ListInsightsInput, optFns ...func(*eks.Options)) (*eks.ListInsightsOutput, error)
 }
 
 // S3ClientAPI is the interface for S3 operations used by AwsRepository.


### PR DESCRIPTION
### Summary

Add an EKS current-version upgrade readiness view so operators can spot version alignment and EKS insight blockers before planning a target upgrade.

- compares control plane and managed node group versions
- checks managed add-on versions against EKS compatibility metadata for the current cluster version
- includes EKS `UPGRADE_READINESS` insights from `ListInsights`
- classifies node group skew, incompatible add-ons, failed/degraded add-ons, and error insights as blockers
- adds a cluster-level `U` readiness report screen and updates docs

### Related Issues

Closes #169

### Review Notes

Reviewed with cli-developer, golang-pro, platform-engineer, security-reviewer, and devops-engineer agents. Addressed target-version wording, add-on severity, keybinding collision with #168, help text, and EKS Upgrade Insights feedback.

### Validation

- [x] `env -u GOROOT go test ./...`
- [x] `env -u GOROOT make test`
- [x] `env -u GOROOT make build`
- [x] `git diff --check`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed
- [x] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented

No breaking changes.

### Merge Note

This PR intentionally uses uppercase `U` for readiness so lowercase `u` can remain available for the EKS access helper in #168. If #168 lands first, this branch may need a small rebase around EKS cluster help/footer text.