### PR TITLE
feat: add EKS access helper for kubeconfig commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ checks:
 | ECR Login | CLI helper: `unic ecr login [--runtime docker|podman] [--copy]` |
 | ECS Exec | `r` refresh, `Enter` drill down / exec |
 | ECS Rollout / Exec | cluster/service lists support refresh and drill-down, service detail shows deployments/task definition images/events, `Enter` continues into tasks and exec |
-| EKS Browser | cluster/node group/add-on lists support `/` filter and `r` refresh, cluster view shows version/status/endpoint visibility/ARN summary, `a` opens managed add-ons, `U` opens current-version upgrade readiness, node group detail shows desired/min/max scaling plus health issues |
+| EKS Browser | cluster/node group/add-on lists support `/` filter and `r` refresh, cluster view shows version/status/endpoint visibility/ARN summary, `a` opens managed add-ons, `U` opens current-version upgrade readiness, `u` opens kubeconfig access helper, node group detail shows desired/min/max scaling plus health issues |
 | Inspector Mode | `i` open mode from the service list, `Enter` open the selected workflow, `l` open the checklist file picker |
 | Security Inspector | `r` run/rescan, `1`-`5` severity filter, `Enter` finding detail |
 | Checklist Inspector | `l` load or switch checklist files, `r` run/rerun the loaded checklist, `Enter` result detail |
@@ -357,6 +357,8 @@ The EKS Browser includes a managed add-on status view for each cluster. Add-on r
 The ECR Repository Browser opens image/tag lists from each repository. Image rows include tags, digest, pushed time, and size, and mark untagged images or images older than 90 days as cleanup candidates. Image detail exposes digest and tag values for clipboard copy.
 
 The EKS Browser includes a current-version upgrade readiness view for each selected cluster. It compares the control plane version with managed node group versions, checks installed managed add-on versions against EKS compatibility metadata for the current cluster version, includes EKS `UPGRADE_READINESS` insights, and highlights blockers or warnings before planning a target-version upgrade.
+
+The EKS Browser includes an access helper for each selected cluster. Press `u` from the cluster list to review the cluster endpoint, ARN, current region/profile, and copy an `aws eks update-kubeconfig` command or a `kubectl get nodes` smoke-check command for handoff into Kubernetes workflows.
 
 The EC2 Instance Browser lists EC2 instances across available states for the active context and region, separate from the SSM session picker that only lists connectable running instances. The detail screen shows core metadata including instance ID, name tag, state, instance type, AZ, VPC, subnet, private and public IPs, launch time, platform details, IAM profile, and tags.
 

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -194,7 +194,7 @@ Current screen families include:
 - CloudWatch metric list/detail flows
 - CloudWatch Logs group/stream/viewer flows
 - ECS cluster/service/rollout detail/task/container flows
-- EKS cluster/node group/add-on status and upgrade readiness flows
+- EKS cluster/node group/add-on status, upgrade readiness, and access helper flows
 - ECR repository/image/detail flows
 - S3 bucket/object/detail flows
 - Inspector mode home, checklist setup, security findings/detail, and checklist results/detail flows

--- a/docs/architecture.ko.md
+++ b/docs/architecture.ko.md
@@ -194,7 +194,7 @@ UNIC은 현재 세 가지 인증 모드를 지원한다.
 - CloudWatch metric list/detail
 - CloudWatch Logs group/stream/viewer
 - ECS cluster/service/rollout detail/task/container
-- EKS cluster/node group/add-on status, upgrade readiness
+- EKS cluster/node group/add-on status, upgrade readiness, access helper
 - ECR repository/image/detail
 - S3 bucket/object/detail
 - Inspector mode home, checklist setup, security findings/detail, checklist results/detail

--- a/docs/project-overview.en.md
+++ b/docs/project-overview.en.md
@@ -24,7 +24,7 @@ Implemented service areas currently include:
 - Lambda
 - Inspector mode
 
-The application already includes interactive mutation flows, polling-based status flows, context helpers, and per-service drill-down screens. CloudWatch Metrics now includes resource-centric preset groups plus time-range, period, and statistic controls for faster terminal triage. EKS includes managed add-on status review plus current-version upgrade readiness checks that compare control plane, managed node group, managed add-on version alignment, and EKS upgrade insights before a target upgrade is planned. ECR includes repository and image/tag browsing with cleanup-oriented untagged and stale image signals.
+The application already includes interactive mutation flows, polling-based status flows, context helpers, and per-service drill-down screens. CloudWatch Metrics now includes resource-centric preset groups plus time-range, period, and statistic controls for faster terminal triage. EKS includes managed add-on status review, current-version upgrade readiness checks that compare control plane, managed node group, managed add-on version alignment, and EKS upgrade insights before a target upgrade is planned, plus a kubeconfig access helper that prepares copyable `aws eks update-kubeconfig` and `kubectl` handoff commands. ECR includes repository and image/tag browsing with cleanup-oriented untagged and stale image signals.
 Inspector mode now includes built-in security scans plus checklist-driven readiness checks for RDS, security groups, secrets, Route53, VPCs/subnets, CloudWatch Logs, and baseline posture wrappers.
 
 ## Primary User Flows

--- a/docs/project-overview.ko.md
+++ b/docs/project-overview.ko.md
@@ -24,7 +24,7 @@ UNIC은 다음 세 가지를 결합한 Go 기반 AWS 터미널 콘솔이다.
 - Lambda
 - Inspector mode
 
-애플리케이션은 이미 상호작용형 변경 작업 플로우, polling 기반 상태 확인, context helper, 서비스별 drill-down 화면을 포함한다. CloudWatch Metrics는 이제 resource-centric preset 그룹과 time-range / period / statistic control을 제공해 터미널에서 더 빠르게 triage할 수 있다. EKS는 cluster 화면에서 managed add-on 상태를 확인하고, target upgrade를 계획하기 전에 control plane, managed node group, managed add-on의 current-version alignment와 EKS upgrade insight를 함께 확인하는 upgrade readiness check를 포함한다. ECR은 repository와 image/tag 탐색을 제공하고, untagged image와 오래된 image를 cleanup 후보로 드러낸다.
+애플리케이션은 이미 상호작용형 변경 작업 플로우, polling 기반 상태 확인, context helper, 서비스별 drill-down 화면을 포함한다. CloudWatch Metrics는 이제 resource-centric preset 그룹과 time-range / period / statistic control을 제공해 터미널에서 더 빠르게 triage할 수 있다. EKS는 cluster 화면에서 managed add-on 상태를 확인하고, target upgrade를 계획하기 전에 control plane, managed node group, managed add-on의 current-version alignment와 EKS upgrade insight를 함께 확인하는 upgrade readiness check와 복사 가능한 `aws eks update-kubeconfig` / `kubectl` handoff 명령을 준비하는 kubeconfig access helper를 포함한다. ECR은 repository와 image/tag 탐색을 제공하고, untagged image와 오래된 image를 cleanup 후보로 드러낸다.
 Inspector mode는 이제 built-in security scan과 함께 RDS, security group, secret, Route53, VPC/subnet, CloudWatch Logs, baseline posture wrapper를 다루는 checklist 기반 readiness check도 포함한다.
 
 ## 주요 사용자 흐름

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -66,6 +66,7 @@ const (
 	screenECSContainerList
 	screenEKSClusterList
 	screenEKSUpgradeReadiness
+	screenEKSAccessHelper
 	screenEKSNodeGroupList
 	screenEKSNodeGroupDetail
 	screenEKSAddonList
@@ -151,6 +152,7 @@ type Model struct {
 	selectedEKSCluster  *awsservice.EKSCluster
 	eksUpgradeReadiness *awsservice.EKSUpgradeReadiness
 	eksUpgradeScroll    int
+	eksAccessCopyMsg    string
 
 	eksNodeGroups         []awsservice.EKSNodeGroup
 	filteredEKSNodeGroups []awsservice.EKSNodeGroup
@@ -492,6 +494,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateEKSClusterList(msg)
 		case screenEKSUpgradeReadiness:
 			return m.updateEKSUpgradeReadiness(msg)
+		case screenEKSAccessHelper:
+			return m.updateEKSAccessHelper(msg)
 		case screenEKSNodeGroupList:
 			return m.updateEKSNodeGroupList(msg)
 		case screenEKSNodeGroupDetail:
@@ -688,6 +692,8 @@ func (m Model) View() string {
 		v = m.viewEKSClusterList()
 	case screenEKSUpgradeReadiness:
 		v = m.viewEKSUpgradeReadiness()
+	case screenEKSAccessHelper:
+		v = m.viewEKSAccessHelper()
 	case screenEKSNodeGroupList:
 		v = m.viewEKSNodeGroupList()
 	case screenEKSNodeGroupDetail:

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -411,7 +411,9 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 			{"/", "Filter clusters"},
 			{"r", "Refresh clusters"},
 			{"enter", "Open managed node groups for the selected cluster"},
+			{"a", "Open managed add-ons for the selected cluster"},
 			{"U", "Open current-version upgrade readiness for the selected cluster"},
+			{"u", "Open the kubeconfig access helper for the selected cluster"},
 			{"q / esc", "Go back to the feature list"},
 		}
 	case screenEKSUpgradeReadiness:
@@ -419,6 +421,13 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 			{"↑/↓, j/k", "Scroll the readiness report"},
 			{"pgup / pgdn", "Scroll by one page"},
 			{"r", "Refresh readiness data"},
+			{"esc", "Go back to the cluster list"},
+			{"q", "Go back to the feature list"},
+		}
+	case screenEKSAccessHelper:
+		return []helpShortcut{
+			{"c", "Copy the aws eks update-kubeconfig command"},
+			{"k", "Copy the kubectl smoke-check command"},
 			{"esc", "Go back to the cluster list"},
 			{"q", "Go back to the feature list"},
 		}
@@ -819,6 +828,8 @@ func (m Model) helpScreenTitle() string {
 		return "EKS Clusters"
 	case screenEKSUpgradeReadiness:
 		return "EKS Upgrade Readiness"
+	case screenEKSAccessHelper:
+		return "EKS Access Helper"
 	case screenEKSNodeGroupList:
 		return "EKS Node Groups"
 	case screenEKSNodeGroupDetail:

--- a/internal/app/screen_eks.go
+++ b/internal/app/screen_eks.go
@@ -8,6 +8,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"unic/internal/clipboard"
 	awsservice "unic/internal/services/aws"
 )
 
@@ -22,6 +23,7 @@ func (m Model) handleEKSMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		m.selectedEKSCluster = nil
 		m.eksUpgradeReadiness = nil
 		m.eksUpgradeScroll = 0
+		m.eksAccessCopyMsg = ""
 		m.eksNodeGroups = nil
 		m.filteredEKSNodeGroups = nil
 		m.selectedEKSNodeGroup = nil
@@ -88,6 +90,13 @@ func (m Model) updateEKSClusterList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.selectedEKSCluster = &cluster
 			return m.startLoading(m.loadEKSUpgradeReadiness())
 		}
+	case "u":
+		if len(m.filteredEKSClusters) > 0 && m.eksClusterIdx < len(m.filteredEKSClusters) {
+			cluster := m.filteredEKSClusters[m.eksClusterIdx]
+			m.selectedEKSCluster = &cluster
+			m.eksAccessCopyMsg = ""
+			m.screen = screenEKSAccessHelper
+		}
 	case "enter":
 		if len(m.filteredEKSClusters) > 0 && m.eksClusterIdx < len(m.filteredEKSClusters) {
 			cluster := m.filteredEKSClusters[m.eksClusterIdx]
@@ -146,7 +155,7 @@ func (m Model) viewEKSClusterList() string {
 		b.WriteString(renderDetailLine("ARN", cluster.ARN))
 		b.WriteString("\n\n")
 	}
-	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • enter: node groups • a: add-ons • U: readiness • r: refresh • esc: back • H: home"))
+	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • enter: node groups • a: add-ons • U: readiness • u: access helper • r: refresh • esc: back • H: home"))
 	return b.String()
 }
 
@@ -208,6 +217,29 @@ func (m Model) viewEKSUpgradeReadiness() string {
 	b.WriteString("\n\n")
 	b.WriteString(m.renderHelpBar("↑/↓: scroll • pgup/pgdn: page • r: refresh • esc: clusters • q: feature list • H: home"))
 	return b.String()
+}
+
+func (m Model) updateEKSAccessHelper(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q":
+		m.screen = screenFeatureList
+	case "esc":
+		m.eksAccessCopyMsg = ""
+		m.screen = screenEKSClusterList
+	case "c":
+		if err := clipboard.Copy(m.eksUpdateKubeconfigCommand()); err != nil {
+			m.eksAccessCopyMsg = fmt.Sprintf("Clipboard error: %s", err)
+		} else {
+			m.eksAccessCopyMsg = "Copied update-kubeconfig command"
+		}
+	case "k":
+		if err := clipboard.Copy(awsservice.BuildEKSKubectlSmokeCommand()); err != nil {
+			m.eksAccessCopyMsg = fmt.Sprintf("Clipboard error: %s", err)
+		} else {
+			m.eksAccessCopyMsg = "Copied kubectl command"
+		}
+	}
+	return m, nil
 }
 
 func (m Model) eksUpgradeReadinessLines() []string {
@@ -275,6 +307,66 @@ func (m Model) eksUpgradeReadinessLines() []string {
 		lines = append(lines, line)
 	}
 	return lines
+}
+
+func (m Model) viewEKSAccessHelper() string {
+	var b strings.Builder
+	b.WriteString(m.renderStatusBar())
+	title := "EKS Access Helper"
+	if m.selectedEKSCluster != nil {
+		title = fmt.Sprintf("EKS Access Helper — %s", m.selectedEKSCluster.Name)
+	}
+	b.WriteString(titleStyle.Render(title))
+	b.WriteString("\n\n")
+
+	cluster := m.selectedEKSCluster
+	if cluster == nil {
+		b.WriteString(dimStyle.Render("No EKS cluster selected"))
+		b.WriteString("\n\n")
+		b.WriteString(m.renderHelpBar("esc: clusters • H: home"))
+		return b.String()
+	}
+
+	var panel strings.Builder
+	panel.WriteString(renderDetailLine("Cluster", cluster.Name))
+	panel.WriteString("\n")
+	panel.WriteString(renderDetailLine("Region", firstNonEmpty(m.cfg.Region, "-")))
+	panel.WriteString("\n")
+	panel.WriteString(renderDetailLine("Profile", firstNonEmpty(m.cfg.Profile, "-")))
+	panel.WriteString("\n")
+	panel.WriteString(renderDetailLine("Context", firstNonEmpty(m.cfg.ContextName, "-")))
+	panel.WriteString("\n")
+	panel.WriteString(renderDetailLine("Endpoint", firstNonEmpty(cluster.Endpoint, "-")))
+	panel.WriteString("\n")
+	panel.WriteString(renderDetailLine("ARN", cluster.ARN))
+	panel.WriteString("\n\n")
+	panel.WriteString(titleStyle.Render("Commands"))
+	panel.WriteString("\n")
+	panel.WriteString("  [c] " + m.eksUpdateKubeconfigCommand())
+	panel.WriteString("\n")
+	panel.WriteString("  [k] " + awsservice.BuildEKSKubectlSmokeCommand())
+	panel.WriteString("\n")
+	if m.eksAccessCopyMsg != "" {
+		panel.WriteString("\n")
+		panel.WriteString(selectedStyle.Render("  " + m.eksAccessCopyMsg))
+		panel.WriteString("\n")
+	}
+
+	b.WriteString(m.renderListPanel(panel.String()))
+	b.WriteString("\n\n")
+	b.WriteString(m.renderHelpBar("c: copy kubeconfig • k: copy kubectl • esc: clusters • q: feature list • H: home"))
+	return b.String()
+}
+
+func (m Model) eksUpdateKubeconfigCommand() string {
+	if m.selectedEKSCluster == nil {
+		return ""
+	}
+	alias := m.selectedEKSCluster.Name
+	if strings.TrimSpace(m.cfg.ContextName) != "" {
+		alias = m.cfg.ContextName + "-" + m.selectedEKSCluster.Name
+	}
+	return awsservice.BuildEKSUpdateKubeconfigCommand(m.selectedEKSCluster.Name, m.cfg.Region, m.cfg.Profile, alias)
 }
 
 func (m Model) updateEKSNodeGroupList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/internal/app/screen_eks_test.go
+++ b/internal/app/screen_eks_test.go
@@ -80,6 +80,31 @@ func TestEKSClusterListALoadsAddons(t *testing.T) {
 	}
 }
 
+func TestEKSClusterListUOpensAccessHelper(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenEKSClusterList
+	m.eksClusters = []awsservice.EKSCluster{{
+		Name:     "prod-eks",
+		ARN:      "arn:aws:eks:ap-northeast-2:123456789012:cluster/prod-eks",
+		Version:  "1.32",
+		Status:   "ACTIVE",
+		Endpoint: "https://prod-eks.eks.amazonaws.com",
+	}}
+	m.filteredEKSClusters = m.eksClusters
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+	model := updated.(Model)
+	if cmd != nil {
+		t.Fatal("expected no async command")
+	}
+	if model.selectedEKSCluster == nil || model.selectedEKSCluster.Name != "prod-eks" {
+		t.Fatalf("unexpected selected cluster: %+v", model.selectedEKSCluster)
+	}
+	if model.screen != screenEKSAccessHelper {
+		t.Fatalf("expected access helper screen, got %v", model.screen)
+	}
+}
+
 func TestEKSClusterListULoadsUpgradeReadiness(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenEKSClusterList
@@ -235,6 +260,39 @@ func TestEKSAddonDetailViewShowsHealthIssues(t *testing.T) {
 		if !strings.Contains(view, want) {
 			t.Fatalf("expected view to contain %q, got %q", want, view)
 		}
+	}
+}
+
+func TestEKSAccessHelperViewShowsCommands(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenEKSAccessHelper
+	m.selectedEKSCluster = &awsservice.EKSCluster{
+		Name:     "prod-eks",
+		ARN:      "arn:aws:eks:ap-northeast-2:123456789012:cluster/prod-eks",
+		Endpoint: "https://prod-eks.eks.amazonaws.com",
+	}
+
+	view := stripANSI(m.viewEKSAccessHelper())
+	for _, want := range []string{
+		"EKS Access Helper — prod-eks",
+		"https://prod-eks.eks.amazonaws.com",
+		`aws eks update-kubeconfig --name 'prod-eks' --region 'us-east-1' --profile 'default' --alias 'prod-eks'`,
+		"kubectl get nodes",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected view to contain %q, got %q", want, view)
+		}
+	}
+}
+
+func TestEKSAccessHelperAliasIncludesContextAndCluster(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.cfg.ContextName = "prod"
+	m.selectedEKSCluster = &awsservice.EKSCluster{Name: "blue"}
+
+	got := m.eksUpdateKubeconfigCommand()
+	if !strings.Contains(got, "--alias 'prod-blue'") {
+		t.Fatalf("expected context-cluster alias, got %s", got)
 	}
 }
 

--- a/internal/services/aws/eks.go
+++ b/internal/services/aws/eks.go
@@ -228,10 +228,11 @@ func (r *AwsRepository) isEKSAddonVersionCompatible(ctx context.Context, addon E
 
 func mapEKSCluster(cluster *ekstypes.Cluster) EKSCluster {
 	item := EKSCluster{
-		Name:    awssdk.ToString(cluster.Name),
-		ARN:     awssdk.ToString(cluster.Arn),
-		Version: awssdk.ToString(cluster.Version),
-		Status:  string(cluster.Status),
+		Name:     awssdk.ToString(cluster.Name),
+		ARN:      awssdk.ToString(cluster.Arn),
+		Version:  awssdk.ToString(cluster.Version),
+		Status:   string(cluster.Status),
+		Endpoint: awssdk.ToString(cluster.Endpoint),
 	}
 	if cluster.ResourcesVpcConfig != nil {
 		item.EndpointPublicAccess = cluster.ResourcesVpcConfig.EndpointPublicAccess

--- a/internal/services/aws/eks_model.go
+++ b/internal/services/aws/eks_model.go
@@ -11,6 +11,7 @@ type EKSCluster struct {
 	ARN                   string
 	Version               string
 	Status                string
+	Endpoint              string
 	EndpointPublicAccess  bool
 	EndpointPrivateAccess bool
 }
@@ -25,6 +26,33 @@ func (c EKSCluster) FilterText() string {
 
 func (c EKSCluster) EndpointVisibility() string {
 	return fmt.Sprintf("pub:%s priv:%s", enabledMarker(c.EndpointPublicAccess), enabledMarker(c.EndpointPrivateAccess))
+}
+
+// BuildEKSUpdateKubeconfigCommand returns a shell-safe AWS CLI command for kubeconfig setup.
+func BuildEKSUpdateKubeconfigCommand(clusterName, region, profile, alias string) string {
+	parts := []string{"aws", "eks", "update-kubeconfig", "--name", shellQuote(clusterName)}
+	if strings.TrimSpace(region) != "" {
+		parts = append(parts, "--region", shellQuote(region))
+	}
+	if strings.TrimSpace(profile) != "" {
+		parts = append(parts, "--profile", shellQuote(profile))
+	}
+	if strings.TrimSpace(alias) != "" {
+		parts = append(parts, "--alias", shellQuote(alias))
+	}
+	return strings.Join(parts, " ")
+}
+
+func BuildEKSKubectlSmokeCommand() string {
+	return "kubectl get nodes"
+}
+
+func shellQuote(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
 }
 
 // EKSHealthIssue describes one managed node group health issue.

--- a/internal/services/aws/eks_test.go
+++ b/internal/services/aws/eks_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
@@ -61,10 +62,11 @@ func TestListEKSClusters(t *testing.T) {
 		describeClusterFunc: func(_ context.Context, params *eks.DescribeClusterInput, _ ...func(*eks.Options)) (*eks.DescribeClusterOutput, error) {
 			name := awssdk.ToString(params.Name)
 			return &eks.DescribeClusterOutput{Cluster: &ekstypes.Cluster{
-				Name:    awssdk.String(name),
-				Arn:     awssdk.String("arn:aws:eks:ap-northeast-2:123456789012:cluster/" + name),
-				Version: awssdk.String("1.32"),
-				Status:  ekstypes.ClusterStatusActive,
+				Name:     awssdk.String(name),
+				Arn:      awssdk.String("arn:aws:eks:ap-northeast-2:123456789012:cluster/" + name),
+				Version:  awssdk.String("1.32"),
+				Status:   ekstypes.ClusterStatusActive,
+				Endpoint: awssdk.String("https://" + name + ".eks.amazonaws.com"),
 				ResourcesVpcConfig: &ekstypes.VpcConfigResponse{
 					EndpointPublicAccess:  true,
 					EndpointPrivateAccess: false,
@@ -86,6 +88,29 @@ func TestListEKSClusters(t *testing.T) {
 	}
 	if got := clusters[0].EndpointVisibility(); got != "pub:yes priv:no" {
 		t.Fatalf("unexpected endpoint visibility: %s", got)
+	}
+	if clusters[0].Endpoint == "" {
+		t.Fatal("expected endpoint to be mapped")
+	}
+}
+
+func TestBuildEKSUpdateKubeconfigCommand(t *testing.T) {
+	got := BuildEKSUpdateKubeconfigCommand("prod-eks", "ap-northeast-2", "prod", "prod-context")
+	want := `aws eks update-kubeconfig --name 'prod-eks' --region 'ap-northeast-2' --profile 'prod' --alias 'prod-context'`
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestBuildEKSUpdateKubeconfigCommandQuotesInput(t *testing.T) {
+	got := BuildEKSUpdateKubeconfigCommand(`prod'; rm -rf /`, `$(touch /tmp/pwn)`, "`id`", "$AWS_PROFILE")
+	if strings.Contains(got, `prod'; rm -rf /`) {
+		t.Fatalf("command should quote shell metacharacters safely: %s", got)
+	}
+	for _, want := range []string{`'prod'"'"'; rm -rf /'`, `'$(touch /tmp/pwn)'`, "'`id`'", "'$AWS_PROFILE'"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected command to contain safely quoted %q, got %s", want, got)
+		}
 	}
 }
 


### PR DESCRIPTION
### Summary

Add an EKS access helper so operators can copy kubeconfig and kubectl handoff commands from the selected cluster.

- adds shell-safe `aws eks update-kubeconfig` command generation
- maps cluster endpoint into the EKS cluster model
- adds a cluster-level `u` access helper screen with clipboard copy actions
- uses context+cluster aliases to avoid kubeconfig context collisions
- updates README and docs for the new EKS handoff workflow

### Related Issues

Closes #168

### Review Notes

Reviewed with cli-developer, golang-pro, platform-engineer, and security-reviewer agents. Addressed shell quoting, kubeconfig alias collision, and help/command labeling feedback.

### Validation

- [x] `env -u GOROOT go test ./...`
- [x] `env -u GOROOT make test`
- [x] `env -u GOROOT make build`
- [x] `git diff --check`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed
- [x] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented

No breaking changes.