### PR TITLE
fix: avoid redundant inspector workflow refresh

### DIFF
--- a/internal/app/screen_inspector.go
+++ b/internal/app/screen_inspector.go
@@ -79,9 +79,7 @@ func (im *inspectorModel) refreshWorkflows() {
 func (im *inspectorModel) ensureWorkflows() {
 	if len(im.workflows) == 0 {
 		im.refreshWorkflows()
-		return
 	}
-	im.refreshWorkflows()
 }
 
 func (im *inspectorModel) Enter(m *Model) {

--- a/internal/app/screen_inspector_test.go
+++ b/internal/app/screen_inspector_test.go
@@ -9,7 +9,6 @@ import (
 
 func TestInspectorEnsureWorkflowsKeepsExistingWorkflows(t *testing.T) {
 	im := inspectorModel{
-		checklistPath: "new-checklist.yaml",
 		workflows: []inspector.Workflow{
 			{
 				Kind:        inspector.WorkflowSecurity,
@@ -35,8 +34,8 @@ func TestInspectorEnsureWorkflowsRefreshesEmptyWorkflows(t *testing.T) {
 
 	im.ensureWorkflows()
 
-	if len(im.workflows) == 0 {
-		t.Fatal("expected empty workflow list to be populated")
+	if len(im.workflows) != 2 {
+		t.Fatalf("expected empty workflow list to be populated with 2 workflows, got %d", len(im.workflows))
 	}
 }
 

--- a/internal/app/screen_inspector_test.go
+++ b/internal/app/screen_inspector_test.go
@@ -3,7 +3,42 @@ package app
 import (
 	"testing"
 	"unicode/utf8"
+
+	"unic/internal/inspector"
 )
+
+func TestInspectorEnsureWorkflowsKeepsExistingWorkflows(t *testing.T) {
+	im := inspectorModel{
+		checklistPath: "new-checklist.yaml",
+		workflows: []inspector.Workflow{
+			{
+				Kind:        inspector.WorkflowSecurity,
+				Title:       "Existing Workflow",
+				Description: "already loaded",
+				Available:   true,
+			},
+		},
+	}
+
+	im.ensureWorkflows()
+
+	if len(im.workflows) != 1 {
+		t.Fatalf("expected existing workflow list to be preserved, got %d workflows", len(im.workflows))
+	}
+	if im.workflows[0].Title != "Existing Workflow" {
+		t.Fatalf("expected existing workflow to be preserved, got %#v", im.workflows[0])
+	}
+}
+
+func TestInspectorEnsureWorkflowsRefreshesEmptyWorkflows(t *testing.T) {
+	im := inspectorModel{}
+
+	im.ensureWorkflows()
+
+	if len(im.workflows) == 0 {
+		t.Fatal("expected empty workflow list to be populated")
+	}
+}
 
 func TestInspectorShortenHandlesUnicodeSafely(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
- Preserve existing Inspector workflows when the workflow list is already populated
- Refresh Inspector workflows only for the empty initial state
- Add regression coverage for both preserved and empty workflow paths

## Validation
- env -u GOROOT go test ./internal/app -run TestInspectorEnsureWorkflows -count=1
- env -u GOROOT make test
- env -u GOROOT make build
- env -u GOROOT go vet ./...
- git diff --check

## Related Issues
- Closes #209

## Checklist
- [x] Issue assigned via @unic-bot
- [x] Fresh worktree from latest main
- [x] Regression tests added
- [x] Standard validation passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow loading efficiency by avoiding unnecessary refresh operations when workflows data is already available.

* **Tests**
  * Added unit tests to verify workflow caching behavior and initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->