### PR TITLE
feat: support MFA-protected assume_role contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ contexts:
     auth_type: assume_role
     role_arn: arn:aws:iam::123456789012:role/Admin
     external_id: optional-external-id
+    mfa_serial: arn:aws:iam::123456789012:mfa/my-user   # optional: MFA-protected roles
 
   - name: local-dev
     profile: local-dev
@@ -209,7 +210,7 @@ contexts:
 |---|---|---|
 | `credential` | Use shared AWS profile credentials | `profile` |
 | `console_login` | Run `aws login` during `unic context setup`, then use the resulting profile-backed console credentials | `profile` |
-| `assume_role` | Assume a role from a base profile | `profile`, `role_arn` |
+| `assume_role` | Assume a role from a base profile, optionally with MFA | `profile`, `role_arn`; optional `mfa_serial` |
 | `sso` | Use AWS IAM Identity Center / SSO, reusing a valid AWS CLI SSO cache and prompting for login only when needed | `sso_start_url`, and for concrete contexts `sso_account_id`, `sso_role_name`; `profile` is optional |
 
 The preferred context format separates `auth` from `resources`. `auth.sso_region` controls IAM Identity Center login and role-credential retrieval. `resources.default_region` is selected at startup, and `resources.regions` lists additional regions available from the global `R` region picker. Switching regions reuses the current credentials and recreates only the regional AWS clients.
@@ -224,6 +225,7 @@ Optional context fields:
 |---|---|
 | `order` | Lower values appear first in the context setup picker. Contexts without `order` fall back after ordered entries in their existing file order. |
 | `sso_region` | (SSO only) Region of the IAM Identity Center portal, used for SSO login and role-credential retrieval. Defaults to `region` when unset. Use it when the SSO portal and your resources live in different regions. |
+| `mfa_serial` | (assume_role only) ARN of the MFA device required by the role's trust policy. CLI flows (`unic env`, `unic context setup`) prompt for a token code on stderr and cache the resulting session under `~/.config/unic/cache/assume-role/` until it expires. The TUI reuses a valid cached session passively and otherwise asks you to run `unic env <context>` first. |
 | `resources.regions` / `regions` | Additional resource regions available through the global `R` picker. The default resource region is always included automatically. |
 
 Resolution priority:

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -181,6 +181,8 @@ UNIC supports four main auth modes.
 - calls STS `AssumeRole`
 - `unic env` exports temporary session credentials
 - SDK clients are initialized with assumed-role credentials
+- with `mfa_serial` set, CLI flows (`unic env`, `unic context setup`) prompt for a token code on stderr and cache the session credentials under `~/.config/unic/cache/assume-role/` until expiry
+- the TUI passively reuses a valid cached session and otherwise fails with a pointer to `unic env <context>`
 
 ### `sso`
 

--- a/docs/architecture.ko.md
+++ b/docs/architecture.ko.md
@@ -174,6 +174,8 @@ UNIC은 현재 세 가지 인증 모드를 지원한다.
 - STS `AssumeRole` 호출
 - `unic env`는 임시 세션 자격증명을 export
 - SDK client는 assume-role 결과 자격증명으로 초기화
+- `mfa_serial`이 설정되면 CLI 흐름(`unic env`, `unic context setup`)이 stderr로 token code를 물어보고, 세션 자격증명을 `~/.config/unic/cache/assume-role/`에 만료 시각까지 캐시한다
+- TUI는 유효한 캐시 세션을 passive하게 재사용하고, 캐시가 없으면 `unic env <context>`를 먼저 실행하라는 에러를 보여준다
 
 ### `console_login`
 

--- a/internal/auth/env.go
+++ b/internal/auth/env.go
@@ -143,7 +143,51 @@ func DetectEnvContext(contexts []config.ContextInfo, lookup func(string) string)
 	}
 }
 
+var (
+	promptMFATokenFn    = promptMFAToken
+	cachedMFASessionFn  = awsservice.CachedAssumeRoleSession
+	assumeRoleWithMFAFn = awsservice.AssumeRoleWithMFA
+)
+
+// promptMFAToken asks for an MFA token code on stderr and reads it from stdin,
+// so `eval "$(unic env ...)"` keeps stdout clean for the exports.
+func promptMFAToken(serial string) (string, error) {
+	fmt.Fprintf(os.Stderr, "MFA token code for %s: ", serial)
+	var code string
+	if _, err := fmt.Fscanln(os.Stdin, &code); err != nil {
+		return "", fmt.Errorf("failed to read MFA token code: %w", err)
+	}
+	code = strings.TrimSpace(code)
+	if code == "" {
+		return "", fmt.Errorf("MFA token code is required for %s", serial)
+	}
+	return code, nil
+}
+
+func assumeRoleMFAEnv(ctx context.Context, cfg *config.Config) (map[string]string, error) {
+	session, ok := cachedMFASessionFn(cfg)
+	if !ok {
+		code, err := promptMFATokenFn(cfg.MFASerial)
+		if err != nil {
+			return nil, err
+		}
+		session, err = assumeRoleWithMFAFn(ctx, cfg, code)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return map[string]string{
+		"AWS_ACCESS_KEY_ID":     session.AccessKeyID,
+		"AWS_SECRET_ACCESS_KEY": session.SecretAccessKey,
+		"AWS_SESSION_TOKEN":     session.SessionToken,
+	}, nil
+}
+
 func assumeRoleEnv(ctx context.Context, cfg *config.Config) (map[string]string, error) {
+	if cfg.MFASerial != "" {
+		return assumeRoleMFAEnv(ctx, cfg)
+	}
+
 	baseCfg, err := awsservice.LoadBaseConfig(ctx, cfg.Region, cfg.Profile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load AWS config: %w", err)

--- a/internal/auth/env_mfa_test.go
+++ b/internal/auth/env_mfa_test.go
@@ -1,0 +1,105 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"unic/internal/config"
+	awsservice "unic/internal/services/aws"
+)
+
+func mfaEnvConfig() *config.Config {
+	return &config.Config{
+		ContextName: "prod-admin",
+		Profile:     "base-profile",
+		Region:      "us-east-1",
+		AuthType:    config.AuthTypeAssumeRole,
+		RoleArn:     "arn:aws:iam::123456789012:role/Admin",
+		MFASerial:   "arn:aws:iam::123456789012:mfa/user",
+	}
+}
+
+func stubMFASeams(t *testing.T) (prompted *bool, assumed *bool) {
+	t.Helper()
+	origPrompt := promptMFATokenFn
+	origCached := cachedMFASessionFn
+	origAssume := assumeRoleWithMFAFn
+	t.Cleanup(func() {
+		promptMFATokenFn = origPrompt
+		cachedMFASessionFn = origCached
+		assumeRoleWithMFAFn = origAssume
+	})
+	prompted = new(bool)
+	assumed = new(bool)
+	promptMFATokenFn = func(string) (string, error) {
+		*prompted = true
+		return "123456", nil
+	}
+	cachedMFASessionFn = func(*config.Config) (awsservice.AssumeRoleSession, bool) {
+		return awsservice.AssumeRoleSession{}, false
+	}
+	assumeRoleWithMFAFn = func(_ context.Context, _ *config.Config, code string) (awsservice.AssumeRoleSession, error) {
+		if code != "123456" {
+			t.Fatalf("expected prompted token code to be used, got %q", code)
+		}
+		*assumed = true
+		return awsservice.AssumeRoleSession{
+			AccessKeyID:     "AKIA123",
+			SecretAccessKey: "secret",
+			SessionToken:    "token",
+			Expiration:      time.Now().Add(time.Hour),
+		}, nil
+	}
+	return prompted, assumed
+}
+
+func TestAssumeRoleEnvMFAPromptsAndExportsSession(t *testing.T) {
+	prompted, assumed := stubMFASeams(t)
+
+	values, err := assumeRoleEnv(context.Background(), mfaEnvConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !*prompted || !*assumed {
+		t.Fatalf("expected prompt and MFA assume-role call, prompted=%v assumed=%v", *prompted, *assumed)
+	}
+	if values["AWS_ACCESS_KEY_ID"] != "AKIA123" || values["AWS_SESSION_TOKEN"] != "token" {
+		t.Fatalf("expected session exports, got %+v", values)
+	}
+}
+
+func TestAssumeRoleEnvMFAReusesCachedSessionWithoutPrompt(t *testing.T) {
+	prompted, assumed := stubMFASeams(t)
+	cachedMFASessionFn = func(*config.Config) (awsservice.AssumeRoleSession, bool) {
+		return awsservice.AssumeRoleSession{
+			AccessKeyID:     "AKIA-CACHED",
+			SecretAccessKey: "secret",
+			SessionToken:    "cached-token",
+			Expiration:      time.Now().Add(time.Hour),
+		}, true
+	}
+
+	values, err := assumeRoleEnv(context.Background(), mfaEnvConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if *prompted || *assumed {
+		t.Fatalf("expected cached session to skip prompting, prompted=%v assumed=%v", *prompted, *assumed)
+	}
+	if values["AWS_ACCESS_KEY_ID"] != "AKIA-CACHED" {
+		t.Fatalf("expected cached session exports, got %+v", values)
+	}
+}
+
+func TestAssumeRoleEnvMFAPropagatesPromptError(t *testing.T) {
+	stubMFASeams(t)
+	promptMFATokenFn = func(string) (string, error) {
+		return "", errors.New("no tty")
+	}
+
+	if _, err := assumeRoleEnv(context.Background(), mfaEnvConfig()); err == nil {
+		t.Fatal("expected prompt error to propagate")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,7 @@ type ContextEntry struct {
 	AuthType     string            `yaml:"auth_type,omitempty"`
 	RoleArn      string            `yaml:"role_arn,omitempty"`
 	ExternalID   string            `yaml:"external_id,omitempty"`
+	MFASerial    string            `yaml:"mfa_serial,omitempty"`
 	SSOStartURL  string            `yaml:"sso_start_url,omitempty"`
 	SSORegion    string            `yaml:"sso_region,omitempty"`
 	SSOAccountID string            `yaml:"sso_account_id,omitempty"`
@@ -83,6 +84,7 @@ type ContextAuth struct {
 	Profile      string `yaml:"profile,omitempty"`
 	RoleArn      string `yaml:"role_arn,omitempty"`
 	ExternalID   string `yaml:"external_id,omitempty"`
+	MFASerial    string `yaml:"mfa_serial,omitempty"`
 	SSOStartURL  string `yaml:"sso_start_url,omitempty"`
 	SSORegion    string `yaml:"sso_region,omitempty"`
 	SSOAccountID string `yaml:"sso_account_id,omitempty"`
@@ -105,6 +107,7 @@ type Config struct {
 	AuthType         AuthType
 	RoleArn          string
 	ExternalID       string
+	MFASerial        string
 	SSOStartURL      string
 	SSORegion        string
 	SSOAccountID     string
@@ -153,6 +156,7 @@ type ContextInfo struct {
 	AuthType     string
 	RoleArn      string
 	ExternalID   string
+	MFASerial    string
 	SSOStartURL  string
 	SSORegion    string
 	SSOAccountID string
@@ -164,6 +168,7 @@ type ContextInfo struct {
 
 type resolvedContextEntry struct {
 	Profile, Region, AuthType, RoleArn, ExternalID    string
+	MFASerial                                         string
 	SSOStartURL, SSORegion, SSOAccountID, SSORoleName string
 	Regions                                           []string
 }
@@ -172,6 +177,7 @@ func (c ContextEntry) resolved(defaultRegion string) resolvedContextEntry {
 	r := resolvedContextEntry{
 		Profile: c.Profile, Region: c.Region, AuthType: c.AuthType,
 		RoleArn: c.RoleArn, ExternalID: c.ExternalID,
+		MFASerial:   c.MFASerial,
 		SSOStartURL: c.SSOStartURL, SSORegion: c.SSORegion,
 		SSOAccountID: c.SSOAccountID, SSORoleName: c.SSORoleName,
 		Regions: c.Regions,
@@ -181,6 +187,7 @@ func (c ContextEntry) resolved(defaultRegion string) resolvedContextEntry {
 		r.Profile = c.Auth.Profile
 		r.RoleArn = c.Auth.RoleArn
 		r.ExternalID = c.Auth.ExternalID
+		r.MFASerial = c.Auth.MFASerial
 		r.SSOStartURL = c.Auth.SSOStartURL
 		r.SSORegion = c.Auth.SSORegion
 		r.SSOAccountID = c.Auth.SSOAccountID
@@ -251,7 +258,7 @@ func Load(cliProfile, cliRegion *string, configPath string) (*Config, error) {
 	}
 
 	// New format: resolve current context
-	var contextName, roleArn, externalID, ssoStartURL, ssoRegion, ssoAccountID, ssoRoleName string
+	var contextName, roleArn, externalID, mfaSerial, ssoStartURL, ssoRegion, ssoAccountID, ssoRoleName string
 	var regions []string
 	var authType AuthType
 	if fc.Current != "" {
@@ -267,6 +274,7 @@ func Load(cliProfile, cliRegion *string, configPath string) (*Config, error) {
 				regions = resolved.Regions
 				roleArn = resolved.RoleArn
 				externalID = resolved.ExternalID
+				mfaSerial = resolved.MFASerial
 				ssoStartURL = resolved.SSOStartURL
 				ssoRegion = resolved.SSORegion
 				ssoAccountID = resolved.SSOAccountID
@@ -303,6 +311,7 @@ func Load(cliProfile, cliRegion *string, configPath string) (*Config, error) {
 		AuthType:         authType,
 		RoleArn:          roleArn,
 		ExternalID:       externalID,
+		MFASerial:        mfaSerial,
 		SSOStartURL:      ssoStartURL,
 		SSORegion:        ssoRegion,
 		SSOAccountID:     ssoAccountID,
@@ -351,6 +360,7 @@ func LoadNamedContext(configPath, name string) (*Config, error) {
 			AuthType:         normalizeAuthType(resolved.AuthType),
 			RoleArn:          resolved.RoleArn,
 			ExternalID:       resolved.ExternalID,
+			MFASerial:        resolved.MFASerial,
 			SSOStartURL:      resolved.SSOStartURL,
 			SSORegion:        resolved.SSORegion,
 			SSOAccountID:     resolved.SSOAccountID,
@@ -432,6 +442,7 @@ func Contexts(configPath string) ([]ContextInfo, error) {
 			AuthType:     resolved.AuthType,
 			RoleArn:      resolved.RoleArn,
 			ExternalID:   resolved.ExternalID,
+			MFASerial:    resolved.MFASerial,
 			SSOStartURL:  resolved.SSOStartURL,
 			SSORegion:    resolved.SSORegion,
 			SSOAccountID: resolved.SSOAccountID,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -953,3 +953,41 @@ contexts:
 		t.Fatalf("expected updated region ap-northeast-2, got %q", cfg.Region)
 	}
 }
+
+func TestContextWithMFASerial(t *testing.T) {
+	dir := t.TempDir()
+	path := writeUnicConfig(t, dir, `
+current: prod-admin
+defaults:
+  region: us-east-1
+contexts:
+  - name: prod-admin
+    profile: base-user
+    auth_type: assume_role
+    role_arn: arn:aws:iam::111111111111:role/AdministratorAccess
+    mfa_serial: arn:aws:iam::111111111111:mfa/user
+  - name: prod-structured
+    auth:
+      type: assume_role
+      profile: base-user
+      role_arn: arn:aws:iam::111111111111:role/ReadOnly
+      mfa_serial: arn:aws:iam::111111111111:mfa/other
+    resources:
+      default_region: us-east-1
+`)
+	cfg, err := Load(nil, nil, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.MFASerial != "arn:aws:iam::111111111111:mfa/user" {
+		t.Errorf("expected flat mfa_serial, got '%s'", cfg.MFASerial)
+	}
+
+	named, err := LoadNamedContext(path, "prod-structured")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if named.MFASerial != "arn:aws:iam::111111111111:mfa/other" {
+		t.Errorf("expected structured auth mfa_serial, got '%s'", named.MFASerial)
+	}
+}

--- a/internal/services/aws/assume_role_cache.go
+++ b/internal/services/aws/assume_role_cache.go
@@ -1,0 +1,134 @@
+package aws
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+
+	"unic/internal/config"
+	uniclog "unic/internal/log"
+)
+
+// AssumeRoleSession holds cached MFA-protected assume-role session credentials.
+type AssumeRoleSession struct {
+	AccessKeyID     string    `json:"access_key_id"`
+	SecretAccessKey string    `json:"secret_access_key"`
+	SessionToken    string    `json:"session_token"`
+	Expiration      time.Time `json:"expiration"`
+}
+
+// Valid reports whether the session is still usable with a small clock skew margin.
+func (s AssumeRoleSession) Valid() bool {
+	return s.AccessKeyID != "" && time.Now().Add(2*time.Minute).Before(s.Expiration)
+}
+
+// assumeRoleCacheDirFn is a test seam for redirecting the cache directory.
+var assumeRoleCacheDirFn = defaultAssumeRoleCacheDir
+
+func defaultAssumeRoleCacheDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "unic", "cache", "assume-role"), nil
+}
+
+func assumeRoleCachePath(cfg *config.Config) (string, error) {
+	dir, err := assumeRoleCacheDirFn()
+	if err != nil {
+		return "", err
+	}
+	hash := sha1.Sum([]byte(cfg.Profile + "|" + cfg.RoleArn + "|" + cfg.MFASerial))
+	return filepath.Join(dir, hex.EncodeToString(hash[:])+".json"), nil
+}
+
+// CachedAssumeRoleSession returns the cached MFA session for the context when
+// it exists and has not expired.
+func CachedAssumeRoleSession(cfg *config.Config) (AssumeRoleSession, bool) {
+	path, err := assumeRoleCachePath(cfg)
+	if err != nil {
+		return AssumeRoleSession{}, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return AssumeRoleSession{}, false
+	}
+	var session AssumeRoleSession
+	if err := json.Unmarshal(data, &session); err != nil {
+		return AssumeRoleSession{}, false
+	}
+	if !session.Valid() {
+		return AssumeRoleSession{}, false
+	}
+	return session, true
+}
+
+func saveAssumeRoleSession(cfg *config.Config, session AssumeRoleSession) error {
+	path, err := assumeRoleCachePath(cfg)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("failed to create assume-role cache directory: %w", err)
+	}
+	data, err := json.Marshal(session)
+	if err != nil {
+		return fmt.Errorf("failed to marshal assume-role session: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("failed to write assume-role session cache: %w", err)
+	}
+	return nil
+}
+
+// AssumeRoleWithMFA assumes the context's role using the given MFA token code
+// and caches the resulting session credentials for reuse until expiry.
+func AssumeRoleWithMFA(ctx context.Context, cfg *config.Config, tokenCode string) (AssumeRoleSession, error) {
+	uniclog.Debug("aws", "assuming role with MFA", "role_arn", cfg.RoleArn, "mfa_serial", cfg.MFASerial)
+	baseCfg, err := LoadBaseConfig(ctx, cfg.Region, cfg.Profile)
+	if err != nil {
+		return AssumeRoleSession{}, fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	input := &sts.AssumeRoleInput{
+		RoleArn:         awssdk.String(cfg.RoleArn),
+		RoleSessionName: awssdk.String("unic-session"),
+		SerialNumber:    awssdk.String(cfg.MFASerial),
+		TokenCode:       awssdk.String(tokenCode),
+	}
+	if cfg.ExternalID != "" {
+		input.ExternalId = awssdk.String(cfg.ExternalID)
+	}
+
+	result, err := stsAssumeRoleFn(ctx, baseCfg, input)
+	if err != nil {
+		return AssumeRoleSession{}, fmt.Errorf("failed to assume role %s with MFA: %w", cfg.RoleArn, err)
+	}
+
+	creds := result.Credentials
+	session := AssumeRoleSession{
+		AccessKeyID:     awssdk.ToString(creds.AccessKeyId),
+		SecretAccessKey: awssdk.ToString(creds.SecretAccessKey),
+		SessionToken:    awssdk.ToString(creds.SessionToken),
+	}
+	if creds.Expiration != nil {
+		session.Expiration = *creds.Expiration
+	}
+	if err := saveAssumeRoleSession(cfg, session); err != nil {
+		uniclog.Info("aws", "failed to cache assume-role session", "error", err.Error())
+	}
+	return session, nil
+}
+
+// stsAssumeRoleFn is a test seam for the STS AssumeRole call.
+var stsAssumeRoleFn = func(ctx context.Context, baseCfg awssdk.Config, input *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
+	return sts.NewFromConfig(baseCfg).AssumeRole(ctx, input)
+}

--- a/internal/services/aws/assume_role_cache_test.go
+++ b/internal/services/aws/assume_role_cache_test.go
@@ -1,0 +1,153 @@
+package aws
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
+
+	"unic/internal/config"
+)
+
+func mfaTestConfig() *config.Config {
+	return &config.Config{
+		ContextName: "prod-admin",
+		Region:      "us-east-1",
+		AuthType:    config.AuthTypeAssumeRole,
+		RoleArn:     "arn:aws:iam::123456789012:role/Admin",
+		MFASerial:   "arn:aws:iam::123456789012:mfa/user",
+	}
+}
+
+func stubCacheDir(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	orig := assumeRoleCacheDirFn
+	t.Cleanup(func() { assumeRoleCacheDirFn = orig })
+	assumeRoleCacheDirFn = func() (string, error) { return dir, nil }
+}
+
+func TestAssumeRoleSessionCacheRoundTrip(t *testing.T) {
+	stubCacheDir(t)
+	cfg := mfaTestConfig()
+
+	if _, ok := CachedAssumeRoleSession(cfg); ok {
+		t.Fatal("expected empty cache before save")
+	}
+
+	session := AssumeRoleSession{
+		AccessKeyID:     "AKIA123",
+		SecretAccessKey: "secret",
+		SessionToken:    "token",
+		Expiration:      time.Now().Add(time.Hour),
+	}
+	if err := saveAssumeRoleSession(cfg, session); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, ok := CachedAssumeRoleSession(cfg)
+	if !ok || got.AccessKeyID != "AKIA123" || got.SessionToken != "token" {
+		t.Fatalf("expected cached session back, got %+v ok=%v", got, ok)
+	}
+
+	other := mfaTestConfig()
+	other.RoleArn = "arn:aws:iam::123456789012:role/ReadOnly"
+	if _, ok := CachedAssumeRoleSession(other); ok {
+		t.Fatal("expected cache miss for a different role")
+	}
+}
+
+func TestCachedAssumeRoleSessionRejectsExpired(t *testing.T) {
+	stubCacheDir(t)
+	cfg := mfaTestConfig()
+
+	session := AssumeRoleSession{
+		AccessKeyID:     "AKIA123",
+		SecretAccessKey: "secret",
+		SessionToken:    "token",
+		Expiration:      time.Now().Add(30 * time.Second),
+	}
+	if err := saveAssumeRoleSession(cfg, session); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := CachedAssumeRoleSession(cfg); ok {
+		t.Fatal("expected session expiring within the skew margin to be rejected")
+	}
+}
+
+func TestAssumeRoleWithMFACachesSession(t *testing.T) {
+	stubCacheDir(t)
+	cfg := mfaTestConfig()
+
+	origSTS := stsAssumeRoleFn
+	t.Cleanup(func() { stsAssumeRoleFn = origSTS })
+	expiry := time.Now().Add(time.Hour)
+	stsAssumeRoleFn = func(_ context.Context, _ awssdk.Config, input *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
+		if awssdk.ToString(input.SerialNumber) != cfg.MFASerial {
+			t.Fatalf("expected MFA serial to be passed, got %+v", input)
+		}
+		if awssdk.ToString(input.TokenCode) != "123456" {
+			t.Fatalf("expected token code to be passed, got %+v", input)
+		}
+		return &sts.AssumeRoleOutput{Credentials: &ststypes.Credentials{
+			AccessKeyId:     awssdk.String("AKIA456"),
+			SecretAccessKey: awssdk.String("secret"),
+			SessionToken:    awssdk.String("token"),
+			Expiration:      &expiry,
+		}}, nil
+	}
+
+	session, err := AssumeRoleWithMFA(context.Background(), cfg, "123456")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if session.AccessKeyID != "AKIA456" {
+		t.Fatalf("expected session credentials, got %+v", session)
+	}
+
+	cached, ok := CachedAssumeRoleSession(cfg)
+	if !ok || cached.AccessKeyID != "AKIA456" {
+		t.Fatalf("expected session to be cached, got %+v ok=%v", cached, ok)
+	}
+}
+
+func TestResolveAssumeRoleCredentialsMFACacheMiss(t *testing.T) {
+	stubCacheDir(t)
+	cfg := mfaTestConfig()
+
+	_, err := resolveAssumeRoleCredentials(context.Background(), cfg)
+	if err == nil || !strings.Contains(err.Error(), "requires MFA") || !strings.Contains(err.Error(), "unic env prod-admin") {
+		t.Fatalf("expected actionable MFA error, got %v", err)
+	}
+}
+
+func TestResolveAssumeRoleCredentialsMFAUsesCachedSession(t *testing.T) {
+	stubCacheDir(t)
+	cfg := mfaTestConfig()
+
+	session := AssumeRoleSession{
+		AccessKeyID:     "AKIA789",
+		SecretAccessKey: "secret",
+		SessionToken:    "token",
+		Expiration:      time.Now().Add(time.Hour),
+	}
+	if err := saveAssumeRoleSession(cfg, session); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	awsCfg, err := resolveAssumeRoleCredentials(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	creds, err := awsCfg.Credentials.Retrieve(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error retrieving credentials: %v", err)
+	}
+	if creds.AccessKeyID != "AKIA789" || creds.SessionToken != "token" {
+		t.Fatalf("expected cached static credentials, got %+v", creds)
+	}
+}

--- a/internal/services/aws/repository.go
+++ b/internal/services/aws/repository.go
@@ -458,6 +458,29 @@ func (r *AwsRepository) GetCallerIdentity(ctx context.Context) (*CallerIdentity,
 // resolveAssumeRoleCredentials assumes a role and returns an aws.Config with temporary credentials.
 func resolveAssumeRoleCredentials(ctx context.Context, cfg *config.Config) (aws.Config, error) {
 	uniclog.Debug("aws", "resolving assume-role credentials", "role_arn", cfg.RoleArn)
+
+	// MFA-protected roles cannot prompt inside the TUI: reuse the cached
+	// session written by the CLI flows, or fail with a pointer to them.
+	if cfg.MFASerial != "" {
+		session, ok := CachedAssumeRoleSession(cfg)
+		if !ok {
+			return aws.Config{}, fmt.Errorf(
+				"context %q requires MFA (%s); run 'unic env %s' first to enter a token code",
+				cfg.ContextName, cfg.MFASerial, cfg.ContextName,
+			)
+		}
+		baseCfg, err := LoadBaseConfig(ctx, cfg.Region, cfg.Profile)
+		if err != nil {
+			return aws.Config{}, fmt.Errorf("failed to load AWS config: %w", err)
+		}
+		baseCfg.Credentials = credentials.NewStaticCredentialsProvider(
+			session.AccessKeyID,
+			session.SecretAccessKey,
+			session.SessionToken,
+		)
+		return baseCfg, nil
+	}
+
 	baseCfg, err := LoadBaseConfig(ctx, cfg.Region, cfg.Profile)
 	if err != nil {
 		return aws.Config{}, fmt.Errorf("failed to load AWS config: %w", err)


### PR DESCRIPTION
## Summary

Implements #240: `assume_role` contexts can now use roles whose trust policy requires MFA.

- New optional `mfa_serial` context field, supported in both the flat form and the structured `auth` section.
- `unic env` / `unic context setup`: when `mfa_serial` is set and no valid cached session exists, prompt for the token code on stderr (stdout stays clean for `eval`), call STS `AssumeRole` with `SerialNumber`/`TokenCode`, and export the session credentials.
- Session credentials are cached under `~/.config/unic/cache/assume-role/` (0700 dir, 0600 files, keyed by profile+role+serial hash) and reused until expiry with a 2-minute skew margin. The MFA code itself is never stored.
- TUI: passively reuses a valid cached session, mirroring the passive SSO startup behavior. With no usable cache it fails fast with `run 'unic env <context>' first to enter a token code` instead of hanging on a prompt the TUI cannot render.
- Non-MFA `assume_role` contexts are untouched.

## Testing

- `go test ./...` passes: config parsing (flat + structured `mfa_serial`), cache round-trip/expiry/keying, MFA AssumeRole parameter passing and caching, TUI cache-miss error and cache-hit credential resolution, env prompt/cached/error paths.
- `make build` passes.

## Docs

- README: auth type table, config example, and a new `mfa_serial` optional-field row documenting the prompt + cache behavior.
- `docs/architecture.en.md` / `docs/architecture.ko.md`: `assume_role` auth model sections updated.

Closes #240
