### PR TITLE
feat: add all-regions EC2 instance browsing for multi-region contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ contexts:
 | `assume_role` | Assume a role from a base profile | `profile`, `role_arn` |
 | `sso` | Use AWS IAM Identity Center / SSO, reusing a valid AWS CLI SSO cache and prompting for login only when needed | `sso_start_url`, and for concrete contexts `sso_account_id`, `sso_role_name`; `profile` is optional |
 
-The preferred context format separates `auth` from `resources`. `auth.sso_region` controls IAM Identity Center login and role-credential retrieval. `resources.default_region` is selected at startup, and `resources.regions` lists additional regions available from the global `R` region picker. Switching regions reuses the current credentials and recreates only the regional AWS clients.
+The preferred context format separates `auth` from `resources`. `auth.sso_region` controls IAM Identity Center login and role-credential retrieval. `resources.default_region` is selected at startup, and `resources.regions` lists additional regions available from the global `R` region picker. Switching regions reuses the current credentials and recreates only the regional AWS clients. The EC2 Instance Browser can additionally aggregate all configured regions into a single list with `A`.
 
 Legacy flat fields (`auth_type`, `profile`, `region`, `regions`, `sso_region`, and related auth fields) remain supported. A context without a region list behaves as a single-region context, and an omitted SSO region still falls back to its default resource region.
 
@@ -363,7 +363,7 @@ checks:
 | Area | Keys |
 |---|---|
 | EC2 SSM | `r` refresh, `Enter` connect |
-| EC2 Instance Browser | `r` refresh, `/` filter, `Enter` detail, detail `g/a/t/b/n` opens related security groups/ASG/target groups/load balancers/listeners |
+| EC2 Instance Browser | `r` refresh, `/` filter, `A` toggle all-regions scope (multi-region contexts), `Enter` detail, detail `g/a/t/b/n` opens related security groups/ASG/target groups/load balancers/listeners |
 | Security Groups | `a` add rule, `d` delete rule, `Tab` switch ingress/egress |
 | Reachability Analyzer | Region select first, `←`/`→` or `Tab` change type, `/` filter, `Enter` advance, `Tab`/`↑`/`↓` move config fields, `←`/`→` protocol, `r` rerun |
 | RDS | `s` start, `x` stop, `f` failover, `r` refresh |
@@ -397,7 +397,7 @@ The EKS Browser includes a current-version upgrade readiness view for each selec
 
 The EKS Browser includes an access helper for each selected cluster. Press `u` from the cluster list to review the cluster endpoint, ARN, current region/profile, and copy an `aws eks update-kubeconfig` command or a `kubectl get nodes` smoke-check command for handoff into Kubernetes workflows.
 
-The EC2 Instance Browser lists EC2 instances across available states for the active context and region, separate from the SSM session picker that only lists connectable running instances. The detail screen shows core metadata including instance ID, name tag, state, instance type, AZ, VPC, subnet, security groups, private and public IPs, launch time, platform details, IAM profile, and tags. From instance detail, related-resource drill-down screens open attached security groups (`g`), Auto Scaling membership (`a`), registered target groups (`t`), associated load balancers (`b`), and listeners (`n`). Related lists support filtering, refresh, wrap navigation, empty states for missing associations, and inline errors when a relationship cannot be loaded because of API or permission failures.
+The EC2 Instance Browser lists EC2 instances across available states for the active context and region, separate from the SSM session picker that only lists connectable running instances. For multi-region contexts, press `A` to toggle an all-regions scope that lists instances from every configured resource region in one view: rows gain a region tag, per-region API failures are shown inline without hiding other regions' results, and detail and related-resource drill-downs query the selected instance's own region. The detail screen shows core metadata including instance ID, name tag, state, instance type, AZ, VPC, subnet, security groups, private and public IPs, launch time, platform details, IAM profile, and tags. From instance detail, related-resource drill-down screens open attached security groups (`g`), Auto Scaling membership (`a`), registered target groups (`t`), associated load balancers (`b`), and listeners (`n`). Related lists support filtering, refresh, wrap navigation, empty states for missing associations, and inline errors when a relationship cannot be loaded because of API or permission failures.
 
 Bedrock API key management uses the active unic AWS context and IAM service-specific credential APIs for `bedrock.amazonaws.com`. The TUI lists long-term Bedrock API key metadata, opens a detail screen for inspection, defaults new key generation to the current IAM user when that user can be inferred from caller identity, and keeps another-user generation as an explicit option. Creation supports an optional expiration period, where blank or `0` means no expiration, rotates secrets with a one-time result screen, and deletes keys only after typed confirmation. Generated and rotated key values are intentionally copy-only and are not printed to the terminal; on the result screen, `c` copies the key and `e` copies `export AWS_BEARER_TOKEN_BEDROCK=...`.
 

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -193,7 +193,7 @@ Two shapes exist:
    - includes `sso_account_id` and `sso_role_name`
    - can produce direct environment exports and SDK credentials
 
-Contexts can use the structured `auth` and `resources` sections to keep identity independent from resource location. `auth.sso_region` is used for SSO login and `GetRoleCredentials`; `resources.default_region` is the initial resource region, and `resources.regions` defines the regions available to the runtime picker. Switching regions reuses the credentials provider and only recreates regional SDK clients.
+Contexts can use the structured `auth` and `resources` sections to keep identity independent from resource location. `auth.sso_region` is used for SSO login and `GetRoleCredentials`; `resources.default_region` is the initial resource region, and `resources.regions` defines the regions available to the runtime picker. Switching regions reuses the credentials provider and only recreates regional SDK clients. The EC2 Instance Browser can additionally toggle an all-regions scope with `A`, merging instances from every configured region into one list while reporting per-region query failures inline without hiding other regions' results.
 
 `unic context setup` also treats the active resource region as session state. After any required SSO account and role selection, multi-region contexts prompt for a resource region and export it through `AWS_REGION` and `AWS_DEFAULT_REGION`. The persisted default region is unchanged, and single-region contexts skip the picker.
 

--- a/docs/architecture.ko.md
+++ b/docs/architecture.ko.md
@@ -193,7 +193,7 @@ UNIC은 현재 세 가지 인증 모드를 지원한다.
    - `sso_account_id`, `sso_role_name` 포함
    - 직접 env export와 SDK credential 생성 가능
 
-컨텍스트는 구조화된 `auth`와 `resources` 섹션을 사용해 인증 정보와 리소스 위치를 분리할 수 있다. `auth.sso_region`은 SSO 로그인과 `GetRoleCredentials`에 사용하고, `resources.default_region`은 최초 리소스 리전, `resources.regions`는 런타임 리전 선택기에 노출할 리전 목록이다. 리전 전환 시 기존 credential provider를 재사용하고 리전별 SDK client만 다시 생성한다.
+컨텍스트는 구조화된 `auth`와 `resources` 섹션을 사용해 인증 정보와 리소스 위치를 분리할 수 있다. `auth.sso_region`은 SSO 로그인과 `GetRoleCredentials`에 사용하고, `resources.default_region`은 최초 리소스 리전, `resources.regions`는 런타임 리전 선택기에 노출할 리전 목록이다. 리전 전환 시 기존 credential provider를 재사용하고 리전별 SDK client만 다시 생성한다. EC2 Instance Browser는 `A` 키로 all-regions scope를 켜서 구성된 모든 리전의 인스턴스를 한 목록으로 병합해 보여줄 수 있으며, 리전별 조회 실패는 다른 리전 결과를 가리지 않고 인라인으로 표시된다.
 
 `unic context setup`도 활성 리전을 세션 상태로 취급한다. 필요한 SSO account와 role을 선택한 뒤 다중 리전 컨텍스트라면 리소스 리전을 추가로 선택하고, 선택값을 `AWS_REGION`과 `AWS_DEFAULT_REGION`으로 export한다. 저장된 기본 리전은 변경하지 않으며 단일 리전 컨텍스트는 선택 단계를 생략한다.
 

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -148,7 +148,11 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 	case screenInstanceList:
 		return listScreenShortcuts("connect to the selected instance", "go back to the feature list", true, true)
 	case screenEC2InstanceBrowserList:
-		return listScreenShortcuts("open the selected instance", "go back to the feature list", true, false)
+		shortcuts := listScreenShortcuts("open the selected instance", "go back to the feature list", true, false)
+		if m.hasMultipleRegions() {
+			shortcuts = append(shortcuts, helpShortcut{"A", "Toggle all-regions instance scope"})
+		}
+		return shortcuts
 	case screenEC2InstanceBrowserDetail:
 		return []helpShortcut{
 			{"g", "Open attached security groups"},

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -12,7 +12,8 @@ type instancesLoadedMsg struct {
 }
 
 type ec2BrowserInstancesLoadedMsg struct {
-	instances []awsservice.EC2Instance
+	instances    []awsservice.EC2Instance
+	regionErrors []awsservice.EC2RegionError
 }
 
 type ec2RelationshipsLoadedMsg struct {

--- a/internal/app/screen_ec2_browser.go
+++ b/internal/app/screen_ec2_browser.go
@@ -17,6 +17,8 @@ type ec2InstanceBrowserModel struct {
 	instances       []awsservice.EC2Instance
 	filtered        []awsservice.EC2Instance
 	idx             int
+	allRegions      bool
+	regionErrors    []awsservice.EC2RegionError
 	selected        *awsservice.EC2Instance
 	relationships   *awsservice.EC2InstanceRelationships
 	relatedKind     ec2RelatedKind
@@ -67,6 +69,7 @@ func (em *ec2InstanceBrowserModel) HandleMessage(m *Model, msg tea.Msg) (tea.Mod
 	switch msg := msg.(type) {
 	case ec2BrowserInstancesLoadedMsg:
 		em.instances = msg.instances
+		em.regionErrors = msg.regionErrors
 		em.filtered = applyFilter(em.instances, m.filterValue(filterEC2BrowserInstances))
 		em.idx = 0
 		em.selected = nil
@@ -154,6 +157,12 @@ func (em *ec2InstanceBrowserModel) updateList(m *Model, msg tea.KeyMsg) (tea.Mod
 	case "r":
 		m.resetFilter(filterEC2BrowserInstances)
 		return m.startLoading(em.loadInstances(*m))
+	case "A":
+		if m.hasMultipleRegions() {
+			em.allRegions = !em.allRegions
+			m.resetFilter(filterEC2BrowserInstances)
+			return m.startLoading(em.loadInstances(*m))
+		}
 	case "enter":
 		if len(em.filtered) > 0 && em.idx < len(em.filtered) {
 			selected := em.filtered[em.idx]
@@ -218,11 +227,21 @@ func (em *ec2InstanceBrowserModel) updateRelatedDetail(m *Model, msg tea.KeyMsg)
 }
 
 func (em ec2InstanceBrowserModel) loadInstances(m Model) tea.Cmd {
+	allRegions := em.allRegions && m.hasMultipleRegions()
+	var regions []string
+	if m.cfg != nil {
+		regions = append(regions, m.cfg.Regions...)
+	}
 	return func() tea.Msg {
 		ctx := context.Background()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}
+		}
+
+		if allRegions {
+			instances, regionErrors := repo.ListEC2InstancesAcrossRegions(ctx, regions)
+			return ec2BrowserInstancesLoadedMsg{instances: instances, regionErrors: regionErrors}
 		}
 
 		instances, err := repo.ListEC2Instances(ctx)
@@ -247,6 +266,9 @@ func (em ec2InstanceBrowserModel) loadRelationships(m Model, inst awsservice.EC2
 		if err != nil {
 			return errMsg{err: err}
 		}
+		if inst.Region != "" && inst.Region != repo.Region {
+			repo = repo.ForRegion(inst.Region)
+		}
 		relationships, err := repo.DescribeEC2InstanceRelationships(ctx, inst)
 		if err != nil {
 			return errMsg{err: err}
@@ -259,12 +281,20 @@ func (em ec2InstanceBrowserModel) viewList(m Model) string {
 	var b strings.Builder
 	var panel strings.Builder
 	b.WriteString(m.renderStatusBar())
-	b.WriteString(titleStyle.Render("EC2 Instance Browser"))
+	title := "EC2 Instance Browser"
+	if em.allRegions {
+		title += " (all regions)"
+	}
+	b.WriteString(titleStyle.Render(title))
 	b.WriteString("\n")
 
 	b.WriteString(m.renderFilterValue(filterEC2BrowserInstances))
 	b.WriteString("\n\n")
 
+	for _, regionErr := range em.regionErrors {
+		panel.WriteString(errorStyle.Render(fmt.Sprintf("  %s: %v", regionErr.Region, regionErr.Err)))
+		panel.WriteString("\n")
+	}
 	if len(em.filtered) == 0 {
 		emptyText := "  No EC2 instances found"
 		if len(em.instances) > 0 {
@@ -288,7 +318,11 @@ func (em ec2InstanceBrowserModel) viewList(m Model) string {
 				cursor = "> "
 				style = selectedStyle
 			}
-			panel.WriteString(style.Render(cursor + m.renderHighlightedValue(filterEC2BrowserInstances, inst.DisplayTitle())))
+			row := inst.DisplayTitle()
+			if em.allRegions {
+				row = fmt.Sprintf("[%s] %s", inst.Region, row)
+			}
+			panel.WriteString(style.Render(cursor + m.renderHighlightedValue(filterEC2BrowserInstances, row)))
 			panel.WriteString("\n")
 		}
 
@@ -298,7 +332,11 @@ func (em ec2InstanceBrowserModel) viewList(m Model) string {
 
 	b.WriteString(m.renderListPanel(panel.String()))
 	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • r: refresh • enter: details • esc: back • H: home"))
+	helpText := "↑/↓: navigate • /: filter • r: refresh • enter: details • esc: back • H: home"
+	if m.hasMultipleRegions() {
+		helpText = "↑/↓: navigate • /: filter • r: refresh • A: all regions • enter: details • esc: back • H: home"
+	}
+	b.WriteString(m.renderHelpBar(helpText))
 	return b.String()
 }
 
@@ -316,6 +354,7 @@ func (em ec2InstanceBrowserModel) viewDetail(m Model) string {
 	b.WriteString(m.renderEC2DetailLine("Name", ec2ValueOrDash(inst.Name)))
 	b.WriteString(m.renderEC2StyledDetailLine("State", renderEC2InstanceState(inst.State)))
 	b.WriteString(m.renderEC2DetailLine("Type", ec2ValueOrDash(inst.InstanceType)))
+	b.WriteString(m.renderEC2DetailLine("Region", ec2ValueOrDash(inst.Region)))
 	b.WriteString(m.renderEC2DetailLine("AZ", ec2ValueOrDash(inst.AvailabilityZone)))
 	b.WriteString(m.renderEC2DetailLine("VPC", ec2ValueOrDash(inst.VPCID)))
 	b.WriteString(m.renderEC2DetailLine("Subnet", ec2ValueOrDash(inst.SubnetID)))

--- a/internal/app/screen_ec2_browser.go
+++ b/internal/app/screen_ec2_browser.go
@@ -281,8 +281,11 @@ func (em ec2InstanceBrowserModel) viewList(m Model) string {
 	var b strings.Builder
 	var panel strings.Builder
 	b.WriteString(m.renderStatusBar())
+	// allRegions can outlive a switch to a single-region context; render from
+	// the effective scope that loadInstances actually uses.
+	allRegions := em.allRegions && m.hasMultipleRegions()
 	title := "EC2 Instance Browser"
-	if em.allRegions {
+	if allRegions {
 		title += " (all regions)"
 	}
 	b.WriteString(titleStyle.Render(title))
@@ -319,7 +322,7 @@ func (em ec2InstanceBrowserModel) viewList(m Model) string {
 				style = selectedStyle
 			}
 			row := inst.DisplayTitle()
-			if em.allRegions {
+			if allRegions {
 				row = fmt.Sprintf("[%s] %s", inst.Region, row)
 			}
 			panel.WriteString(style.Render(cursor + m.renderHighlightedValue(filterEC2BrowserInstances, row)))

--- a/internal/app/screen_ec2_browser_test.go
+++ b/internal/app/screen_ec2_browser_test.go
@@ -1,0 +1,84 @@
+package app
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"unic/internal/config"
+	awsservice "unic/internal/services/aws"
+)
+
+func keyA() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}}
+}
+
+func TestEC2BrowserAllRegionsToggleStartsReload(t *testing.T) {
+	m := Model{
+		cfg:    &config.Config{Region: "us-east-1", Regions: []string{"us-east-1", "eu-west-1"}},
+		screen: screenEC2InstanceBrowserList,
+	}
+
+	newM, cmd := m.ec2Browser.updateList(&m, keyA())
+	updated := newM.(Model)
+	if !updated.ec2Browser.allRegions {
+		t.Fatal("expected all-regions scope to be enabled")
+	}
+	if updated.screen != screenLoading {
+		t.Fatalf("expected loading screen after toggle, got %v", updated.screen)
+	}
+	if cmd == nil {
+		t.Fatal("expected reload command after toggle")
+	}
+}
+
+func TestEC2BrowserAllRegionsToggleIgnoredForSingleRegion(t *testing.T) {
+	m := Model{
+		cfg:    &config.Config{Region: "us-east-1", Regions: []string{"us-east-1"}},
+		screen: screenEC2InstanceBrowserList,
+	}
+
+	_, cmd := m.ec2Browser.updateList(&m, keyA())
+	if m.ec2Browser.allRegions {
+		t.Fatal("expected all-regions scope to stay disabled for single-region contexts")
+	}
+	if m.screen != screenEC2InstanceBrowserList || cmd != nil {
+		t.Fatalf("expected no-op for single-region contexts, got screen %v", m.screen)
+	}
+}
+
+func TestEC2BrowserStoresRegionErrorsFromLoadedMsg(t *testing.T) {
+	m := Model{
+		cfg:    &config.Config{Region: "us-east-1", Regions: []string{"us-east-1", "eu-west-1"}},
+		screen: screenLoading,
+	}
+	m.ec2Browser.allRegions = true
+
+	msg := ec2BrowserInstancesLoadedMsg{
+		instances: []awsservice.EC2Instance{
+			{InstanceID: "i-east", Region: "us-east-1"},
+		},
+		regionErrors: []awsservice.EC2RegionError{
+			{Region: "eu-west-1", Err: errors.New("access denied")},
+		},
+	}
+	_, _, handled := m.ec2Browser.HandleMessage(&m, msg)
+	if !handled {
+		t.Fatal("expected instances-loaded message to be handled")
+	}
+	if m.screen != screenEC2InstanceBrowserList {
+		t.Fatalf("expected instance list screen, got %v", m.screen)
+	}
+	if len(m.ec2Browser.regionErrors) != 1 || m.ec2Browser.regionErrors[0].Region != "eu-west-1" {
+		t.Fatalf("expected eu-west-1 region error to be stored, got %+v", m.ec2Browser.regionErrors)
+	}
+
+	view := m.ec2Browser.viewList(m)
+	for _, want := range []string{"(all regions)", "[us-east-1]", "eu-west-1: access denied"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected view to contain %q, got:\n%s", want, view)
+		}
+	}
+}

--- a/internal/app/screen_ec2_browser_test.go
+++ b/internal/app/screen_ec2_browser_test.go
@@ -82,3 +82,16 @@ func TestEC2BrowserStoresRegionErrorsFromLoadedMsg(t *testing.T) {
 		}
 	}
 }
+
+func TestEC2BrowserAllRegionsScopeIgnoredAfterSwitchToSingleRegion(t *testing.T) {
+	m := Model{
+		cfg:    &config.Config{Region: "us-east-1", Regions: []string{"us-east-1"}},
+		screen: screenEC2InstanceBrowserList,
+	}
+	m.ec2Browser.allRegions = true // left over from a previous multi-region context
+
+	view := m.ec2Browser.viewList(m)
+	if strings.Contains(view, "(all regions)") {
+		t.Fatalf("expected single-region context to render without all-regions title, got:\n%s", view)
+	}
+}

--- a/internal/app/screen_region.go
+++ b/internal/app/screen_region.go
@@ -12,8 +12,14 @@ import (
 
 var newAwsRepositoryForRegionFn = awsservice.NewAwsRepository
 
+// hasMultipleRegions reports whether the active context exposes more than one
+// resource region.
+func (m Model) hasMultipleRegions() bool {
+	return m.cfg != nil && len(m.cfg.Regions) > 1
+}
+
 func (m Model) canSwitchResourceRegion() bool {
-	if m.cfg == nil || len(m.cfg.Regions) <= 1 || m.filterTI.Focused() || m.isTextEntryScreen() {
+	if !m.hasMultipleRegions() || m.filterTI.Focused() || m.isTextEntryScreen() {
 		return false
 	}
 	switch m.screen {

--- a/internal/services/aws/ec2.go
+++ b/internal/services/aws/ec2.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sort"
 	"strings"
+	"sync"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -75,13 +76,66 @@ func (r *AwsRepository) ListEC2Instances(ctx context.Context) ([]EC2Instance, er
 
 		for _, reservation := range page.Reservations {
 			for _, inst := range reservation.Instances {
-				instances = append(instances, ec2InstanceFromSDK(inst))
+				instance := ec2InstanceFromSDK(inst)
+				instance.Region = r.Region
+				instances = append(instances, instance)
 			}
 		}
 	}
 
 	sortEC2Instances(instances)
 	return instances, nil
+}
+
+// EC2RegionError reports a per-region listing failure during an all-regions scan.
+type EC2RegionError struct {
+	Region string
+	Err    error
+}
+
+// ec2RepoForRegion is a test seam: ForRegion builds real SDK clients, so tests
+// substitute regional repositories with mocked clients here.
+var ec2RepoForRegion = func(r *AwsRepository, region string) *AwsRepository {
+	return r.ForRegion(region)
+}
+
+// ListEC2InstancesAcrossRegions fans ListEC2Instances out over the given regions
+// concurrently, reusing the repository credentials. Per-region failures are
+// returned alongside the successful rows instead of failing the whole scan.
+func (r *AwsRepository) ListEC2InstancesAcrossRegions(ctx context.Context, regions []string) ([]EC2Instance, []EC2RegionError) {
+	uniclog.Debug("aws", "ListEC2InstancesAcrossRegions called", "regions", regions)
+
+	type regionResult struct {
+		instances []EC2Instance
+		err       error
+	}
+	results := make([]regionResult, len(regions))
+	var wg sync.WaitGroup
+	for i, region := range regions {
+		wg.Add(1)
+		go func(i int, region string) {
+			defer wg.Done()
+			repo := r
+			if region != r.Region {
+				repo = ec2RepoForRegion(r, region)
+			}
+			instances, err := repo.ListEC2Instances(ctx)
+			results[i] = regionResult{instances: instances, err: err}
+		}(i, region)
+	}
+	wg.Wait()
+
+	var instances []EC2Instance
+	var regionErrors []EC2RegionError
+	for i, result := range results {
+		if result.err != nil {
+			regionErrors = append(regionErrors, EC2RegionError{Region: regions[i], Err: result.err})
+			continue
+		}
+		instances = append(instances, result.instances...)
+	}
+	sortEC2Instances(instances)
+	return instances, regionErrors
 }
 
 // listSSMManagedInstanceIDs returns instance IDs that SSM reports as online.

--- a/internal/services/aws/ec2_model.go
+++ b/internal/services/aws/ec2_model.go
@@ -13,6 +13,7 @@ type EC2Instance struct {
 	State            string
 	InstanceType     string
 	AvailabilityZone string
+	Region           string
 	VPCID            string
 	SubnetID         string
 	PrivateIP        string
@@ -39,6 +40,7 @@ func (i EC2Instance) FilterText() string {
 		i.State,
 		i.InstanceType,
 		i.AvailabilityZone,
+		i.Region,
 		i.VPCID,
 		i.SubnetID,
 		i.PrivateIP,

--- a/internal/services/aws/ec2_test.go
+++ b/internal/services/aws/ec2_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -301,3 +302,74 @@ func containsSubstr(s, sub string) bool {
 	}
 	return false
 }
+
+func regionEC2Mock(region, instanceID string) *mockEC2Client {
+	return &mockEC2Client{
+		describeInstancesFunc: func(_ context.Context, _ *ec2.DescribeInstancesInput, _ ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+			return &ec2.DescribeInstancesOutput{
+				Reservations: []types.Reservation{
+					{
+						Instances: []types.Instance{
+							{
+								InstanceId: aws.String(instanceID),
+								Tags:       []types.Tag{{Key: aws.String("Name"), Value: aws.String(region + "-web")}},
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+}
+
+func TestListEC2InstancesAcrossRegions_MergesAndTagsRegions(t *testing.T) {
+	base := &AwsRepository{Region: "us-east-1", EC2Client: regionEC2Mock("us-east-1", "i-east")}
+	west := &AwsRepository{Region: "eu-west-1", EC2Client: regionEC2Mock("eu-west-1", "i-west")}
+
+	original := ec2RepoForRegion
+	defer func() { ec2RepoForRegion = original }()
+	ec2RepoForRegion = func(r *AwsRepository, region string) *AwsRepository {
+		if region != "eu-west-1" {
+			t.Fatalf("unexpected region requested: %s", region)
+		}
+		return west
+	}
+
+	instances, regionErrors := base.ListEC2InstancesAcrossRegions(context.Background(), []string{"us-east-1", "eu-west-1"})
+	if len(regionErrors) != 0 {
+		t.Fatalf("unexpected region errors: %+v", regionErrors)
+	}
+	if len(instances) != 2 {
+		t.Fatalf("expected 2 instances, got %d", len(instances))
+	}
+	regions := map[string]string{}
+	for _, inst := range instances {
+		regions[inst.InstanceID] = inst.Region
+	}
+	if regions["i-east"] != "us-east-1" || regions["i-west"] != "eu-west-1" {
+		t.Fatalf("expected per-region tagging, got %+v", regions)
+	}
+}
+
+func TestListEC2InstancesAcrossRegions_KeepsPartialResultsOnFailure(t *testing.T) {
+	base := &AwsRepository{Region: "us-east-1", EC2Client: regionEC2Mock("us-east-1", "i-east")}
+	broken := &AwsRepository{Region: "eu-west-1", EC2Client: &mockEC2Client{
+		describeInstancesFunc: func(_ context.Context, _ *ec2.DescribeInstancesInput, _ ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+			return nil, errRegionDown
+		},
+	}}
+
+	original := ec2RepoForRegion
+	defer func() { ec2RepoForRegion = original }()
+	ec2RepoForRegion = func(_ *AwsRepository, _ string) *AwsRepository { return broken }
+
+	instances, regionErrors := base.ListEC2InstancesAcrossRegions(context.Background(), []string{"us-east-1", "eu-west-1"})
+	if len(instances) != 1 || instances[0].InstanceID != "i-east" {
+		t.Fatalf("expected the healthy region's instances to survive, got %+v", instances)
+	}
+	if len(regionErrors) != 1 || regionErrors[0].Region != "eu-west-1" || regionErrors[0].Err != errRegionDown {
+		t.Fatalf("expected one eu-west-1 error, got %+v", regionErrors)
+	}
+}
+
+var errRegionDown = errors.New("region down")


### PR DESCRIPTION
## Summary

Implements #237: for contexts with multiple configured resource regions, the EC2 Instance Browser can now aggregate every region into one list instead of browsing a single active region at a time.

- `A` in the EC2 Instance Browser toggles the all-regions scope (no-op and hidden from help for single-region contexts).
- `ListEC2InstancesAcrossRegions` fans `ListEC2Instances` out concurrently over the context's configured regions, reusing existing credentials via `ForRegion`.
- Per-region API failures render inline in the list without hiding other regions' results.
- Rows gain a `[region]` tag in all-regions mode, instance detail shows a Region line, and region is part of the filter text.
- Detail and related-resource drill-downs (`g/a/t/b/n`) query the selected instance's own region rather than the globally active one.

## Testing

- `go test ./...` passes, including new coverage for the cross-region fan-out (merge + per-region tagging, partial failure) and the browser toggle/scope/view behavior.
- `make build` passes.

## Docs

- README: key bindings, EC2 Instance Browser feature description, and multi-region configuration notes updated.
- `docs/architecture.en.md` / `docs/architecture.ko.md`: region model sections mention the all-regions scope.

Closes #237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * EC2 Instance Browser now supports viewing instances across all configured regions with the `A` shortcut.
  * Cross-region results show each instance’s region, while related resources are queried in the correct region.
  * Regional query failures appear inline without hiding successful results.
  * The all-regions option is available only when multiple regions are configured.

* **Documentation**
  * Updated English and Korean documentation with multi-region browsing, navigation, and error-handling details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
