### PR TITLE
feat: add EC2 related resource browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ checks:
 | Area | Keys |
 |---|---|
 | EC2 SSM | `r` refresh, `Enter` connect |
-| EC2 Instance Browser | `r` refresh, `/` filter, `Enter` detail |
+| EC2 Instance Browser | `r` refresh, `/` filter, `Enter` detail, detail `g/a/t/b/n` opens related security groups/ASG/target groups/load balancers/listeners |
 | Security Groups | `a` add rule, `d` delete rule, `Tab` switch ingress/egress |
 | Reachability Analyzer | Region select first, `←`/`→` or `Tab` change type, `/` filter, `Enter` advance, `Tab`/`↑`/`↓` move config fields, `←`/`→` protocol, `r` rerun |
 | RDS | `s` start, `x` stop, `f` failover, `r` refresh |
@@ -360,7 +360,7 @@ The EKS Browser includes a current-version upgrade readiness view for each selec
 
 The EKS Browser includes an access helper for each selected cluster. Press `u` from the cluster list to review the cluster endpoint, ARN, current region/profile, and copy an `aws eks update-kubeconfig` command or a `kubectl get nodes` smoke-check command for handoff into Kubernetes workflows.
 
-The EC2 Instance Browser lists EC2 instances across available states for the active context and region, separate from the SSM session picker that only lists connectable running instances. The detail screen shows core metadata including instance ID, name tag, state, instance type, AZ, VPC, subnet, private and public IPs, launch time, platform details, IAM profile, and tags.
+The EC2 Instance Browser lists EC2 instances across available states for the active context and region, separate from the SSM session picker that only lists connectable running instances. The detail screen shows core metadata including instance ID, name tag, state, instance type, AZ, VPC, subnet, security groups, private and public IPs, launch time, platform details, IAM profile, and tags. From instance detail, related-resource drill-down screens open attached security groups (`g`), Auto Scaling membership (`a`), registered target groups (`t`), associated load balancers (`b`), and listeners (`n`). Related lists support filtering, refresh, wrap navigation, empty states for missing associations, and inline errors when a relationship cannot be loaded because of API or permission failures.
 
 Bedrock API key management uses the active unic AWS context and IAM service-specific credential APIs for `bedrock.amazonaws.com`. The TUI lists long-term Bedrock API key metadata, opens a detail screen for inspection, defaults new key generation to the current IAM user when that user can be inferred from caller identity, and keeps another-user generation as an explicit option. Creation supports an optional expiration period, where blank or `0` means no expiration, rotates secrets with a one-time result screen, and deletes keys only after typed confirmation. Generated and rotated key values are intentionally copy-only and are not printed to the terminal; on the result screen, `c` copies the key and `e` copies `export AWS_BEARER_TOKEN_BEDROCK=...`.
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.12
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.12
+	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.61.1
 	github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.9
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.56.0
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.68.0
@@ -15,6 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.76.0
 	github.com/aws/aws-sdk-go-v2/service/eks v1.82.1
 	github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.0
+	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.11
 	github.com/aws/aws-sdk-go-v2/service/guardduty v1.75.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.7
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.89.0

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6/go.mod h1:O3h0IK87yXci+kg6flUKzJnWeziQUKciKrLjcatSNcY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 h1:rWyie/PxDRIdhNf4DzRk0lvjVOqFJuNnO8WwaIRVxzQ=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22/go.mod h1:zd/JsJ4P7oGfUhXn1VyLqaRZwPmZwg44Jf2dS84Dm3Y=
+github.com/aws/aws-sdk-go-v2/service/autoscaling v1.61.1 h1:VB+9RFYfUUY8TyL6W025CZToo6h9vC3zeYob7M7/2CE=
+github.com/aws/aws-sdk-go-v2/service/autoscaling v1.61.1/go.mod h1:6q/I1pH386VpPfB6FE62X/MOs6NW/oCsY9FXU33YXOU=
 github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.9 h1:ndjU1c3H1BYJy7fG0Y6Nh/sgD2M/KN+PZaqyCK/Fdfs=
 github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.9/go.mod h1:aH6yXmBYSr1k8uycfqxH5pv4T5N3x2cfFPvrlhyWjAU=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.56.0 h1:ud2A364lLBkhGAC7oYw/1xg9BF4acwJC+qdLykxy83o=
@@ -36,6 +38,8 @@ github.com/aws/aws-sdk-go-v2/service/eks v1.82.1 h1:xTzXiQ8Q6U4ACdMNSCm72zd4Ds7Q
 github.com/aws/aws-sdk-go-v2/service/eks v1.82.1/go.mod h1:jjcGpziR11RTrr3JIgXg/Nn8GSwK3WOz2z1v/RqEBUI=
 github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.0 h1:inluxH5ArTlQNGrFxP7RN5o5DEfP8bRbkPC/408Esgs=
 github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.0/go.mod h1:DxywiXnEB21757xcql9xCqgt8vyTxSB7tVEIOdfKIY8=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.11 h1:0iNKMyO0SXuRfl5FF6TQASAHTXnTYZlQS3/oJSfpEbQ=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.11/go.mod h1:WdVArS8riWgCC1JoIVmKdqfBfj2+cSWAjBU5dEapMhA=
 github.com/aws/aws-sdk-go-v2/service/guardduty v1.75.0 h1:sZA3jpOkwrinRL0B5aZY6npTjDmmBCJRY51dee1Oh7Q=
 github.com/aws/aws-sdk-go-v2/service/guardduty v1.75.0/go.mod h1:lv/r48VXsENinEcSlNRYIERuliYk9dyc919tS+NWqW0=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.7 h1:n9YLiWtX3+6pTLZWvRJmtq5JIB9NA/KFelyCg5fOlTU=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -25,6 +25,8 @@ const (
 	screenInstanceList
 	screenEC2InstanceBrowserList
 	screenEC2InstanceBrowserDetail
+	screenEC2InstanceBrowserRelatedList
+	screenEC2InstanceBrowserRelatedDetail
 	screenVPCList
 	screenSubnetList
 	screenSubnetDetail

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
 	"unic/internal/config"
 	"unic/internal/domain"
@@ -469,6 +470,123 @@ func TestEC2BrowserDetailViewShowsMetadata(t *testing.T) {
 		if !strings.Contains(view, want) {
 			t.Fatalf("expected EC2 detail view to contain %q, got %q", want, view)
 		}
+	}
+}
+
+func TestEC2BrowserDetailViewKeepsRowsSeparateAndClipped(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenEC2InstanceBrowserDetail
+	m.width = 96
+	m.height = 30
+	m.ec2Browser.selected = &awsservice.EC2Instance{
+		InstanceID:   "i-0f237d69dbc37d27f",
+		Name:         "plantadmext-plted_apnortheast2-v075",
+		State:        "running",
+		InstanceType: "t4g.medium",
+		SecurityGroups: []awsservice.EC2InstanceSecurityGroup{
+			{GroupID: "sg-054e6a98f4a972b67", Name: "plantadmext-plted_apnortheast2"},
+			{GroupID: "sg-0844134f83a41ab59", Name: "vpc-00a9c49eb2111f495-querypie-joined-sg-260205124724"},
+		},
+		Tags: map[string]string{
+			"ansible-tags":              "all app plantadmext apps_version plantadmext-release-202604221456-2f31d19c.jar",
+			"aws:autoscaling:groupName": "coreprobeworker-plted_apnortheast2-v020",
+			"aws:ec2launchtemplate:id":  "lt-09f7820d193aba7d1",
+			"branch":                    "main service_jar_file=plantadmext/main/plantadmext-release-202604221456-2f31d19c.jar",
+		},
+	}
+
+	view := stripANSI(m.View())
+	lines := strings.Split(view, "\n")
+	for _, line := range lines {
+		if width := lipgloss.Width(line); width > m.width {
+			t.Fatalf("expected EC2 detail line to fit width %d, got %d: %q", m.width, width, line)
+		}
+	}
+	for _, want := range []string{"Instance ID", "Security Groups", "Tags", "ansible-tags", "branch"} {
+		found := false
+		for _, line := range lines {
+			if strings.Contains(line, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected EC2 detail view to contain separate row %q, got %q", want, view)
+		}
+	}
+	for _, line := range lines {
+		if strings.Contains(line, "oupName") && !strings.Contains(line, "aws:autoscaling:groupName") {
+			t.Fatalf("expected long tag key to stay on one row without wrapping, got fragment row %q", line)
+		}
+	}
+}
+
+func TestEC2BrowserRelatedListNavigationAndFilter(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenEC2InstanceBrowserRelatedList
+	m.ec2Browser.selected = &awsservice.EC2Instance{InstanceID: "i-123", Name: "prod-web"}
+	m.ec2Browser.relatedKind = ec2RelatedTargetGroups
+	m.ec2Browser.relatedItems = []ec2RelatedItem{
+		{
+			title:  "prod-tg HTTP:80 [healthy]",
+			filter: "prod-tg http healthy",
+			details: []detailRow{
+				{"Name", "prod-tg"},
+			},
+		},
+		{
+			title:  "dev-tg HTTP:8080 [unused]",
+			filter: "dev-tg http unused",
+			details: []detailRow{
+				{"Name", "dev-tg"},
+			},
+		},
+	}
+	m.ec2Browser.filteredRelated = m.ec2Browser.relatedItems
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	model := updated.(Model)
+	if model.ec2Browser.relatedIdx != 1 {
+		t.Fatalf("expected related list up from first to wrap to last, got %d", model.ec2Browser.relatedIdx)
+	}
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	model = updated.(Model)
+	for _, ch := range []rune("prod") {
+		updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{ch}})
+		model = updated.(Model)
+	}
+	if len(model.ec2Browser.filteredRelated) != 1 {
+		t.Fatalf("expected 1 filtered related item, got %d", len(model.ec2Browser.filteredRelated))
+	}
+	if model.ec2Browser.filteredRelated[0].title != "prod-tg HTTP:80 [healthy]" {
+		t.Fatalf("unexpected filtered related item: %+v", model.ec2Browser.filteredRelated[0])
+	}
+}
+
+func TestEC2RelationshipsLoadedOpensRequestedRelatedList(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenLoading
+	msg := ec2RelationshipsLoadedMsg{
+		kind: ec2RelatedLoadBalancers,
+		relationships: &awsservice.EC2InstanceRelationships{
+			InstanceID: "i-123",
+			LoadBalancers: []awsservice.EC2LoadBalancer{
+				{Name: "app-lb", DNSName: "app.example.com", Type: "application", State: "active"},
+			},
+		},
+	}
+
+	updated, _ := m.Update(msg)
+	model := updated.(Model)
+	if model.screen != screenEC2InstanceBrowserRelatedList {
+		t.Fatalf("expected related list screen, got %d", model.screen)
+	}
+	if model.ec2Browser.relatedKind != ec2RelatedLoadBalancers {
+		t.Fatalf("expected load balancer related kind, got %q", model.ec2Browser.relatedKind)
+	}
+	if len(model.ec2Browser.relatedItems) != 1 || !strings.Contains(model.ec2Browser.relatedItems[0].title, "app-lb") {
+		t.Fatalf("unexpected related items: %+v", model.ec2Browser.relatedItems)
 	}
 }
 

--- a/internal/app/filter.go
+++ b/internal/app/filter.go
@@ -12,6 +12,7 @@ const (
 	filterServices
 	filterInstances
 	filterEC2BrowserInstances
+	filterEC2BrowserRelated
 	filterSubnetIPs
 	filterRDS
 	filterRoute53Zones

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -136,7 +136,18 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 		return listScreenShortcuts("open the selected instance", "go back to the feature list", true, false)
 	case screenEC2InstanceBrowserDetail:
 		return []helpShortcut{
+			{"g", "Open attached security groups"},
+			{"a", "Open Auto Scaling membership"},
+			{"t", "Open registered target groups"},
+			{"b", "Open associated load balancers"},
+			{"n", "Open associated listeners"},
 			{"q / esc", "Go back to the instance list"},
+		}
+	case screenEC2InstanceBrowserRelatedList:
+		return listScreenShortcuts("open the selected related resource", "go back to the instance detail", true, true)
+	case screenEC2InstanceBrowserRelatedDetail:
+		return []helpShortcut{
+			{"q / esc", "Go back to the related resource list"},
 		}
 	case screenVPCList:
 		return []helpShortcut{
@@ -746,6 +757,10 @@ func (m Model) helpScreenTitle() string {
 		return "EC2 Instance Browser"
 	case screenEC2InstanceBrowserDetail:
 		return "EC2 Instance Detail"
+	case screenEC2InstanceBrowserRelatedList:
+		return "EC2 Related Resources"
+	case screenEC2InstanceBrowserRelatedDetail:
+		return "EC2 Related Resource Detail"
 	case screenVPCList:
 		return "VPC List"
 	case screenSubnetList:

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -15,6 +15,11 @@ type ec2BrowserInstancesLoadedMsg struct {
 	instances []awsservice.EC2Instance
 }
 
+type ec2RelationshipsLoadedMsg struct {
+	relationships *awsservice.EC2InstanceRelationships
+	kind          ec2RelatedKind
+}
+
 type vpcsLoadedMsg struct {
 	vpcs []awsservice.VPC
 }

--- a/internal/app/screen_ec2_browser.go
+++ b/internal/app/screen_ec2_browser.go
@@ -8,19 +8,55 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
 	awsservice "unic/internal/services/aws"
 )
 
 type ec2InstanceBrowserModel struct {
-	instances []awsservice.EC2Instance
-	filtered  []awsservice.EC2Instance
-	idx       int
-	selected  *awsservice.EC2Instance
+	instances       []awsservice.EC2Instance
+	filtered        []awsservice.EC2Instance
+	idx             int
+	selected        *awsservice.EC2Instance
+	relationships   *awsservice.EC2InstanceRelationships
+	relatedKind     ec2RelatedKind
+	relatedItems    []ec2RelatedItem
+	filteredRelated []ec2RelatedItem
+	relatedIdx      int
+	selectedRelated *ec2RelatedItem
 }
 
 func newEC2InstanceBrowserModel() ec2InstanceBrowserModel {
 	return ec2InstanceBrowserModel{}
+}
+
+type ec2RelatedKind string
+
+const (
+	ec2RelatedSecurityGroups ec2RelatedKind = "security groups"
+	ec2RelatedAutoScaling    ec2RelatedKind = "auto scaling"
+	ec2RelatedTargetGroups   ec2RelatedKind = "target groups"
+	ec2RelatedLoadBalancers  ec2RelatedKind = "load balancers"
+	ec2RelatedListeners      ec2RelatedKind = "listeners"
+)
+
+type ec2RelatedItem struct {
+	title   string
+	filter  string
+	details []detailRow
+}
+
+type detailRow struct {
+	label string
+	value string
+}
+
+func (i ec2RelatedItem) DisplayTitle() string {
+	return i.title
+}
+
+func (i ec2RelatedItem) FilterText() string {
+	return strings.ToLower(i.filter)
 }
 
 func (em *ec2InstanceBrowserModel) Start(m *Model) (tea.Model, tea.Cmd) {
@@ -34,7 +70,17 @@ func (em *ec2InstanceBrowserModel) HandleMessage(m *Model, msg tea.Msg) (tea.Mod
 		em.filtered = applyFilter(em.instances, m.filterValue(filterEC2BrowserInstances))
 		em.idx = 0
 		em.selected = nil
+		em.relationships = nil
 		m.screen = screenEC2InstanceBrowserList
+		return *m, nil, true
+	case ec2RelationshipsLoadedMsg:
+		em.relationships = msg.relationships
+		em.relatedKind = msg.kind
+		em.relatedItems = em.buildRelatedItems(msg.kind)
+		em.filteredRelated = applyFilter(em.relatedItems, m.filterValue(filterEC2BrowserRelated))
+		em.relatedIdx = 0
+		em.selectedRelated = nil
+		m.screen = screenEC2InstanceBrowserRelatedList
 		return *m, nil, true
 	}
 	return *m, nil, false
@@ -48,6 +94,12 @@ func (em *ec2InstanceBrowserModel) HandleKey(m *Model, msg tea.KeyMsg) (tea.Mode
 	case screenEC2InstanceBrowserDetail:
 		newM, cmd := em.updateDetail(m, msg)
 		return newM, cmd, true
+	case screenEC2InstanceBrowserRelatedList:
+		newM, cmd := em.updateRelatedList(m, msg)
+		return newM, cmd, true
+	case screenEC2InstanceBrowserRelatedDetail:
+		newM, cmd := em.updateRelatedDetail(m, msg)
+		return newM, cmd, true
 	default:
 		return *m, nil, false
 	}
@@ -59,18 +111,27 @@ func (em ec2InstanceBrowserModel) View(m Model) (string, bool) {
 		return em.viewList(m), true
 	case screenEC2InstanceBrowserDetail:
 		return em.viewDetail(m), true
+	case screenEC2InstanceBrowserRelatedList:
+		return em.viewRelatedList(m), true
+	case screenEC2InstanceBrowserRelatedDetail:
+		return em.viewRelatedDetail(m), true
 	default:
 		return "", false
 	}
 }
 
 func (em *ec2InstanceBrowserModel) ApplyFilter(m *Model, target filterTarget) bool {
-	if target != filterEC2BrowserInstances {
-		return false
+	switch target {
+	case filterEC2BrowserInstances:
+		em.filtered = applyFilter(em.instances, m.filterValue(target))
+		em.idx = 0
+		return true
+	case filterEC2BrowserRelated:
+		em.filteredRelated = applyFilter(em.relatedItems, m.filterValue(target))
+		em.relatedIdx = 0
+		return true
 	}
-	em.filtered = applyFilter(em.instances, m.filterValue(target))
-	em.idx = 0
-	return true
+	return false
 }
 
 func (em *ec2InstanceBrowserModel) updateList(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -107,6 +168,51 @@ func (em *ec2InstanceBrowserModel) updateDetail(m *Model, msg tea.KeyMsg) (tea.M
 	switch msg.String() {
 	case "q", "esc":
 		m.screen = screenEC2InstanceBrowserList
+	case "g":
+		return em.openRelated(m, ec2RelatedSecurityGroups)
+	case "a":
+		return em.openRelated(m, ec2RelatedAutoScaling)
+	case "t":
+		return em.openRelated(m, ec2RelatedTargetGroups)
+	case "b":
+		return em.openRelated(m, ec2RelatedLoadBalancers)
+	case "n":
+		return em.openRelated(m, ec2RelatedListeners)
+	}
+	return *m, nil
+}
+
+func (em *ec2InstanceBrowserModel) updateRelatedList(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if cmd, handled := m.updateSharedFilter(msg, filterEC2BrowserRelated); handled {
+		return *m, cmd
+	}
+	switch msg.String() {
+	case "q", "esc":
+		m.screen = screenEC2InstanceBrowserDetail
+		m.resetFilter(filterEC2BrowserRelated)
+	case "up", "k":
+		em.relatedIdx = previousListIndex(em.relatedIdx, len(em.filteredRelated))
+	case "down", "j":
+		em.relatedIdx = nextListIndex(em.relatedIdx, len(em.filteredRelated))
+	case "/":
+		return *m, m.activateFilter(filterEC2BrowserRelated)
+	case "r":
+		m.resetFilter(filterEC2BrowserRelated)
+		return em.openRelated(m, em.relatedKind)
+	case "enter":
+		if len(em.filteredRelated) > 0 && em.relatedIdx < len(em.filteredRelated) {
+			selected := em.filteredRelated[em.relatedIdx]
+			em.selectedRelated = &selected
+			m.screen = screenEC2InstanceBrowserRelatedDetail
+		}
+	}
+	return *m, nil
+}
+
+func (em *ec2InstanceBrowserModel) updateRelatedDetail(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "esc":
+		m.screen = screenEC2InstanceBrowserRelatedList
 	}
 	return *m, nil
 }
@@ -124,6 +230,28 @@ func (em ec2InstanceBrowserModel) loadInstances(m Model) tea.Cmd {
 			return errMsg{err: err}
 		}
 		return ec2BrowserInstancesLoadedMsg{instances: instances}
+	}
+}
+
+func (em *ec2InstanceBrowserModel) openRelated(m *Model, kind ec2RelatedKind) (tea.Model, tea.Cmd) {
+	if em.selected == nil {
+		return *m, nil
+	}
+	return m.startLoadingWithMessage("Loading EC2 relationships...", []string{em.selected.InstanceID, string(kind)}, em.loadRelationships(*m, *em.selected, kind))
+}
+
+func (em ec2InstanceBrowserModel) loadRelationships(m Model, inst awsservice.EC2Instance, kind ec2RelatedKind) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		relationships, err := repo.DescribeEC2InstanceRelationships(ctx, inst)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		return ec2RelationshipsLoadedMsg{relationships: relationships, kind: kind}
 	}
 }
 
@@ -184,18 +312,19 @@ func (em ec2InstanceBrowserModel) viewDetail(m Model) string {
 	b.WriteString(titleStyle.Render("EC2 Instance Detail"))
 	b.WriteString("\n\n")
 
-	b.WriteString(renderDetailLine("Instance ID", normalStyle.Render(inst.InstanceID)))
-	b.WriteString(renderDetailLine("Name", normalStyle.Render(ec2ValueOrDash(inst.Name))))
-	b.WriteString(renderDetailLine("State", renderEC2InstanceState(inst.State)))
-	b.WriteString(renderDetailLine("Type", normalStyle.Render(ec2ValueOrDash(inst.InstanceType))))
-	b.WriteString(renderDetailLine("AZ", normalStyle.Render(ec2ValueOrDash(inst.AvailabilityZone))))
-	b.WriteString(renderDetailLine("VPC", normalStyle.Render(ec2ValueOrDash(inst.VPCID))))
-	b.WriteString(renderDetailLine("Subnet", normalStyle.Render(ec2ValueOrDash(inst.SubnetID))))
-	b.WriteString(renderDetailLine("Private IP", normalStyle.Render(ec2ValueOrDash(inst.PrivateIP))))
-	b.WriteString(renderDetailLine("Public IP", normalStyle.Render(ec2ValueOrDash(inst.PublicIP))))
-	b.WriteString(renderDetailLine("Launch Time", normalStyle.Render(formatEC2LaunchTime(inst.LaunchTime))))
-	b.WriteString(renderDetailLine("Platform", normalStyle.Render(ec2ValueOrDash(inst.PlatformDetails))))
-	b.WriteString(renderDetailLine("IAM Profile", normalStyle.Render(ec2ValueOrDash(inst.IAMProfile))))
+	b.WriteString(m.renderEC2DetailLine("Instance ID", inst.InstanceID))
+	b.WriteString(m.renderEC2DetailLine("Name", ec2ValueOrDash(inst.Name)))
+	b.WriteString(m.renderEC2StyledDetailLine("State", renderEC2InstanceState(inst.State)))
+	b.WriteString(m.renderEC2DetailLine("Type", ec2ValueOrDash(inst.InstanceType)))
+	b.WriteString(m.renderEC2DetailLine("AZ", ec2ValueOrDash(inst.AvailabilityZone)))
+	b.WriteString(m.renderEC2DetailLine("VPC", ec2ValueOrDash(inst.VPCID)))
+	b.WriteString(m.renderEC2DetailLine("Subnet", ec2ValueOrDash(inst.SubnetID)))
+	b.WriteString(m.renderEC2DetailLine("Private IP", ec2ValueOrDash(inst.PrivateIP)))
+	b.WriteString(m.renderEC2DetailLine("Public IP", ec2ValueOrDash(inst.PublicIP)))
+	b.WriteString(m.renderEC2DetailLine("Security Groups", formatEC2InstanceSecurityGroups(inst.SecurityGroups)))
+	b.WriteString(m.renderEC2DetailLine("Launch Time", formatEC2LaunchTime(inst.LaunchTime)))
+	b.WriteString(m.renderEC2DetailLine("Platform", ec2ValueOrDash(inst.PlatformDetails)))
+	b.WriteString(m.renderEC2DetailLine("IAM Profile", ec2ValueOrDash(inst.IAMProfile)))
 
 	b.WriteString("\n")
 	b.WriteString(titleStyle.Render("Tags"))
@@ -205,13 +334,264 @@ func (em ec2InstanceBrowserModel) viewDetail(m Model) string {
 		b.WriteString("\n")
 	} else {
 		for _, key := range sortedEC2TagKeys(inst.Tags) {
-			b.WriteString(renderDetailLine(key, normalStyle.Render(inst.Tags[key])))
+			b.WriteString(m.renderEC2TagLine(key, inst.Tags[key]))
 		}
 	}
 
 	b.WriteString("\n")
+	b.WriteString(m.renderHelpBar("g: SGs • a: ASG • t: TGs • b: LBs • n: listeners • esc: back • H: home"))
+	return b.String()
+}
+
+func (em ec2InstanceBrowserModel) viewRelatedList(m Model) string {
+	var b strings.Builder
+	var panel strings.Builder
+	title := fmt.Sprintf("EC2 Related %s", ec2RelatedTitle(em.relatedKind))
+	b.WriteString(m.renderStatusBar())
+	b.WriteString(titleStyle.Render(title))
+	b.WriteString("\n")
+	if em.selected != nil {
+		b.WriteString(dimStyle.Render(fmt.Sprintf("  Instance: %s (%s)", ec2ValueOrDash(em.selected.Name), em.selected.InstanceID)))
+		b.WriteString("\n")
+	}
+	b.WriteString(m.renderFilterValue(filterEC2BrowserRelated))
+	b.WriteString("\n\n")
+
+	if errText := em.relationshipErrorText(em.relatedKind); errText != "" {
+		panel.WriteString(errorStyle.Render("  " + errText))
+		panel.WriteString("\n")
+	}
+	if len(em.filteredRelated) == 0 {
+		emptyText := fmt.Sprintf("  No related %s", em.relatedKind)
+		if len(em.relatedItems) > 0 {
+			emptyText = fmt.Sprintf("  No matching %s", em.relatedKind)
+		}
+		panel.WriteString(dimStyle.Render(emptyText))
+		panel.WriteString("\n")
+	} else {
+		visibleLines := max(m.height-11, 5)
+		start := 0
+		if em.relatedIdx >= visibleLines {
+			start = em.relatedIdx - visibleLines + 1
+		}
+		end := min(start+visibleLines, len(em.filteredRelated))
+		for i := start; i < end; i++ {
+			item := em.filteredRelated[i]
+			cursor := "  "
+			style := normalStyle
+			if i == em.relatedIdx {
+				cursor = "> "
+				style = selectedStyle
+			}
+			panel.WriteString(style.Render(cursor + m.renderHighlightedValue(filterEC2BrowserRelated, item.DisplayTitle())))
+			panel.WriteString("\n")
+		}
+		panel.WriteString("\n")
+		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d %s", len(em.filteredRelated), len(em.relatedItems), em.relatedKind)))
+	}
+
+	b.WriteString(m.renderListPanel(panel.String()))
+	b.WriteString("\n\n")
+	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • r: refresh • enter: details • esc: back • H: home"))
+	return b.String()
+}
+
+func (em ec2InstanceBrowserModel) viewRelatedDetail(m Model) string {
+	if em.selectedRelated == nil {
+		return ""
+	}
+	item := em.selectedRelated
+	var b strings.Builder
+	b.WriteString(m.renderStatusBar())
+	b.WriteString(titleStyle.Render(fmt.Sprintf("EC2 Related %s Detail", ec2RelatedTitle(em.relatedKind))))
+	b.WriteString("\n\n")
+	for _, row := range item.details {
+		b.WriteString(m.renderEC2DetailLine(row.label, ec2ValueOrDash(row.value)))
+	}
+	b.WriteString("\n")
 	b.WriteString(m.renderHelpBar("esc: back • H: home"))
 	return b.String()
+}
+
+func (em ec2InstanceBrowserModel) buildRelatedItems(kind ec2RelatedKind) []ec2RelatedItem {
+	if em.relationships == nil {
+		return nil
+	}
+	switch kind {
+	case ec2RelatedSecurityGroups:
+		items := make([]ec2RelatedItem, 0, len(em.relationships.SecurityGroups))
+		for _, sg := range em.relationships.SecurityGroups {
+			items = append(items, ec2RelatedItem{
+				title:  sg.DisplayTitle(),
+				filter: sg.FilterText(),
+				details: []detailRow{
+					{"Group ID", sg.GroupID},
+					{"Name", sg.Name},
+					{"VPC", sg.VPCID},
+					{"Description", sg.Description},
+					{"Ingress Rules", fmt.Sprint(len(sg.IngressRules))},
+					{"Egress Rules", fmt.Sprint(len(sg.EgressRules))},
+				},
+			})
+		}
+		return items
+	case ec2RelatedAutoScaling:
+		if em.relationships.AutoScaling == nil {
+			return nil
+		}
+		asg := *em.relationships.AutoScaling
+		return []ec2RelatedItem{{
+			title:  asg.DisplayTitle(),
+			filter: asg.FilterText(),
+			details: []detailRow{
+				{"Name", asg.Name},
+				{"ARN", asg.ARN},
+				{"Lifecycle", asg.LifecycleState},
+				{"Health", asg.HealthStatus},
+				{"Desired", fmt.Sprint(asg.DesiredCapacity)},
+				{"Min", fmt.Sprint(asg.MinSize)},
+				{"Max", fmt.Sprint(asg.MaxSize)},
+				{"Target Groups", strings.Join(asg.TargetGroupARNs, ", ")},
+				{"Classic LBs", strings.Join(asg.LoadBalancerNames, ", ")},
+			},
+		}}
+	case ec2RelatedTargetGroups:
+		items := make([]ec2RelatedItem, 0, len(em.relationships.TargetGroups))
+		for _, tg := range em.relationships.TargetGroups {
+			items = append(items, ec2RelatedItem{
+				title:  tg.DisplayTitle(),
+				filter: tg.FilterText(),
+				details: []detailRow{
+					{"Name", tg.Name},
+					{"ARN", tg.ARN},
+					{"Protocol", tg.Protocol},
+					{"Port", fmt.Sprint(tg.Port)},
+					{"VPC", tg.VPCID},
+					{"Target Type", tg.TargetType},
+					{"Health", tg.HealthState},
+					{"Health Reason", tg.HealthReason},
+					{"Health Detail", tg.HealthDescription},
+					{"Load Balancers", strings.Join(tg.LoadBalancerARNs, ", ")},
+				},
+			})
+		}
+		return items
+	case ec2RelatedLoadBalancers:
+		items := make([]ec2RelatedItem, 0, len(em.relationships.LoadBalancers))
+		for _, lb := range em.relationships.LoadBalancers {
+			items = append(items, ec2RelatedItem{
+				title:  lb.DisplayTitle(),
+				filter: lb.FilterText(),
+				details: []detailRow{
+					{"Name", lb.Name},
+					{"ARN", lb.ARN},
+					{"DNS", lb.DNSName},
+					{"Type", lb.Type},
+					{"Scheme", lb.Scheme},
+					{"State", lb.State},
+					{"VPC", lb.VPCID},
+				},
+			})
+		}
+		return items
+	case ec2RelatedListeners:
+		items := make([]ec2RelatedItem, 0, len(em.relationships.Listeners))
+		for _, listener := range em.relationships.Listeners {
+			items = append(items, ec2RelatedItem{
+				title:  listener.DisplayTitle(),
+				filter: listener.FilterText(),
+				details: []detailRow{
+					{"Listener ARN", listener.ARN},
+					{"Load Balancer", listener.LoadBalancerName},
+					{"Load Balancer ARN", listener.LoadBalancerARN},
+					{"Protocol", listener.Protocol},
+					{"Port", fmt.Sprint(listener.Port)},
+					{"Rules", fmt.Sprint(listener.RuleCount)},
+					{"Default Action", listener.DefaultAction},
+				},
+			})
+		}
+		return items
+	}
+	return nil
+}
+
+func (m Model) renderEC2DetailLine(label, value string) string {
+	return m.renderEC2DetailLineWithLabelWidth(label, value, ec2DetailLabelWidth)
+}
+
+func (m Model) renderEC2StyledDetailLine(label, renderedValue string) string {
+	return m.renderEC2StyledDetailLineWithLabelWidth(label, renderedValue, ec2DetailLabelWidth)
+}
+
+func (m Model) renderEC2TagLine(label, value string) string {
+	return m.renderEC2DetailLineWithLabelWidth(label, value, ec2TagLabelWidth)
+}
+
+func (m Model) renderEC2DetailLineWithLabelWidth(label, value string, labelWidth int) string {
+	width := m.ec2DetailValueWidth(labelWidth)
+	return m.renderEC2StyledDetailLineWithLabelWidth(label, normalStyle.Render(truncateEC2DetailValue(value, width)), labelWidth)
+}
+
+func (m Model) renderEC2StyledDetailLineWithLabelWidth(label, renderedValue string, labelWidth int) string {
+	label = truncateEC2DetailValue(label, labelWidth)
+	padding := labelWidth - lipgloss.Width(label)
+	if padding < 0 {
+		padding = 0
+	}
+	return "  " + dimStyle.Render(label+strings.Repeat(" ", padding)) + renderedValue + "\n"
+}
+
+func (m Model) ec2DetailValueWidth(labelWidth int) int {
+	if m.width <= 0 {
+		return 88
+	}
+	width := m.width - 2 - labelWidth
+	if width < 24 {
+		return 24
+	}
+	return width
+}
+
+const ec2DetailLabelWidth = 18
+const ec2TagLabelWidth = 30
+
+func truncateEC2DetailValue(value string, width int) string {
+	if width <= 0 || lipgloss.Width(value) <= width {
+		return value
+	}
+	suffix := "..."
+	target := width - lipgloss.Width(suffix)
+	if target <= 0 {
+		return suffix
+	}
+	var b strings.Builder
+	current := 0
+	for _, r := range value {
+		rw := lipgloss.Width(string(r))
+		if current+rw > target {
+			break
+		}
+		b.WriteRune(r)
+		current += rw
+	}
+	return b.String() + suffix
+}
+
+func (em ec2InstanceBrowserModel) relationshipErrorText(kind ec2RelatedKind) string {
+	if em.relationships == nil {
+		return ""
+	}
+	section := string(kind)
+	if kind == ec2RelatedLoadBalancers || kind == ec2RelatedListeners {
+		section = "load balancers/listeners"
+	}
+	for _, relErr := range em.relationships.Errors {
+		if relErr.Section == section && relErr.Err != nil {
+			return relErr.Err.Error()
+		}
+	}
+	return ""
 }
 
 func renderEC2InstanceState(state string) string {
@@ -241,6 +621,38 @@ func sortedEC2TagKeys(tags map[string]string) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+func formatEC2InstanceSecurityGroups(groups []awsservice.EC2InstanceSecurityGroup) string {
+	if len(groups) == 0 {
+		return "-"
+	}
+	parts := make([]string, 0, len(groups))
+	for _, group := range groups {
+		label := group.GroupID
+		if group.Name != "" {
+			label = fmt.Sprintf("%s (%s)", group.Name, group.GroupID)
+		}
+		parts = append(parts, label)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func ec2RelatedTitle(kind ec2RelatedKind) string {
+	switch kind {
+	case ec2RelatedSecurityGroups:
+		return "Security Groups"
+	case ec2RelatedAutoScaling:
+		return "Auto Scaling"
+	case ec2RelatedTargetGroups:
+		return "Target Groups"
+	case ec2RelatedLoadBalancers:
+		return "Load Balancers"
+	case ec2RelatedListeners:
+		return "Listeners"
+	default:
+		return "Resources"
+	}
 }
 
 func ec2ValueOrDash(value string) string {

--- a/internal/services/aws/ec2.go
+++ b/internal/services/aws/ec2.go
@@ -131,6 +131,7 @@ func ec2InstanceFromSDK(inst types.Instance) EC2Instance {
 		PublicIP:        derefString(inst.PublicIpAddress),
 		VPCID:           derefString(inst.VpcId),
 		SubnetID:        derefString(inst.SubnetId),
+		SecurityGroups:  ec2InstanceSecurityGroupsFromSDK(inst.SecurityGroups),
 		InstanceType:    string(inst.InstanceType),
 		State:           ec2InstanceStateName(inst.State),
 		PlatformDetails: derefString(inst.PlatformDetails),
@@ -146,6 +147,28 @@ func ec2InstanceFromSDK(inst types.Instance) EC2Instance {
 		instance.IAMProfile = derefString(inst.IamInstanceProfile.Arn)
 	}
 	return instance
+}
+
+func ec2InstanceSecurityGroupsFromSDK(groups []types.GroupIdentifier) []EC2InstanceSecurityGroup {
+	if len(groups) == 0 {
+		return nil
+	}
+	out := make([]EC2InstanceSecurityGroup, 0, len(groups))
+	for _, group := range groups {
+		out = append(out, EC2InstanceSecurityGroup{
+			GroupID: derefString(group.GroupId),
+			Name:    derefString(group.GroupName),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		left := normalizedSortKey(out[i].Name, out[i].GroupID)
+		right := normalizedSortKey(out[j].Name, out[j].GroupID)
+		if left == right {
+			return out[i].GroupID < out[j].GroupID
+		}
+		return left < right
+	})
+	return out
 }
 
 func ec2InstanceStateName(state *types.InstanceState) string {

--- a/internal/services/aws/ec2_model.go
+++ b/internal/services/aws/ec2_model.go
@@ -17,10 +17,17 @@ type EC2Instance struct {
 	SubnetID         string
 	PrivateIP        string
 	PublicIP         string
+	SecurityGroups   []EC2InstanceSecurityGroup
 	LaunchTime       time.Time
 	PlatformDetails  string
 	IAMProfile       string
 	Tags             map[string]string
+}
+
+// EC2InstanceSecurityGroup identifies a security group attached to an instance.
+type EC2InstanceSecurityGroup struct {
+	GroupID string
+	Name    string
 }
 
 // FilterText returns a lowercase string combining name, instance ID, and IP
@@ -38,6 +45,9 @@ func (i EC2Instance) FilterText() string {
 		i.PublicIP,
 		i.PlatformDetails,
 		i.IAMProfile,
+	}
+	for _, sg := range i.SecurityGroups {
+		parts = append(parts, sg.GroupID, sg.Name)
 	}
 	for key, value := range i.Tags {
 		parts = append(parts, key, value)
@@ -67,4 +77,109 @@ func (i EC2Instance) DisplayTitle() string {
 		state = "-"
 	}
 	return fmt.Sprintf("%s (%s) %s [%s] - %s", name, i.InstanceID, instanceType, state, network)
+}
+
+// EC2InstanceRelationships groups resources connected to an EC2 instance.
+type EC2InstanceRelationships struct {
+	InstanceID     string
+	SecurityGroups []SecurityGroup
+	AutoScaling    *EC2AutoScalingGroup
+	TargetGroups   []EC2TargetGroup
+	LoadBalancers  []EC2LoadBalancer
+	Listeners      []EC2Listener
+	Errors         []EC2RelationshipError
+}
+
+// EC2RelationshipError records a failed relationship lookup without discarding partial results.
+type EC2RelationshipError struct {
+	Section string
+	Err     error
+}
+
+// EC2AutoScalingGroup describes the Auto Scaling group that owns an instance.
+type EC2AutoScalingGroup struct {
+	Name              string
+	ARN               string
+	LifecycleState    string
+	HealthStatus      string
+	DesiredCapacity   int32
+	MinSize           int32
+	MaxSize           int32
+	TargetGroupARNs   []string
+	LoadBalancerNames []string
+}
+
+func (a EC2AutoScalingGroup) DisplayTitle() string {
+	return fmt.Sprintf("%s desired:%d min:%d max:%d [%s/%s]", a.Name, a.DesiredCapacity, a.MinSize, a.MaxSize, valueOrDash(a.LifecycleState), valueOrDash(a.HealthStatus))
+}
+
+func (a EC2AutoScalingGroup) FilterText() string {
+	return strings.ToLower(fmt.Sprintf("%s %s %s %s %v %v", a.Name, a.ARN, a.LifecycleState, a.HealthStatus, a.TargetGroupARNs, a.LoadBalancerNames))
+}
+
+// EC2TargetGroup describes a target group where the instance is registered.
+type EC2TargetGroup struct {
+	ARN               string
+	Name              string
+	Protocol          string
+	Port              int32
+	VPCID             string
+	TargetType        string
+	HealthState       string
+	HealthReason      string
+	HealthDescription string
+	LoadBalancerARNs  []string
+}
+
+func (t EC2TargetGroup) DisplayTitle() string {
+	return fmt.Sprintf("%s %s:%d [%s]", valueOrDash(t.Name), valueOrDash(t.Protocol), t.Port, valueOrDash(t.HealthState))
+}
+
+func (t EC2TargetGroup) FilterText() string {
+	return strings.ToLower(fmt.Sprintf("%s %s %s %s %s %s %v", t.Name, t.ARN, t.Protocol, t.VPCID, t.TargetType, t.HealthState, t.LoadBalancerARNs))
+}
+
+// EC2LoadBalancer describes a load balancer associated through a target group.
+type EC2LoadBalancer struct {
+	ARN     string
+	Name    string
+	DNSName string
+	Type    string
+	Scheme  string
+	State   string
+	VPCID   string
+}
+
+func (l EC2LoadBalancer) DisplayTitle() string {
+	return fmt.Sprintf("%s %s [%s] - %s", valueOrDash(l.Name), valueOrDash(l.Type), valueOrDash(l.State), valueOrDash(l.DNSName))
+}
+
+func (l EC2LoadBalancer) FilterText() string {
+	return strings.ToLower(fmt.Sprintf("%s %s %s %s %s %s %s", l.Name, l.ARN, l.DNSName, l.Type, l.Scheme, l.State, l.VPCID))
+}
+
+// EC2Listener describes a load balancer listener and its rule count.
+type EC2Listener struct {
+	ARN              string
+	LoadBalancerARN  string
+	LoadBalancerName string
+	Protocol         string
+	Port             int32
+	RuleCount        int
+	DefaultAction    string
+}
+
+func (l EC2Listener) DisplayTitle() string {
+	return fmt.Sprintf("%s:%d on %s (%d rules)", valueOrDash(l.Protocol), l.Port, valueOrDash(l.LoadBalancerName), l.RuleCount)
+}
+
+func (l EC2Listener) FilterText() string {
+	return strings.ToLower(fmt.Sprintf("%s %s %s %s %d %s", l.ARN, l.LoadBalancerARN, l.LoadBalancerName, l.Protocol, l.Port, l.DefaultAction))
+}
+
+func valueOrDash(value string) string {
+	if value == "" {
+		return "-"
+	}
+	return value
 }

--- a/internal/services/aws/ec2_relationships.go
+++ b/internal/services/aws/ec2_relationships.go
@@ -36,7 +36,8 @@ func (r *AwsRepository) DescribeEC2InstanceRelationships(ctx context.Context, in
 		result.Errors = append(result.Errors, EC2RelationshipError{Section: "auto scaling", Err: err})
 	}
 
-	targetGroups, err := r.describeRelatedTargetGroups(ctx, inst.InstanceID)
+	targetGroupARNs := relatedAutoScalingTargetGroupARNs(result.AutoScaling)
+	targetGroups, err := r.describeRelatedTargetGroups(ctx, inst.InstanceID, targetGroupARNs)
 	result.TargetGroups = targetGroups
 	if err != nil {
 		result.Errors = append(result.Errors, EC2RelationshipError{Section: "target groups", Err: err})
@@ -144,19 +145,24 @@ func mergeAutoScalingGroupDetails(group *EC2AutoScalingGroup, sdkGroup asgtypes.
 	sort.Strings(group.LoadBalancerNames)
 }
 
-func (r *AwsRepository) describeRelatedTargetGroups(ctx context.Context, instanceID string) ([]EC2TargetGroup, error) {
-	if r.ELBv2Client == nil {
+func relatedAutoScalingTargetGroupARNs(group *EC2AutoScalingGroup) []string {
+	if group == nil || len(group.TargetGroupARNs) == 0 {
+		return nil
+	}
+	return append([]string(nil), group.TargetGroupARNs...)
+}
+
+func (r *AwsRepository) describeRelatedTargetGroups(ctx context.Context, instanceID string, targetGroupARNs []string) ([]EC2TargetGroup, error) {
+	if r.ELBv2Client == nil || len(targetGroupARNs) == 0 {
 		return nil, nil
 	}
 	var groups []EC2TargetGroup
-	var nextToken *string
-	for {
+	for _, chunk := range chunkStrings(targetGroupARNs, 20) {
 		out, err := r.ELBv2Client.DescribeTargetGroups(ctx, &elasticloadbalancingv2.DescribeTargetGroupsInput{
-			PageSize: awssdk.Int32(400),
-			Marker:   nextToken,
+			TargetGroupArns: chunk,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("failed to describe target groups: %w", err)
+			return groups, fmt.Errorf("failed to describe target groups: %w", err)
 		}
 		for _, tg := range out.TargetGroups {
 			if string(tg.TargetType) != "instance" {
@@ -170,10 +176,6 @@ func (r *AwsRepository) describeRelatedTargetGroups(ctx context.Context, instanc
 				groups = append(groups, targetGroupFromSDK(tg, healthState, healthReason, healthDescription))
 			}
 		}
-		if out.NextMarker == nil || awssdk.ToString(out.NextMarker) == "" {
-			break
-		}
-		nextToken = out.NextMarker
 	}
 	sort.Slice(groups, func(i, j int) bool {
 		left := normalizedSortKey(groups[i].Name, groups[i].ARN)
@@ -184,6 +186,21 @@ func (r *AwsRepository) describeRelatedTargetGroups(ctx context.Context, instanc
 		return left < right
 	})
 	return groups, nil
+}
+
+func chunkStrings(values []string, size int) [][]string {
+	if size <= 0 || len(values) == 0 {
+		return nil
+	}
+	chunks := make([][]string, 0, (len(values)+size-1)/size)
+	for start := 0; start < len(values); start += size {
+		end := start + size
+		if end > len(values) {
+			end = len(values)
+		}
+		chunks = append(chunks, values[start:end])
+	}
+	return chunks
 }
 
 func (r *AwsRepository) targetGroupHasInstance(ctx context.Context, targetGroupARN, instanceID string) (bool, string, string, string, error) {

--- a/internal/services/aws/ec2_relationships.go
+++ b/internal/services/aws/ec2_relationships.go
@@ -1,0 +1,366 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	asgtypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+)
+
+// DescribeEC2InstanceRelationships returns resources connected to an EC2 instance.
+// Permission failures are returned in result.Errors so the TUI can render partial data.
+func (r *AwsRepository) DescribeEC2InstanceRelationships(ctx context.Context, inst EC2Instance) (*EC2InstanceRelationships, error) {
+	if inst.InstanceID == "" {
+		return nil, fmt.Errorf("instance ID is required")
+	}
+	result := &EC2InstanceRelationships{InstanceID: inst.InstanceID}
+
+	if len(inst.SecurityGroups) > 0 {
+		securityGroups, err := r.describeRelatedSecurityGroups(ctx, inst.SecurityGroups)
+		if err != nil {
+			result.Errors = append(result.Errors, EC2RelationshipError{Section: "security groups", Err: err})
+		} else {
+			result.SecurityGroups = securityGroups
+		}
+	}
+
+	asg, err := r.describeRelatedAutoScalingGroup(ctx, inst)
+	result.AutoScaling = asg
+	if err != nil {
+		result.Errors = append(result.Errors, EC2RelationshipError{Section: "auto scaling", Err: err})
+	}
+
+	targetGroups, err := r.describeRelatedTargetGroups(ctx, inst.InstanceID)
+	result.TargetGroups = targetGroups
+	if err != nil {
+		result.Errors = append(result.Errors, EC2RelationshipError{Section: "target groups", Err: err})
+	}
+
+	loadBalancers, listeners, err := r.describeRelatedLoadBalancersAndListeners(ctx, targetGroups)
+	if err != nil {
+		result.Errors = append(result.Errors, EC2RelationshipError{Section: "load balancers/listeners", Err: err})
+	}
+	result.LoadBalancers = loadBalancers
+	result.Listeners = listeners
+
+	return result, nil
+}
+
+func (r *AwsRepository) describeRelatedSecurityGroups(ctx context.Context, attached []EC2InstanceSecurityGroup) ([]SecurityGroup, error) {
+	ids := make([]string, 0, len(attached))
+	for _, sg := range attached {
+		if sg.GroupID != "" {
+			ids = append(ids, sg.GroupID)
+		}
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	out, err := r.EC2Client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{GroupIds: ids})
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe instance security groups: %w", err)
+	}
+	groups := make([]SecurityGroup, 0, len(out.SecurityGroups))
+	for _, sg := range out.SecurityGroups {
+		group := SecurityGroup{
+			GroupID:      awssdk.ToString(sg.GroupId),
+			Name:         awssdk.ToString(sg.GroupName),
+			Description:  awssdk.ToString(sg.Description),
+			VPCID:        awssdk.ToString(sg.VpcId),
+			IsDefault:    awssdk.ToString(sg.GroupName) == "default",
+			IngressRules: parseRules(sg.IpPermissions),
+			EgressRules:  parseRules(sg.IpPermissionsEgress),
+		}
+		groups = append(groups, group)
+	}
+	sortSecurityGroups(groups)
+	return groups, nil
+}
+
+func (r *AwsRepository) describeRelatedAutoScalingGroup(ctx context.Context, inst EC2Instance) (*EC2AutoScalingGroup, error) {
+	if r.AutoScalingClient == nil {
+		return autoScalingGroupFromTag(inst), nil
+	}
+	out, err := r.AutoScalingClient.DescribeAutoScalingInstances(ctx, &autoscaling.DescribeAutoScalingInstancesInput{
+		InstanceIds: []string{inst.InstanceID},
+	})
+	if err != nil {
+		if tagGroup := autoScalingGroupFromTag(inst); tagGroup != nil {
+			return tagGroup, fmt.Errorf("failed to describe Auto Scaling instance: %w", err)
+		}
+		return nil, fmt.Errorf("failed to describe Auto Scaling instance: %w", err)
+	}
+	if len(out.AutoScalingInstances) == 0 {
+		return autoScalingGroupFromTag(inst), nil
+	}
+
+	instance := out.AutoScalingInstances[0]
+	group := EC2AutoScalingGroup{
+		Name:           awssdk.ToString(instance.AutoScalingGroupName),
+		LifecycleState: awssdk.ToString(instance.LifecycleState),
+		HealthStatus:   awssdk.ToString(instance.HealthStatus),
+	}
+	if group.Name == "" {
+		return &group, nil
+	}
+
+	groupOut, err := r.AutoScalingClient.DescribeAutoScalingGroups(ctx, &autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []string{group.Name},
+	})
+	if err != nil {
+		return &group, fmt.Errorf("failed to describe Auto Scaling group %s: %w", group.Name, err)
+	}
+	if len(groupOut.AutoScalingGroups) > 0 {
+		mergeAutoScalingGroupDetails(&group, groupOut.AutoScalingGroups[0])
+	}
+	return &group, nil
+}
+
+func autoScalingGroupFromTag(inst EC2Instance) *EC2AutoScalingGroup {
+	if inst.Tags == nil {
+		return nil
+	}
+	name := inst.Tags["aws:autoscaling:groupName"]
+	if name == "" {
+		return nil
+	}
+	return &EC2AutoScalingGroup{Name: name}
+}
+
+func mergeAutoScalingGroupDetails(group *EC2AutoScalingGroup, sdkGroup asgtypes.AutoScalingGroup) {
+	group.ARN = awssdk.ToString(sdkGroup.AutoScalingGroupARN)
+	group.DesiredCapacity = awssdk.ToInt32(sdkGroup.DesiredCapacity)
+	group.MinSize = awssdk.ToInt32(sdkGroup.MinSize)
+	group.MaxSize = awssdk.ToInt32(sdkGroup.MaxSize)
+	group.TargetGroupARNs = append([]string(nil), sdkGroup.TargetGroupARNs...)
+	group.LoadBalancerNames = append([]string(nil), sdkGroup.LoadBalancerNames...)
+	sort.Strings(group.TargetGroupARNs)
+	sort.Strings(group.LoadBalancerNames)
+}
+
+func (r *AwsRepository) describeRelatedTargetGroups(ctx context.Context, instanceID string) ([]EC2TargetGroup, error) {
+	if r.ELBv2Client == nil {
+		return nil, nil
+	}
+	var groups []EC2TargetGroup
+	var nextToken *string
+	for {
+		out, err := r.ELBv2Client.DescribeTargetGroups(ctx, &elasticloadbalancingv2.DescribeTargetGroupsInput{
+			PageSize: awssdk.Int32(400),
+			Marker:   nextToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to describe target groups: %w", err)
+		}
+		for _, tg := range out.TargetGroups {
+			if string(tg.TargetType) != "instance" {
+				continue
+			}
+			matched, healthState, healthReason, healthDescription, err := r.targetGroupHasInstance(ctx, awssdk.ToString(tg.TargetGroupArn), instanceID)
+			if err != nil {
+				return groups, err
+			}
+			if matched {
+				groups = append(groups, targetGroupFromSDK(tg, healthState, healthReason, healthDescription))
+			}
+		}
+		if out.NextMarker == nil || awssdk.ToString(out.NextMarker) == "" {
+			break
+		}
+		nextToken = out.NextMarker
+	}
+	sort.Slice(groups, func(i, j int) bool {
+		left := normalizedSortKey(groups[i].Name, groups[i].ARN)
+		right := normalizedSortKey(groups[j].Name, groups[j].ARN)
+		if left == right {
+			return groups[i].ARN < groups[j].ARN
+		}
+		return left < right
+	})
+	return groups, nil
+}
+
+func (r *AwsRepository) targetGroupHasInstance(ctx context.Context, targetGroupARN, instanceID string) (bool, string, string, string, error) {
+	out, err := r.ELBv2Client.DescribeTargetHealth(ctx, &elasticloadbalancingv2.DescribeTargetHealthInput{
+		TargetGroupArn: awssdk.String(targetGroupARN),
+	})
+	if err != nil {
+		return false, "", "", "", fmt.Errorf("failed to describe target health for %s: %w", targetGroupARN, err)
+	}
+	for _, target := range out.TargetHealthDescriptions {
+		if target.Target == nil || awssdk.ToString(target.Target.Id) != instanceID {
+			continue
+		}
+		if target.TargetHealth == nil {
+			return true, "", "", "", nil
+		}
+		return true,
+			string(target.TargetHealth.State),
+			string(target.TargetHealth.Reason),
+			awssdk.ToString(target.TargetHealth.Description),
+			nil
+	}
+	return false, "", "", "", nil
+}
+
+func targetGroupFromSDK(tg elbtypes.TargetGroup, healthState, healthReason, healthDescription string) EC2TargetGroup {
+	return EC2TargetGroup{
+		ARN:               awssdk.ToString(tg.TargetGroupArn),
+		Name:              awssdk.ToString(tg.TargetGroupName),
+		Protocol:          string(tg.Protocol),
+		Port:              awssdk.ToInt32(tg.Port),
+		VPCID:             awssdk.ToString(tg.VpcId),
+		TargetType:        string(tg.TargetType),
+		HealthState:       healthState,
+		HealthReason:      healthReason,
+		HealthDescription: healthDescription,
+		LoadBalancerARNs:  append([]string(nil), tg.LoadBalancerArns...),
+	}
+}
+
+func (r *AwsRepository) describeRelatedLoadBalancersAndListeners(ctx context.Context, targetGroups []EC2TargetGroup) ([]EC2LoadBalancer, []EC2Listener, error) {
+	if r.ELBv2Client == nil || len(targetGroups) == 0 {
+		return nil, nil, nil
+	}
+	arns := uniqueLoadBalancerARNs(targetGroups)
+	if len(arns) == 0 {
+		return nil, nil, nil
+	}
+	out, err := r.ELBv2Client.DescribeLoadBalancers(ctx, &elasticloadbalancingv2.DescribeLoadBalancersInput{
+		LoadBalancerArns: arns,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to describe load balancers: %w", err)
+	}
+
+	loadBalancers := make([]EC2LoadBalancer, 0, len(out.LoadBalancers))
+	listeners := make([]EC2Listener, 0)
+	for _, lb := range out.LoadBalancers {
+		mapped := loadBalancerFromSDK(lb)
+		loadBalancers = append(loadBalancers, mapped)
+		lbListeners, err := r.describeListenersForLoadBalancer(ctx, mapped)
+		if err != nil {
+			return loadBalancers, listeners, err
+		}
+		listeners = append(listeners, lbListeners...)
+	}
+	sortLoadBalancers(loadBalancers)
+	sortListeners(listeners)
+	return loadBalancers, listeners, nil
+}
+
+func uniqueLoadBalancerARNs(targetGroups []EC2TargetGroup) []string {
+	seen := make(map[string]struct{})
+	for _, tg := range targetGroups {
+		for _, arn := range tg.LoadBalancerARNs {
+			if arn != "" {
+				seen[arn] = struct{}{}
+			}
+		}
+	}
+	arns := make([]string, 0, len(seen))
+	for arn := range seen {
+		arns = append(arns, arn)
+	}
+	sort.Strings(arns)
+	return arns
+}
+
+func loadBalancerFromSDK(lb elbtypes.LoadBalancer) EC2LoadBalancer {
+	state := ""
+	if lb.State != nil {
+		state = string(lb.State.Code)
+	}
+	return EC2LoadBalancer{
+		ARN:     awssdk.ToString(lb.LoadBalancerArn),
+		Name:    awssdk.ToString(lb.LoadBalancerName),
+		DNSName: awssdk.ToString(lb.DNSName),
+		Type:    string(lb.Type),
+		Scheme:  string(lb.Scheme),
+		State:   state,
+		VPCID:   awssdk.ToString(lb.VpcId),
+	}
+}
+
+func (r *AwsRepository) describeListenersForLoadBalancer(ctx context.Context, lb EC2LoadBalancer) ([]EC2Listener, error) {
+	out, err := r.ELBv2Client.DescribeListeners(ctx, &elasticloadbalancingv2.DescribeListenersInput{
+		LoadBalancerArn: awssdk.String(lb.ARN),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe listeners for %s: %w", lb.Name, err)
+	}
+	listeners := make([]EC2Listener, 0, len(out.Listeners))
+	for _, listener := range out.Listeners {
+		ruleCount, err := r.listenerRuleCount(ctx, awssdk.ToString(listener.ListenerArn))
+		if err != nil {
+			return listeners, err
+		}
+		listeners = append(listeners, listenerFromSDK(listener, lb.Name, ruleCount))
+	}
+	return listeners, nil
+}
+
+func (r *AwsRepository) listenerRuleCount(ctx context.Context, listenerARN string) (int, error) {
+	out, err := r.ELBv2Client.DescribeRules(ctx, &elasticloadbalancingv2.DescribeRulesInput{
+		ListenerArn: awssdk.String(listenerARN),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to describe listener rules for %s: %w", listenerARN, err)
+	}
+	return len(out.Rules), nil
+}
+
+func listenerFromSDK(listener elbtypes.Listener, loadBalancerName string, ruleCount int) EC2Listener {
+	defaultAction := ""
+	if len(listener.DefaultActions) > 0 {
+		defaultAction = string(listener.DefaultActions[0].Type)
+	}
+	return EC2Listener{
+		ARN:              awssdk.ToString(listener.ListenerArn),
+		LoadBalancerARN:  awssdk.ToString(listener.LoadBalancerArn),
+		LoadBalancerName: loadBalancerName,
+		Protocol:         string(listener.Protocol),
+		Port:             awssdk.ToInt32(listener.Port),
+		RuleCount:        ruleCount,
+		DefaultAction:    defaultAction,
+	}
+}
+
+func sortSecurityGroups(groups []SecurityGroup) {
+	sort.Slice(groups, func(i, j int) bool {
+		left := normalizedSortKey(groups[i].Name, groups[i].GroupID)
+		right := normalizedSortKey(groups[j].Name, groups[j].GroupID)
+		if left == right {
+			return groups[i].GroupID < groups[j].GroupID
+		}
+		return left < right
+	})
+}
+
+func sortLoadBalancers(loadBalancers []EC2LoadBalancer) {
+	sort.Slice(loadBalancers, func(i, j int) bool {
+		left := normalizedSortKey(loadBalancers[i].Name, loadBalancers[i].ARN)
+		right := normalizedSortKey(loadBalancers[j].Name, loadBalancers[j].ARN)
+		if left == right {
+			return loadBalancers[i].ARN < loadBalancers[j].ARN
+		}
+		return left < right
+	})
+}
+
+func sortListeners(listeners []EC2Listener) {
+	sort.Slice(listeners, func(i, j int) bool {
+		left := normalizedSortKey(listeners[i].LoadBalancerName, listeners[i].Protocol, fmt.Sprint(listeners[i].Port))
+		right := normalizedSortKey(listeners[j].LoadBalancerName, listeners[j].Protocol, fmt.Sprint(listeners[j].Port))
+		if left == right {
+			return listeners[i].ARN < listeners[j].ARN
+		}
+		return left < right
+	})
+}

--- a/internal/services/aws/ec2_relationships_test.go
+++ b/internal/services/aws/ec2_relationships_test.go
@@ -136,7 +136,13 @@ func TestDescribeEC2InstanceRelationshipsMapsMainPaths(t *testing.T) {
 		},
 	}
 	elbMock := &mockELBv2Client{
-		describeTargetGroupsFunc: func(_ context.Context, _ *elasticloadbalancingv2.DescribeTargetGroupsInput, _ ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeTargetGroupsOutput, error) {
+		describeTargetGroupsFunc: func(_ context.Context, params *elasticloadbalancingv2.DescribeTargetGroupsInput, _ ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeTargetGroupsOutput, error) {
+			if len(params.TargetGroupArns) != 1 || params.TargetGroupArns[0] != "arn:tg" {
+				t.Fatalf("expected bounded target group ARN lookup, got %+v", params.TargetGroupArns)
+			}
+			if params.Marker != nil || params.PageSize != nil {
+				t.Fatalf("expected no account-wide target group pagination, got marker=%v pageSize=%v", params.Marker, params.PageSize)
+			}
 			return &elasticloadbalancingv2.DescribeTargetGroupsOutput{
 				TargetGroups: []elbtypes.TargetGroup{
 					{

--- a/internal/services/aws/ec2_relationships_test.go
+++ b/internal/services/aws/ec2_relationships_test.go
@@ -1,0 +1,222 @@
+package aws
+
+import (
+	"context"
+	"testing"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	asgtypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+)
+
+type mockAutoScalingClient struct {
+	describeInstancesFunc func(ctx context.Context, params *autoscaling.DescribeAutoScalingInstancesInput, optFns ...func(*autoscaling.Options)) (*autoscaling.DescribeAutoScalingInstancesOutput, error)
+	describeGroupsFunc    func(ctx context.Context, params *autoscaling.DescribeAutoScalingGroupsInput, optFns ...func(*autoscaling.Options)) (*autoscaling.DescribeAutoScalingGroupsOutput, error)
+}
+
+func (m *mockAutoScalingClient) DescribeAutoScalingInstances(ctx context.Context, params *autoscaling.DescribeAutoScalingInstancesInput, optFns ...func(*autoscaling.Options)) (*autoscaling.DescribeAutoScalingInstancesOutput, error) {
+	if m.describeInstancesFunc != nil {
+		return m.describeInstancesFunc(ctx, params, optFns...)
+	}
+	return &autoscaling.DescribeAutoScalingInstancesOutput{}, nil
+}
+
+func (m *mockAutoScalingClient) DescribeAutoScalingGroups(ctx context.Context, params *autoscaling.DescribeAutoScalingGroupsInput, optFns ...func(*autoscaling.Options)) (*autoscaling.DescribeAutoScalingGroupsOutput, error) {
+	if m.describeGroupsFunc != nil {
+		return m.describeGroupsFunc(ctx, params, optFns...)
+	}
+	return &autoscaling.DescribeAutoScalingGroupsOutput{}, nil
+}
+
+type mockELBv2Client struct {
+	describeTargetGroupsFunc  func(ctx context.Context, params *elasticloadbalancingv2.DescribeTargetGroupsInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeTargetGroupsOutput, error)
+	describeTargetHealthFunc  func(ctx context.Context, params *elasticloadbalancingv2.DescribeTargetHealthInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeTargetHealthOutput, error)
+	describeLoadBalancersFunc func(ctx context.Context, params *elasticloadbalancingv2.DescribeLoadBalancersInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeLoadBalancersOutput, error)
+	describeListenersFunc     func(ctx context.Context, params *elasticloadbalancingv2.DescribeListenersInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeListenersOutput, error)
+	describeRulesFunc         func(ctx context.Context, params *elasticloadbalancingv2.DescribeRulesInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeRulesOutput, error)
+}
+
+func (m *mockELBv2Client) DescribeTargetGroups(ctx context.Context, params *elasticloadbalancingv2.DescribeTargetGroupsInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeTargetGroupsOutput, error) {
+	return m.describeTargetGroupsFunc(ctx, params, optFns...)
+}
+
+func (m *mockELBv2Client) DescribeTargetHealth(ctx context.Context, params *elasticloadbalancingv2.DescribeTargetHealthInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeTargetHealthOutput, error) {
+	return m.describeTargetHealthFunc(ctx, params, optFns...)
+}
+
+func (m *mockELBv2Client) DescribeLoadBalancers(ctx context.Context, params *elasticloadbalancingv2.DescribeLoadBalancersInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeLoadBalancersOutput, error) {
+	return m.describeLoadBalancersFunc(ctx, params, optFns...)
+}
+
+func (m *mockELBv2Client) DescribeListeners(ctx context.Context, params *elasticloadbalancingv2.DescribeListenersInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeListenersOutput, error) {
+	return m.describeListenersFunc(ctx, params, optFns...)
+}
+
+func (m *mockELBv2Client) DescribeRules(ctx context.Context, params *elasticloadbalancingv2.DescribeRulesInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeRulesOutput, error) {
+	return m.describeRulesFunc(ctx, params, optFns...)
+}
+
+func TestDescribeEC2InstanceRelationshipsMapsMainPaths(t *testing.T) {
+	instance := EC2Instance{
+		InstanceID: "i-123",
+		SecurityGroups: []EC2InstanceSecurityGroup{
+			{GroupID: "sg-web", Name: "web"},
+		},
+	}
+	ec2Mock := &mockEC2Client{
+		describeSecurityGroupsFunc: func(_ context.Context, params *ec2.DescribeSecurityGroupsInput, _ ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error) {
+			if len(params.GroupIds) != 1 || params.GroupIds[0] != "sg-web" {
+				t.Fatalf("unexpected security group IDs: %+v", params.GroupIds)
+			}
+			return &ec2.DescribeSecurityGroupsOutput{
+				SecurityGroups: []ec2types.SecurityGroup{
+					{
+						GroupId:     awssdk.String("sg-web"),
+						GroupName:   awssdk.String("web"),
+						Description: awssdk.String("web tier"),
+						VpcId:       awssdk.String("vpc-1"),
+					},
+				},
+			}, nil
+		},
+	}
+	asgMock := &mockAutoScalingClient{
+		describeInstancesFunc: func(_ context.Context, params *autoscaling.DescribeAutoScalingInstancesInput, _ ...func(*autoscaling.Options)) (*autoscaling.DescribeAutoScalingInstancesOutput, error) {
+			if len(params.InstanceIds) != 1 || params.InstanceIds[0] != "i-123" {
+				t.Fatalf("unexpected ASG instance IDs: %+v", params.InstanceIds)
+			}
+			return &autoscaling.DescribeAutoScalingInstancesOutput{
+				AutoScalingInstances: []asgtypes.AutoScalingInstanceDetails{
+					{
+						InstanceId:           awssdk.String("i-123"),
+						AutoScalingGroupName: awssdk.String("app-asg"),
+						LifecycleState:       awssdk.String("InService"),
+						HealthStatus:         awssdk.String("Healthy"),
+						AvailabilityZone:     awssdk.String("us-east-1a"),
+						ProtectedFromScaleIn: awssdk.Bool(false),
+					},
+				},
+			}, nil
+		},
+		describeGroupsFunc: func(_ context.Context, params *autoscaling.DescribeAutoScalingGroupsInput, _ ...func(*autoscaling.Options)) (*autoscaling.DescribeAutoScalingGroupsOutput, error) {
+			if len(params.AutoScalingGroupNames) != 1 || params.AutoScalingGroupNames[0] != "app-asg" {
+				t.Fatalf("unexpected ASG names: %+v", params.AutoScalingGroupNames)
+			}
+			return &autoscaling.DescribeAutoScalingGroupsOutput{
+				AutoScalingGroups: []asgtypes.AutoScalingGroup{
+					{
+						AutoScalingGroupName: awssdk.String("app-asg"),
+						AutoScalingGroupARN:  awssdk.String("arn:asg"),
+						DesiredCapacity:      awssdk.Int32(2),
+						MinSize:              awssdk.Int32(1),
+						MaxSize:              awssdk.Int32(4),
+						TargetGroupARNs:      []string{"arn:tg"},
+					},
+				},
+			}, nil
+		},
+	}
+	elbMock := &mockELBv2Client{
+		describeTargetGroupsFunc: func(_ context.Context, _ *elasticloadbalancingv2.DescribeTargetGroupsInput, _ ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeTargetGroupsOutput, error) {
+			return &elasticloadbalancingv2.DescribeTargetGroupsOutput{
+				TargetGroups: []elbtypes.TargetGroup{
+					{
+						TargetGroupArn:   awssdk.String("arn:tg"),
+						TargetGroupName:  awssdk.String("app-tg"),
+						Protocol:         elbtypes.ProtocolEnumHttp,
+						Port:             awssdk.Int32(80),
+						TargetType:       elbtypes.TargetTypeEnumInstance,
+						VpcId:            awssdk.String("vpc-1"),
+						LoadBalancerArns: []string{"arn:lb"},
+					},
+				},
+			}, nil
+		},
+		describeTargetHealthFunc: func(_ context.Context, params *elasticloadbalancingv2.DescribeTargetHealthInput, _ ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeTargetHealthOutput, error) {
+			if awssdk.ToString(params.TargetGroupArn) != "arn:tg" {
+				t.Fatalf("unexpected target group ARN: %s", awssdk.ToString(params.TargetGroupArn))
+			}
+			return &elasticloadbalancingv2.DescribeTargetHealthOutput{
+				TargetHealthDescriptions: []elbtypes.TargetHealthDescription{
+					{
+						Target:       &elbtypes.TargetDescription{Id: awssdk.String("i-123")},
+						TargetHealth: &elbtypes.TargetHealth{State: elbtypes.TargetHealthStateEnumHealthy},
+					},
+				},
+			}, nil
+		},
+		describeLoadBalancersFunc: func(_ context.Context, params *elasticloadbalancingv2.DescribeLoadBalancersInput, _ ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeLoadBalancersOutput, error) {
+			if len(params.LoadBalancerArns) != 1 || params.LoadBalancerArns[0] != "arn:lb" {
+				t.Fatalf("unexpected load balancer ARNs: %+v", params.LoadBalancerArns)
+			}
+			return &elasticloadbalancingv2.DescribeLoadBalancersOutput{
+				LoadBalancers: []elbtypes.LoadBalancer{
+					{
+						LoadBalancerArn:  awssdk.String("arn:lb"),
+						LoadBalancerName: awssdk.String("app-lb"),
+						DNSName:          awssdk.String("app.example.com"),
+						Type:             elbtypes.LoadBalancerTypeEnumApplication,
+						Scheme:           elbtypes.LoadBalancerSchemeEnumInternetFacing,
+						State:            &elbtypes.LoadBalancerState{Code: elbtypes.LoadBalancerStateEnumActive},
+						VpcId:            awssdk.String("vpc-1"),
+					},
+				},
+			}, nil
+		},
+		describeListenersFunc: func(_ context.Context, params *elasticloadbalancingv2.DescribeListenersInput, _ ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeListenersOutput, error) {
+			if awssdk.ToString(params.LoadBalancerArn) != "arn:lb" {
+				t.Fatalf("unexpected listener LB ARN: %s", awssdk.ToString(params.LoadBalancerArn))
+			}
+			return &elasticloadbalancingv2.DescribeListenersOutput{
+				Listeners: []elbtypes.Listener{
+					{
+						ListenerArn:     awssdk.String("arn:listener"),
+						LoadBalancerArn: awssdk.String("arn:lb"),
+						Protocol:        elbtypes.ProtocolEnumHttp,
+						Port:            awssdk.Int32(80),
+						DefaultActions:  []elbtypes.Action{{Type: elbtypes.ActionTypeEnumForward}},
+					},
+				},
+			}, nil
+		},
+		describeRulesFunc: func(_ context.Context, params *elasticloadbalancingv2.DescribeRulesInput, _ ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeRulesOutput, error) {
+			if awssdk.ToString(params.ListenerArn) != "arn:listener" {
+				t.Fatalf("unexpected listener ARN: %s", awssdk.ToString(params.ListenerArn))
+			}
+			return &elasticloadbalancingv2.DescribeRulesOutput{
+				Rules: []elbtypes.Rule{
+					{Priority: awssdk.String("default")},
+					{Priority: awssdk.String("10")},
+				},
+			}, nil
+		},
+	}
+
+	repo := &AwsRepository{EC2Client: ec2Mock, AutoScalingClient: asgMock, ELBv2Client: elbMock}
+	relationships, err := repo.DescribeEC2InstanceRelationships(context.Background(), instance)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(relationships.Errors) != 0 {
+		t.Fatalf("expected no relationship errors, got %+v", relationships.Errors)
+	}
+	if len(relationships.SecurityGroups) != 1 || relationships.SecurityGroups[0].GroupID != "sg-web" {
+		t.Fatalf("unexpected security groups: %+v", relationships.SecurityGroups)
+	}
+	if relationships.AutoScaling == nil || relationships.AutoScaling.Name != "app-asg" || relationships.AutoScaling.DesiredCapacity != 2 {
+		t.Fatalf("unexpected auto scaling group: %+v", relationships.AutoScaling)
+	}
+	if len(relationships.TargetGroups) != 1 || relationships.TargetGroups[0].HealthState != "healthy" {
+		t.Fatalf("unexpected target groups: %+v", relationships.TargetGroups)
+	}
+	if len(relationships.LoadBalancers) != 1 || relationships.LoadBalancers[0].Name != "app-lb" {
+		t.Fatalf("unexpected load balancers: %+v", relationships.LoadBalancers)
+	}
+	if len(relationships.Listeners) != 1 || relationships.Listeners[0].RuleCount != 2 {
+		t.Fatalf("unexpected listeners: %+v", relationships.Listeners)
+	}
+}

--- a/internal/services/aws/ec2_relationships_test.go
+++ b/internal/services/aws/ec2_relationships_test.go
@@ -41,23 +41,38 @@ type mockELBv2Client struct {
 }
 
 func (m *mockELBv2Client) DescribeTargetGroups(ctx context.Context, params *elasticloadbalancingv2.DescribeTargetGroupsInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeTargetGroupsOutput, error) {
-	return m.describeTargetGroupsFunc(ctx, params, optFns...)
+	if m.describeTargetGroupsFunc != nil {
+		return m.describeTargetGroupsFunc(ctx, params, optFns...)
+	}
+	return &elasticloadbalancingv2.DescribeTargetGroupsOutput{}, nil
 }
 
 func (m *mockELBv2Client) DescribeTargetHealth(ctx context.Context, params *elasticloadbalancingv2.DescribeTargetHealthInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeTargetHealthOutput, error) {
-	return m.describeTargetHealthFunc(ctx, params, optFns...)
+	if m.describeTargetHealthFunc != nil {
+		return m.describeTargetHealthFunc(ctx, params, optFns...)
+	}
+	return &elasticloadbalancingv2.DescribeTargetHealthOutput{}, nil
 }
 
 func (m *mockELBv2Client) DescribeLoadBalancers(ctx context.Context, params *elasticloadbalancingv2.DescribeLoadBalancersInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeLoadBalancersOutput, error) {
-	return m.describeLoadBalancersFunc(ctx, params, optFns...)
+	if m.describeLoadBalancersFunc != nil {
+		return m.describeLoadBalancersFunc(ctx, params, optFns...)
+	}
+	return &elasticloadbalancingv2.DescribeLoadBalancersOutput{}, nil
 }
 
 func (m *mockELBv2Client) DescribeListeners(ctx context.Context, params *elasticloadbalancingv2.DescribeListenersInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeListenersOutput, error) {
-	return m.describeListenersFunc(ctx, params, optFns...)
+	if m.describeListenersFunc != nil {
+		return m.describeListenersFunc(ctx, params, optFns...)
+	}
+	return &elasticloadbalancingv2.DescribeListenersOutput{}, nil
 }
 
 func (m *mockELBv2Client) DescribeRules(ctx context.Context, params *elasticloadbalancingv2.DescribeRulesInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeRulesOutput, error) {
-	return m.describeRulesFunc(ctx, params, optFns...)
+	if m.describeRulesFunc != nil {
+		return m.describeRulesFunc(ctx, params, optFns...)
+	}
+	return &elasticloadbalancingv2.DescribeRulesOutput{}, nil
 }
 
 func TestDescribeEC2InstanceRelationshipsMapsMainPaths(t *testing.T) {

--- a/internal/services/aws/repository.go
+++ b/internal/services/aws/repository.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	"github.com/aws/aws-sdk-go-v2/service/cloudtrail"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
@@ -16,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	"github.com/aws/aws-sdk-go-v2/service/guardduty"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
@@ -75,8 +77,14 @@ var _ ECRClientAPI = (*ecr.Client)(nil)
 // Verify *eks.Client satisfies EKSClientAPI at compile time.
 var _ EKSClientAPI = (*eks.Client)(nil)
 
+// Verify *autoscaling.Client satisfies AutoScalingClientAPI at compile time.
+var _ AutoScalingClientAPI = (*autoscaling.Client)(nil)
+
 // Verify *elasticache.Client satisfies ElastiCacheClientAPI at compile time.
 var _ ElastiCacheClientAPI = (*elasticache.Client)(nil)
+
+// Verify *elasticloadbalancingv2.Client satisfies ELBv2ClientAPI at compile time.
+var _ ELBv2ClientAPI = (*elasticloadbalancingv2.Client)(nil)
 
 // Verify *s3.Client satisfies S3ClientAPI at compile time.
 var _ S3ClientAPI = (*s3.Client)(nil)
@@ -204,6 +212,21 @@ type EKSClientAPI interface {
 	ListInsights(ctx context.Context, params *eks.ListInsightsInput, optFns ...func(*eks.Options)) (*eks.ListInsightsOutput, error)
 }
 
+// AutoScalingClientAPI is the interface for Auto Scaling operations used by AwsRepository.
+type AutoScalingClientAPI interface {
+	DescribeAutoScalingInstances(ctx context.Context, params *autoscaling.DescribeAutoScalingInstancesInput, optFns ...func(*autoscaling.Options)) (*autoscaling.DescribeAutoScalingInstancesOutput, error)
+	DescribeAutoScalingGroups(ctx context.Context, params *autoscaling.DescribeAutoScalingGroupsInput, optFns ...func(*autoscaling.Options)) (*autoscaling.DescribeAutoScalingGroupsOutput, error)
+}
+
+// ELBv2ClientAPI is the interface for Elastic Load Balancing v2 operations used by AwsRepository.
+type ELBv2ClientAPI interface {
+	DescribeTargetGroups(ctx context.Context, params *elasticloadbalancingv2.DescribeTargetGroupsInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeTargetGroupsOutput, error)
+	DescribeTargetHealth(ctx context.Context, params *elasticloadbalancingv2.DescribeTargetHealthInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeTargetHealthOutput, error)
+	DescribeLoadBalancers(ctx context.Context, params *elasticloadbalancingv2.DescribeLoadBalancersInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeLoadBalancersOutput, error)
+	DescribeListeners(ctx context.Context, params *elasticloadbalancingv2.DescribeListenersInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeListenersOutput, error)
+	DescribeRules(ctx context.Context, params *elasticloadbalancingv2.DescribeRulesInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeRulesOutput, error)
+}
+
 // S3ClientAPI is the interface for S3 operations used by AwsRepository.
 type S3ClientAPI interface {
 	ListBuckets(ctx context.Context, params *s3.ListBucketsInput, optFns ...func(*s3.Options)) (*s3.ListBucketsOutput, error)
@@ -279,7 +302,9 @@ type AwsRepository struct {
 	ECSClient            ECSClientAPI
 	ECRClient            ECRClientAPI
 	EKSClient            EKSClientAPI
+	AutoScalingClient    AutoScalingClientAPI
 	ElastiCacheClient    ElastiCacheClientAPI
+	ELBv2Client          ELBv2ClientAPI
 	S3Client             S3ClientAPI
 	LambdaClient         LambdaClientAPI
 	Region               string
@@ -352,7 +377,9 @@ func NewAwsRepository(ctx context.Context, cfg *config.Config) (*AwsRepository, 
 		ECSClient:            ecs.NewFromConfig(awsCfg),
 		ECRClient:            ecr.NewFromConfig(awsCfg),
 		EKSClient:            eks.NewFromConfig(awsCfg),
+		AutoScalingClient:    autoscaling.NewFromConfig(awsCfg),
 		ElastiCacheClient:    elasticache.NewFromConfig(awsCfg),
+		ELBv2Client:          elasticloadbalancingv2.NewFromConfig(awsCfg),
 		S3Client:             s3.NewFromConfig(awsCfg),
 		LambdaClient:         lambda.NewFromConfig(awsCfg),
 		Region:               cfg.Region,


### PR DESCRIPTION
### Summary

Add EC2 instance relationship navigation so operators can drill from instance detail into attached and traffic-path resources.

- maps attached security groups, Auto Scaling membership, registered target groups, load balancers, listeners, and listener rule counts
- adds related-resource list/detail screens from EC2 instance detail with filter, refresh, wrap navigation, empty states, and inline partial-error display
- keeps EC2 detail rows readable for long security group and tag values
- documents the new EC2 related-resource keybindings and behavior

### Related Issues

Closes #174

### Validation

- [x] make test
- [x] make build
- [x] git diff --check

### Checklist

- [x] Scope is focused
- [x] Branch name follows docs/branch-naming-harness.md
- [x] Documentation harness reviewed (docs/documentation-harness.md)
- [x] README updated if user-facing behavior changed
- [x] Relevant docs/ pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented

No breaking changes.