### PR TITLE
fix: reject malformed config mapping on unset

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -384,11 +384,8 @@ func UnsetCurrent(configPath string) error {
 	}
 	mapping := doc.Content[0]
 
-	for i := 0; i < len(mapping.Content)-1; i += 2 {
-		if mapping.Content[i].Value == "current" {
-			mapping.Content = append(mapping.Content[:i], mapping.Content[i+2:]...)
-			break
-		}
+	if err := unsetCurrentFromMapping(mapping); err != nil {
+		return err
 	}
 
 	out, err := yaml.Marshal(&doc)
@@ -398,6 +395,21 @@ func UnsetCurrent(configPath string) error {
 	if err := os.WriteFile(configPath, out, 0644); err != nil {
 		return fmt.Errorf("failed to write config: %w", err)
 	}
+	return nil
+}
+
+func unsetCurrentFromMapping(mapping *yaml.Node) error {
+	if len(mapping.Content)%2 != 0 {
+		return fmt.Errorf("malformed config: YAML mapping has odd number of content nodes")
+	}
+
+	for i := 0; i < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == "current" {
+			mapping.Content = append(mapping.Content[:i], mapping.Content[i+2:]...)
+			break
+		}
+	}
+
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func writeUnicConfig(t *testing.T, dir, content string) string {
@@ -579,6 +581,23 @@ contexts:
 	}
 	if cfg.Region != "ap-northeast-2" {
 		t.Fatalf("expected defaults region to remain, got %q", cfg.Region)
+	}
+}
+
+func TestUnsetCurrentRejectsMalformedMappingNode(t *testing.T) {
+	mapping := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: "current"},
+		},
+	}
+
+	err := unsetCurrentFromMapping(mapping)
+	if err == nil {
+		t.Fatal("expected malformed mapping error")
+	}
+	if err.Error() != "malformed config: YAML mapping has odd number of content nodes" {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
### Summary

Updates UnsetCurrent to reject malformed YAML mapping nodes with odd-length content before mutating the config. This turns the corrupted-config edge case into a clear error instead of silently ignoring malformed trailing nodes or risking key/value indexing assumptions.

Adds regression coverage with a synthetic yaml.Node that exercises the malformed mapping path directly.

### Related Issues

Closes #208

### Validation

- go test ./internal/config
- make test
- make build

### Checklist

- [x] Scope is focused
- [x] Branch name follows docs/branch-naming-harness.md
- [x] Documentation harness reviewed (docs/documentation-harness.md)
- [x] README updated if user-facing behavior changed
- [x] Relevant docs/ pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented