### PR TITLE
chore: configure CodeRabbit reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 ---
 
-language: "ko-KR"
+language: "en-US"
 early_access: false
 
 reviews:
@@ -30,29 +30,35 @@ reviews:
   path_instructions:
     - path: "**/*.go"
       instructions: |
-        Go 리뷰에서는 컴파일 가능성만 보지 말고 nil pointer, context 전달, AWS SDK pagination,
-        error wrapping, deterministic sorting, table/detail rendering 안정성을 우선 확인한다.
-        새 AWS 서비스 작업은 repository interface, model mapping, app integration, tests가 함께
-        갱신됐는지 확인한다.
+        For Go reviews, look beyond compilation and prioritize nil pointer risks,
+        context propagation, AWS SDK pagination, error wrapping, deterministic
+        sorting, and stable table/detail rendering. For new AWS service work,
+        verify that repository interfaces, model mapping, app integration, and
+        tests are updated together.
     - path: "internal/app/**"
       instructions: |
-        Bubble Tea 화면 변경은 message routing, key handling, filter target reset, height-based
-        windowing, help text, back/home navigation이 기존 화면 패턴과 일관적인지 확인한다.
+        For Bubble Tea screen changes, verify message routing, key handling,
+        filter target resets, height-based windowing, help text, and back/home
+        navigation against the existing screen patterns.
     - path: "internal/services/aws/**"
       instructions: |
-        AWS 연동 코드는 SDK client interface mockability, paginator 사용, nil/empty response 처리,
-        AWS pointer conversion, stable list ordering, 사용자에게 전달되는 오류 메시지를 중점 검토한다.
+        For AWS integration code, focus on SDK client interface mockability,
+        paginator usage, nil/empty response handling, AWS pointer conversion,
+        stable list ordering, and user-facing error messages.
     - path: "**/*_test.go"
       instructions: |
-        테스트는 happy path뿐 아니라 API error, mapping edge case, navigation state transition을
-        검증하는지 확인한다. 외부 AWS 호출에 의존하지 않는 mock 기반 테스트를 선호한다.
+        Check that tests cover API errors, mapping edge cases, and navigation
+        state transitions, not only happy paths. Prefer mock-based tests that do
+        not depend on external AWS calls.
     - path: "README.md"
       instructions: |
-        README 변경은 실제 CLI/TUI 동작과 맞는지, Currently Implemented Features, TUI Key Bindings,
-        Usage, Configuration 관련 설명이 코드 변경과 함께 갱신됐는지 확인한다.
+        Verify that README changes match actual CLI/TUI behavior and that
+        Currently Implemented Features, TUI Key Bindings, Usage, and
+        Configuration content stay aligned with code changes.
     - path: "docs/**"
       instructions: |
-        문서는 구현된 동작과 일치해야 하며, 영어/한국어 문서가 같은 의미를 유지하는지 확인한다.
+        Documentation must match implemented behavior. When both English and
+        Korean docs are updated, verify that they preserve the same meaning.
   pre_merge_checks:
     title:
       mode: "warning"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,95 @@
+# yamllint disable rule:line-length
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+---
+
+language: "ko-KR"
+early_access: false
+
+reviews:
+  profile: "assertive"
+  request_changes_workflow: false
+  high_level_summary: true
+  review_status: true
+  review_details: true
+  collapse_walkthrough: false
+  in_progress_fortune: false
+  poem: false
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    drafts: false
+    base_branches:
+      - "main"
+    ignore_title_keywords:
+      - "wip"
+      - "draft"
+  path_filters:
+    - "!dist/**"
+    - "!tmp/**"
+    - "!unic"
+  path_instructions:
+    - path: "**/*.go"
+      instructions: |
+        Go 리뷰에서는 컴파일 가능성만 보지 말고 nil pointer, context 전달, AWS SDK pagination,
+        error wrapping, deterministic sorting, table/detail rendering 안정성을 우선 확인한다.
+        새 AWS 서비스 작업은 repository interface, model mapping, app integration, tests가 함께
+        갱신됐는지 확인한다.
+    - path: "internal/app/**"
+      instructions: |
+        Bubble Tea 화면 변경은 message routing, key handling, filter target reset, height-based
+        windowing, help text, back/home navigation이 기존 화면 패턴과 일관적인지 확인한다.
+    - path: "internal/services/aws/**"
+      instructions: |
+        AWS 연동 코드는 SDK client interface mockability, paginator 사용, nil/empty response 처리,
+        AWS pointer conversion, stable list ordering, 사용자에게 전달되는 오류 메시지를 중점 검토한다.
+    - path: "**/*_test.go"
+      instructions: |
+        테스트는 happy path뿐 아니라 API error, mapping edge case, navigation state transition을
+        검증하는지 확인한다. 외부 AWS 호출에 의존하지 않는 mock 기반 테스트를 선호한다.
+    - path: "README.md"
+      instructions: |
+        README 변경은 실제 CLI/TUI 동작과 맞는지, Currently Implemented Features, TUI Key Bindings,
+        Usage, Configuration 관련 설명이 코드 변경과 함께 갱신됐는지 확인한다.
+    - path: "docs/**"
+      instructions: |
+        문서는 구현된 동작과 일치해야 하며, 영어/한국어 문서가 같은 의미를 유지하는지 확인한다.
+  pre_merge_checks:
+    title:
+      mode: "warning"
+      requirements: "PR title should use a conventional prefix such as feat:, fix:, docs:, chore:, refactor:, or test:."
+    description:
+      mode: "warning"
+    issue_assessment:
+      mode: "warning"
+  tools:
+    golangci-lint:
+      enabled: true
+    markdownlint:
+      enabled: true
+    yamllint:
+      enabled: true
+    actionlint:
+      enabled: true
+    shellcheck:
+      enabled: true
+    checkmake:
+      enabled: true
+    gitleaks:
+      enabled: true
+    osvScanner:
+      enabled: true
+
+chat:
+  art: false
+  auto_reply: true
+
+knowledge_base:
+  opt_out: false
+  web_search:
+    enabled: true
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "AGENTS.md"
+      - "docs/documentation-harness.md"
+      - "docs/branch-naming-harness.md"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -26,7 +26,7 @@ reviews:
   path_filters:
     - "!dist/**"
     - "!tmp/**"
-    - "!unic"
+    - "!unic/**"
   path_instructions:
     - path: "**/*.go"
       instructions: |


### PR DESCRIPTION
## Summary
- Add repository-root .coderabbit.yaml so CodeRabbit can use branch-local review settings
- Enable automatic reviews for PRs targeting main, including incremental reviews on push
- Add unic-specific review guidance for Go, Bubble Tea TUI, AWS service mapping, tests, and docs
- Enable CodeRabbit knowledge-base guidance from AGENTS.md and repo workflow docs

## Validation
- ruby YAML parse for .coderabbit.yaml
- yamllint .coderabbit.yaml

## Related Issues
- N/A: repository workflow configuration only

## Checklist
- [x] CodeRabbit configuration is located at the repository root
- [x] Auto review is enabled for PRs targeting main
- [x] Repo-specific path instructions are configured
- [x] YAML syntax and lint validation passed

Note: this is a repository workflow configuration change without a linked issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **설정**
  * CodeRabbit 통합 구성 추가: 검토 언어를 en-US로 설정하고 `assertive` 검토 프로필 및 상세 리뷰 섹션 활성화.
  * main 브랜치 대상 자동·증분 자동리뷰 활성화, 제목 키워드(wip, draft) 무시.
  * 특정 경로 제외 규칙 및 경로별 맞춤 검토 체크리스트 지정.
  * 다수 정적분석 도구 및 사전 병합 검사(타이틀/설명/이슈)를 경고 수준으로 설정.
  * 채팅 자동응답·지식베이스 검색 활성화, 코드 가이드라인 출처 범위 제한.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DevopsArtFactory/unic/pull/215)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->