### PR TITLE
fix: fail fast for unknown checklist types

### DIFF
--- a/internal/inspector/checklist.go
+++ b/internal/inspector/checklist.go
@@ -427,9 +427,7 @@ func (r *checklistRunner) runCheck(ctx context.Context, check ChecklistCheck) Ch
 	case ChecklistCheckElastiCacheValkeyBaseline:
 		return r.runBaselineCheck(ctx, check, "ElastiCache for Valkey baseline", runElastiCacheValkeySecurityScan)
 	default:
-		return failedChecklistResult(check, "", "Unsupported checklist type.", []string{
-			fmt.Sprintf("type %q is not supported", check.Type),
-		})
+		panic(fmt.Sprintf("unhandled ChecklistCheckType: %v", check.Type))
 	}
 }
 

--- a/internal/inspector/checklist_test.go
+++ b/internal/inspector/checklist_test.go
@@ -220,6 +220,28 @@ func TestRunChecklistReportsPassAndFailPerCheck(t *testing.T) {
 	}
 }
 
+func TestRunChecklistPanicsForUnhandledCheckType(t *testing.T) {
+	runner := &checklistRunner{}
+
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			t.Fatal("expected panic for unhandled checklist type")
+		}
+		message, ok := recovered.(string)
+		if !ok {
+			t.Fatalf("expected string panic, got %T", recovered)
+		}
+		if !strings.Contains(message, "unhandled ChecklistCheckType: unsupported") {
+			t.Fatalf("unexpected panic: %v", recovered)
+		}
+	}()
+
+	runner.runCheck(context.Background(), ChecklistCheck{
+		Type: ChecklistCheckType("unsupported"),
+	})
+}
+
 func TestRunChecklistRoute53Checks(t *testing.T) {
 	checklistPath := filepath.Join(t.TempDir(), "route53.yaml")
 	content := strings.Join([]string{


### PR DESCRIPTION
### Summary

Adds an explicit panic for unhandled checklist check types so future ChecklistCheckType additions cannot silently return a zero-value result from runCheck(). Removes the previous unsupported-type result fallback and covers the fail-fast behavior with a regression test.

### Related Issues

Closes #203

### Validation

- make test
- make build

### Checklist

- [x] Scope is focused
- [x] Branch name follows docs/branch-naming-harness.md
- [x] Documentation harness reviewed (docs/documentation-harness.md)
- [x] README updated if user-facing behavior changed
- [x] Relevant docs/ pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented