### PR TITLE
fix: keep context selection visible in compact terminals

### DIFF
--- a/internal/app/context_table.go
+++ b/internal/app/context_table.go
@@ -50,7 +50,8 @@ func newContextTable() table.Model {
 }
 
 func contextTableSelectedStyle() lipgloss.Style {
-	return selectedStyle.Copy().
+	base := selectedStyle
+	return base.
 		Bold(true).
 		Foreground(lipgloss.Color("255")).
 		Background(lipgloss.Color("57"))

--- a/internal/app/context_table.go
+++ b/internal/app/context_table.go
@@ -35,9 +35,7 @@ func newContextTable() table.Model {
 	styles := table.DefaultStyles()
 	styles.Header = dimStyle.Copy().Bold(true).Padding(0, 1)
 	styles.Cell = table.DefaultStyles().Cell.Copy()
-	styles.Selected = selectedStyle.Copy().
-		Bold(true).
-		Background(lipgloss.Color("236"))
+	styles.Selected = contextTableSelectedStyle()
 
 	t := table.New(
 		table.WithColumns(contextTableColumns(0)),
@@ -49,6 +47,13 @@ func newContextTable() table.Model {
 	)
 	t.Focus()
 	return t
+}
+
+func contextTableSelectedStyle() lipgloss.Style {
+	return selectedStyle.Copy().
+		Bold(true).
+		Foreground(lipgloss.Color("255")).
+		Background(lipgloss.Color("57"))
 }
 
 func (m *Model) syncContextTable() {

--- a/internal/app/screen_context.go
+++ b/internal/app/screen_context.go
@@ -255,8 +255,10 @@ func (m Model) viewContextPicker() string {
 	b.WriteString(renderDetailLine("Shell env", m.displayShellEnvContext()))
 	b.WriteString("\n\n")
 
-	b.WriteString(m.renderFilterValue(filterContexts))
-	b.WriteString("\n\n")
+	if filter := m.renderFilterValue(filterContexts); filter != "" {
+		b.WriteString(filter)
+		b.WriteString("\n\n")
+	}
 
 	if len(m.ctxList) == 0 {
 		panel.WriteString(normalStyle.Render("  No contexts defined."))

--- a/internal/app/styles_test.go
+++ b/internal/app/styles_test.go
@@ -211,7 +211,8 @@ func TestContextPickerKeepsSelectionVisibleInCompactTerminal(t *testing.T) {
 }
 
 func TestContextTableSelectedStyleUsesHighContrast(t *testing.T) {
-	want := selectedStyle.Copy().
+	base := selectedStyle
+	want := base.
 		Bold(true).
 		Foreground(lipgloss.Color("255")).
 		Background(lipgloss.Color("57"))

--- a/internal/app/styles_test.go
+++ b/internal/app/styles_test.go
@@ -190,3 +190,32 @@ func TestContextPickerPanelDoesNotOverflowHelpBar(t *testing.T) {
 		t.Fatalf("expected help bar below panel border, got border line %d help line %d in %q", borderLine, helpLine, view)
 	}
 }
+
+func TestContextPickerKeepsSelectionVisibleInCompactTerminal(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.width = 80
+	m.height = 14
+
+	updated, _ := m.Update(contextsLoadedMsg{contexts: styleTestContexts()})
+	m = updated.(Model)
+	view := stripANSI(m.View())
+
+	for _, want := range []string{"Select Context", "prod", "q: quit"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected compact context picker to keep %q visible, got %q", want, view)
+		}
+	}
+	if strings.Contains(view, "...") {
+		t.Fatalf("expected compact context picker to fit without middle truncation, got %q", view)
+	}
+}
+
+func TestContextTableSelectedStyleUsesHighContrast(t *testing.T) {
+	want := selectedStyle.Copy().
+		Bold(true).
+		Foreground(lipgloss.Color("255")).
+		Background(lipgloss.Color("57"))
+	if !reflect.DeepEqual(contextTableSelectedStyle(), want) {
+		t.Fatal("expected context table selected style to use high-contrast foreground/background")
+	}
+}


### PR DESCRIPTION
### Summary

Improves the context picker in short IDE terminal panes by removing the empty filter spacer when no filter is active, which lets the picker fit without middle truncation. Also raises the selected-row contrast so the active context remains visually obvious across dark terminal themes.

Adds compact-height rendering coverage to keep the selected context and help bar visible without the truncation marker.

### Related Issues

Closes #212

### Validation

- go test ./internal/app -run 'TestContextPickerKeepsSelectionVisibleInCompactTerminal|TestContextTableSelectedStyleUsesHighContrast|TestContextPickerPanelDoesNotOverflowHelpBar|TestContextPickerUsesBorderedPanelAndHelpBar'
- make test
- make build

### Checklist

- [x] Scope is focused
- [x] Branch name follows docs/branch-naming-harness.md
- [x] Documentation harness reviewed (docs/documentation-harness.md)
- [x] README updated if user-facing behavior changed
- [x] Relevant docs/ pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Context filter UI no longer displays empty newlines when no filter value is present
  * Context picker preserves visibility of key UI elements in compact terminal sizes

* **Style**
  * Selected context items use a higher-contrast appearance for improved readability

* **Tests**
  * Added tests verifying compact-terminal visibility and the high-contrast selected style

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DevopsArtFactory/unic/pull/214)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->