### PR TITLE
feat: add Okta SAML credential exchange with session cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ contexts:
 | `console_login` | Run `aws login` during `unic context setup`, then use the resulting profile-backed console credentials | `profile` |
 | `assume_role` | Assume a role from a base profile | `profile`, `role_arn` |
 | `sso` | Use AWS IAM Identity Center / SSO, reusing a valid AWS CLI SSO cache and prompting for login only when needed | `sso_start_url`, and for concrete contexts `sso_account_id`, `sso_role_name`; `profile` is optional |
-| `okta_saml` | Okta SAML federation context (config schema only for now; runtime credential exchange is in progress) | `okta_org_url`, `okta_app_id`; optional `role_arn` for a preferred role. Passwords and MFA secrets are never stored in config |
+| `okta_saml` | Okta SAML federation: `unic env` signs in to Okta (prompt on stderr, password without echo; `UNIC_OKTA_USERNAME`/`UNIC_OKTA_PASSWORD` for automation), exchanges the SAML assertion via `sts:AssumeRoleWithSAML`, and caches the session under `~/.config/unic/cache/okta-saml/`. The TUI reuses a valid cached session passively. Okta MFA challenges are not supported yet | `okta_org_url`, `okta_app_id`; `role_arn` required when the assertion carries multiple roles. Passwords and MFA secrets are never stored |
 
 The preferred context format separates `auth` from `resources`. `auth.sso_region` controls IAM Identity Center login and role-credential retrieval. `resources.default_region` is selected at startup, and `resources.regions` lists additional regions available from the global `R` region picker. Switching regions reuses the current credentials and recreates only the regional AWS clients.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module unic
 
-go 1.24.2
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.6
@@ -70,6 +70,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sys v0.38.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
+	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.3.8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,10 @@ golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
 golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=
+golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
 golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/internal/app/context_add.go
+++ b/internal/app/context_add.go
@@ -15,9 +15,7 @@ type fieldDef struct {
 	required bool
 }
 
-// okta_saml stays out of the picker until its runtime credential exchange
-// lands (#85); its field definitions below are ready for that slice.
-var authTypes = []string{"sso", "credential", "console_login", "assume_role"}
+var authTypes = []string{"sso", "credential", "console_login", "assume_role", "okta_saml"}
 
 var fieldsByAuthType = map[string][]fieldDef{
 	"sso": {

--- a/internal/app/context_add_test.go
+++ b/internal/app/context_add_test.go
@@ -66,19 +66,46 @@ func TestContextAddKeepsCurrentFieldVisibleOnShortTerminal(t *testing.T) {
 	}
 }
 
-func TestContextAddDoesNotOfferOktaSAMLYet(t *testing.T) {
-	for _, authType := range authTypes {
+func TestContextAddSelectsOktaSAMLFields(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.screen = screenContextAdd
+	m.addStep = 0
+	m.addValues = map[string]string{}
+
+	for i, authType := range authTypes {
 		if authType == "okta_saml" {
-			t.Fatal("okta_saml must stay out of the add-context picker until runtime credential exchange lands")
+			m.addAuthIdx = i
+			break
 		}
 	}
-	fields, ok := fieldsByAuthType["okta_saml"]
-	if !ok || len(fields) == 0 {
-		t.Fatal("okta_saml field definitions should stay ready for the runtime slice")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model := updated.(Model)
+	if model.addValues["auth_type"] != "okta_saml" {
+		t.Fatalf("expected okta_saml selection, got %q", model.addValues["auth_type"])
 	}
-	for _, field := range fields {
-		if strings.Contains(field.key, "password") || strings.Contains(field.key, "secret") || strings.Contains(field.key, "mfa") {
-			t.Fatalf("okta_saml wizard must not collect secrets, got field %q", field.key)
+
+	keys := make([]string, 0, len(model.addFields))
+	required := map[string]bool{}
+	for _, field := range model.addFields {
+		keys = append(keys, field.key)
+		required[field.key] = field.required
+	}
+	joined := strings.Join(keys, ",")
+	for _, want := range []string{"okta_org_url", "okta_app_id", "role_arn"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("expected %s field for okta_saml, got %v", want, keys)
+		}
+	}
+	if !required["okta_org_url"] || !required["okta_app_id"] {
+		t.Fatal("expected okta org URL and app ID to be required")
+	}
+	if required["role_arn"] {
+		t.Fatal("expected preferred role ARN to be optional")
+	}
+	for _, key := range keys {
+		if strings.Contains(key, "password") || strings.Contains(key, "secret") || strings.Contains(key, "mfa") {
+			t.Fatalf("okta_saml wizard must not collect secrets, got field %q", key)
 		}
 	}
 }

--- a/internal/auth/env.go
+++ b/internal/auth/env.go
@@ -16,6 +16,7 @@ import (
 
 var assumeRoleFn = assumeRoleEnv
 var resolveSSORoleFn = resolveSSORoleEnv
+var resolveOktaSAMLSessionFn = ResolveOktaSAMLSession
 
 const ContextEnvVar = "UNIC_CONTEXT"
 
@@ -54,7 +55,18 @@ func BuildEnvExports(ctx context.Context, cfg *config.Config) (string, error) {
 		values["AWS_PROFILE"] = ""
 
 	case config.AuthTypeOktaSAML:
-		return "", fmt.Errorf("context %q uses okta_saml, whose runtime credential exchange is not implemented yet", cfg.ContextName)
+		session, err := resolveOktaSAMLSessionFn(ctx, cfg)
+		if err != nil {
+			return "", err
+		}
+		values = map[string]string{
+			"AWS_ACCESS_KEY_ID":     session.AccessKeyID,
+			"AWS_SECRET_ACCESS_KEY": session.SecretAccessKey,
+			"AWS_SESSION_TOKEN":     session.SessionToken,
+			"AWS_REGION":            cfg.Region,
+			"AWS_DEFAULT_REGION":    cfg.Region,
+			"AWS_PROFILE":           "",
+		}
 
 	case config.AuthTypeCredential, config.AuthTypeConsoleLogin, config.AuthTypeDefault:
 		if cfg.AuthType == config.AuthTypeConsoleLogin {

--- a/internal/auth/okta.go
+++ b/internal/auth/okta.go
@@ -7,18 +7,17 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"html"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
-	"regexp"
 	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"golang.org/x/net/html"
 	"golang.org/x/term"
 
 	"unic/internal/config"
@@ -38,7 +37,6 @@ var (
 	stsAssumeRoleWithSAMLFn  = stsAssumeRoleWithSAML
 	cachedOktaSessionFn      = awsservice.CachedOktaSAMLSession
 	saveOktaSessionFn        = awsservice.SaveOktaSAMLSession
-	samlResponseInputPattern = regexp.MustCompile(`name="SAMLResponse"[^>]*value="([^"]+)"`)
 )
 
 // OktaSAMLRole is one AWS role/principal pair carried in the SAML assertion.
@@ -208,11 +206,48 @@ func oktaFetchSAMLAssertion(ctx context.Context, client *http.Client, orgURL, ap
 		return "", err
 	}
 
-	match := samlResponseInputPattern.FindSubmatch(page)
-	if match == nil {
+	assertion, ok := samlResponseFromHTML(page)
+	if !ok {
 		return "", fmt.Errorf("no SAMLResponse found in the okta app response; check okta_app_id")
 	}
-	return html.UnescapeString(string(match[1])), nil
+	return assertion, nil
+}
+
+// samlResponseFromHTML tokenizes the auto-submit form and returns the value of
+// the input named SAMLResponse. Tokenizing keeps the extraction independent of
+// attribute order, quoting style, and incidental markup changes.
+func samlResponseFromHTML(page []byte) (string, bool) {
+	tokenizer := html.NewTokenizer(bytes.NewReader(page))
+	for {
+		tokenType := tokenizer.Next()
+		if tokenType == html.ErrorToken {
+			return "", false
+		}
+		if tokenType != html.StartTagToken && tokenType != html.SelfClosingTagToken {
+			continue
+		}
+		name, hasAttr := tokenizer.TagName()
+		if string(name) != "input" || !hasAttr {
+			continue
+		}
+		var isSAMLResponse bool
+		var value string
+		for {
+			key, val, more := tokenizer.TagAttr()
+			switch string(key) {
+			case "name":
+				isSAMLResponse = string(val) == "SAMLResponse"
+			case "value":
+				value = string(val)
+			}
+			if !more {
+				break
+			}
+		}
+		if isSAMLResponse && value != "" {
+			return value, true
+		}
+	}
 }
 
 // parseSAMLRoles extracts the AWS role/principal pairs from a base64 SAML assertion.

--- a/internal/auth/okta.go
+++ b/internal/auth/okta.go
@@ -1,0 +1,310 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"html"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"golang.org/x/term"
+
+	"unic/internal/config"
+	awsservice "unic/internal/services/aws"
+)
+
+// Okta SAML federation: primary auth -> session token -> SAML assertion from
+// the app embed link -> sts:AssumeRoleWithSAML. Resulting AWS credentials are
+// cached (see services/aws/okta_saml_cache.go) so the TUI reuses them
+// passively; the Okta password and session token are never persisted.
+
+const samlRoleAttributeName = "https://aws.amazon.com/SAML/Attributes/Role"
+
+var (
+	oktaHTTPClientFn         = func() *http.Client { return &http.Client{Timeout: 30 * time.Second} }
+	promptOktaCredentialsFn  = promptOktaCredentials
+	stsAssumeRoleWithSAMLFn  = stsAssumeRoleWithSAML
+	cachedOktaSessionFn      = awsservice.CachedOktaSAMLSession
+	saveOktaSessionFn        = awsservice.SaveOktaSAMLSession
+	samlResponseInputPattern = regexp.MustCompile(`name="SAMLResponse"[^>]*value="([^"]+)"`)
+)
+
+// OktaSAMLRole is one AWS role/principal pair carried in the SAML assertion.
+type OktaSAMLRole struct {
+	RoleARN      string
+	PrincipalARN string
+}
+
+// ResolveOktaSAMLSession returns cached AWS credentials for an okta_saml
+// context, or runs the full Okta sign-in and SAML exchange and caches the
+// result until expiry.
+func ResolveOktaSAMLSession(ctx context.Context, cfg *config.Config) (awsservice.OktaSAMLSession, error) {
+	if session, ok := cachedOktaSessionFn(cfg); ok {
+		return session, nil
+	}
+	if cfg.OktaOrgURL == "" || cfg.OktaAppID == "" {
+		return awsservice.OktaSAMLSession{}, fmt.Errorf("context %q is missing okta_org_url or okta_app_id", cfg.ContextName)
+	}
+
+	username, password, err := promptOktaCredentialsFn(cfg.OktaOrgURL)
+	if err != nil {
+		return awsservice.OktaSAMLSession{}, err
+	}
+
+	client := oktaHTTPClientFn()
+	sessionToken, err := oktaPrimaryAuth(ctx, client, cfg.OktaOrgURL, username, password)
+	if err != nil {
+		return awsservice.OktaSAMLSession{}, err
+	}
+
+	assertion, err := oktaFetchSAMLAssertion(ctx, client, cfg.OktaOrgURL, cfg.OktaAppID, sessionToken)
+	if err != nil {
+		return awsservice.OktaSAMLSession{}, err
+	}
+
+	roles, err := parseSAMLRoles(assertion)
+	if err != nil {
+		return awsservice.OktaSAMLSession{}, err
+	}
+	role, err := selectOktaRole(roles, cfg.RoleArn)
+	if err != nil {
+		return awsservice.OktaSAMLSession{}, err
+	}
+
+	out, err := stsAssumeRoleWithSAMLFn(ctx, cfg.Region, &sts.AssumeRoleWithSAMLInput{
+		PrincipalArn:  aws.String(role.PrincipalARN),
+		RoleArn:       aws.String(role.RoleARN),
+		SAMLAssertion: aws.String(assertion),
+	})
+	if err != nil {
+		return awsservice.OktaSAMLSession{}, fmt.Errorf("failed to assume role %s with SAML: %w", role.RoleARN, err)
+	}
+
+	creds := out.Credentials
+	session := awsservice.OktaSAMLSession{
+		AccessKeyID:     aws.ToString(creds.AccessKeyId),
+		SecretAccessKey: aws.ToString(creds.SecretAccessKey),
+		SessionToken:    aws.ToString(creds.SessionToken),
+	}
+	if creds.Expiration != nil {
+		session.Expiration = *creds.Expiration
+	}
+	if err := saveOktaSessionFn(cfg, session); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to cache Okta SAML session: %v\n", err)
+	}
+	return session, nil
+}
+
+// promptOktaCredentials reads the Okta username and password. Prompts go to
+// stderr and the password is read without echo. UNIC_OKTA_USERNAME and
+// UNIC_OKTA_PASSWORD override prompting for non-interactive use.
+func promptOktaCredentials(orgURL string) (string, string, error) {
+	username := strings.TrimSpace(os.Getenv("UNIC_OKTA_USERNAME"))
+	password := os.Getenv("UNIC_OKTA_PASSWORD")
+	if username != "" && password != "" {
+		return username, password, nil
+	}
+
+	fmt.Fprintf(os.Stderr, "Okta username for %s: ", orgURL)
+	if _, err := fmt.Fscanln(os.Stdin, &username); err != nil {
+		return "", "", fmt.Errorf("failed to read Okta username: %w", err)
+	}
+	fmt.Fprint(os.Stderr, "Okta password: ")
+	raw, err := term.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Fprintln(os.Stderr)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to read Okta password: %w", err)
+	}
+	username = strings.TrimSpace(username)
+	if username == "" || len(raw) == 0 {
+		return "", "", fmt.Errorf("okta username and password are required")
+	}
+	return username, string(raw), nil
+}
+
+type oktaAuthnResponse struct {
+	Status       string `json:"status"`
+	SessionToken string `json:"sessionToken"`
+}
+
+// oktaPrimaryAuth performs Okta primary authentication and returns a one-time
+// session token.
+func oktaPrimaryAuth(ctx context.Context, client *http.Client, orgURL, username, password string) (string, error) {
+	body, err := json.Marshal(map[string]string{"username": username, "password": password})
+	if err != nil {
+		return "", err
+	}
+	endpoint := strings.TrimRight(orgURL, "/") + "/api/v1/authn"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("okta authentication request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return "", fmt.Errorf("okta rejected the credentials (401)")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("okta authentication returned status %d", resp.StatusCode)
+	}
+
+	var authn oktaAuthnResponse
+	if err := json.NewDecoder(resp.Body).Decode(&authn); err != nil {
+		return "", fmt.Errorf("failed to parse okta authentication response: %w", err)
+	}
+	switch authn.Status {
+	case "SUCCESS":
+		if authn.SessionToken == "" {
+			return "", fmt.Errorf("okta returned SUCCESS without a session token")
+		}
+		return authn.SessionToken, nil
+	case "MFA_REQUIRED", "MFA_ENROLL":
+		return "", fmt.Errorf("okta requires an MFA challenge, which unic does not support yet (see issue #87)")
+	default:
+		return "", fmt.Errorf("okta authentication ended in status %q", authn.Status)
+	}
+}
+
+// oktaFetchSAMLAssertion loads the app embed link with the one-time session
+// token and extracts the base64 SAML response from the auto-submit form.
+func oktaFetchSAMLAssertion(ctx context.Context, client *http.Client, orgURL, appID, sessionToken string) (string, error) {
+	embed := strings.TrimRight(orgURL, "/") + "/home/" + strings.Trim(appID, "/") +
+		"?sessionToken=" + url.QueryEscape(sessionToken)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, embed, nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to load okta app embed link: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("okta app embed link returned status %d", resp.StatusCode)
+	}
+	page, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	match := samlResponseInputPattern.FindSubmatch(page)
+	if match == nil {
+		return "", fmt.Errorf("no SAMLResponse found in the okta app response; check okta_app_id")
+	}
+	return html.UnescapeString(string(match[1])), nil
+}
+
+// parseSAMLRoles extracts the AWS role/principal pairs from a base64 SAML assertion.
+func parseSAMLRoles(assertion string) ([]OktaSAMLRole, error) {
+	decoded, err := base64.StdEncoding.DecodeString(assertion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode SAML assertion: %w", err)
+	}
+
+	var doc struct {
+		Assertion struct {
+			AttributeStatement struct {
+				Attributes []struct {
+					Name   string   `xml:"Name,attr"`
+					Values []string `xml:"AttributeValue"`
+				} `xml:"Attribute"`
+			} `xml:"AttributeStatement"`
+		} `xml:"Assertion"`
+	}
+	if err := xml.Unmarshal(decoded, &doc); err != nil {
+		return nil, fmt.Errorf("failed to parse SAML assertion: %w", err)
+	}
+
+	var roles []OktaSAMLRole
+	for _, attr := range doc.Assertion.AttributeStatement.Attributes {
+		if attr.Name != samlRoleAttributeName {
+			continue
+		}
+		for _, value := range attr.Values {
+			role, ok := samlRoleFromValue(value)
+			if !ok {
+				continue
+			}
+			roles = append(roles, role)
+		}
+	}
+	if len(roles) == 0 {
+		return nil, fmt.Errorf("SAML assertion contains no AWS roles")
+	}
+	return roles, nil
+}
+
+// samlRoleFromValue parses "arn:...:role/X,arn:...:saml-provider/Y" in either order.
+func samlRoleFromValue(value string) (OktaSAMLRole, bool) {
+	var role OktaSAMLRole
+	for _, part := range strings.Split(value, ",") {
+		part = strings.TrimSpace(part)
+		switch {
+		case strings.Contains(part, ":role/"):
+			role.RoleARN = part
+		case strings.Contains(part, ":saml-provider/"):
+			role.PrincipalARN = part
+		}
+	}
+	return role, role.RoleARN != "" && role.PrincipalARN != ""
+}
+
+// selectOktaRole picks the role to assume: the configured role_arn when set,
+// otherwise the only available role. Multiple roles without a preference is
+// an explicit error so selection stays deterministic.
+func selectOktaRole(roles []OktaSAMLRole, preferred string) (OktaSAMLRole, error) {
+	if preferred != "" {
+		for _, role := range roles {
+			if role.RoleARN == preferred {
+				return role, nil
+			}
+		}
+		return OktaSAMLRole{}, fmt.Errorf("configured role_arn %s is not in the SAML assertion (%s)", preferred, joinRoleARNs(roles))
+	}
+	if len(roles) == 1 {
+		return roles[0], nil
+	}
+	return OktaSAMLRole{}, fmt.Errorf("multiple AWS roles available (%s); set role_arn on the context to choose one", joinRoleARNs(roles))
+}
+
+func joinRoleARNs(roles []OktaSAMLRole) string {
+	arns := make([]string, 0, len(roles))
+	for _, role := range roles {
+		arns = append(arns, role.RoleARN)
+	}
+	return strings.Join(arns, ", ")
+}
+
+// stsAssumeRoleWithSAML calls STS with anonymous credentials; the SAML
+// assertion itself authorizes the exchange.
+func stsAssumeRoleWithSAML(ctx context.Context, region string, input *sts.AssumeRoleWithSAMLInput) (*sts.AssumeRoleWithSAMLOutput, error) {
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion(region),
+		awsconfig.WithCredentialsProvider(aws.AnonymousCredentials{}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS config: %w", err)
+	}
+	return sts.NewFromConfig(awsCfg).AssumeRoleWithSAML(ctx, input)
+}

--- a/internal/auth/okta_test.go
+++ b/internal/auth/okta_test.go
@@ -1,0 +1,210 @@
+package auth
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
+
+	"unic/internal/config"
+	awsservice "unic/internal/services/aws"
+)
+
+const testSAMLAssertionXML = `<?xml version="1.0" encoding="UTF-8"?>
+<saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol">
+  <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">
+    <saml2:AttributeStatement>
+      <saml2:Attribute Name="https://aws.amazon.com/SAML/Attributes/Role">
+        <saml2:AttributeValue>arn:aws:iam::111111111111:saml-provider/okta,arn:aws:iam::111111111111:role/Dev</saml2:AttributeValue>
+        <saml2:AttributeValue>arn:aws:iam::111111111111:role/Admin,arn:aws:iam::111111111111:saml-provider/okta</saml2:AttributeValue>
+      </saml2:Attribute>
+    </saml2:AttributeStatement>
+  </saml2:Assertion>
+</saml2p:Response>`
+
+func testAssertionB64() string {
+	return base64.StdEncoding.EncodeToString([]byte(testSAMLAssertionXML))
+}
+
+func TestParseSAMLRolesHandlesBothOrderings(t *testing.T) {
+	roles, err := parseSAMLRoles(testAssertionB64())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(roles) != 2 {
+		t.Fatalf("expected 2 roles, got %+v", roles)
+	}
+	for _, role := range roles {
+		if !strings.Contains(role.RoleARN, ":role/") || !strings.Contains(role.PrincipalARN, ":saml-provider/") {
+			t.Fatalf("expected role/principal split regardless of ordering, got %+v", role)
+		}
+	}
+}
+
+func TestSelectOktaRole(t *testing.T) {
+	roles := []OktaSAMLRole{
+		{RoleARN: "arn:aws:iam::1:role/Dev", PrincipalARN: "arn:aws:iam::1:saml-provider/okta"},
+		{RoleARN: "arn:aws:iam::1:role/Admin", PrincipalARN: "arn:aws:iam::1:saml-provider/okta"},
+	}
+
+	role, err := selectOktaRole(roles, "arn:aws:iam::1:role/Admin")
+	if err != nil || role.RoleARN != "arn:aws:iam::1:role/Admin" {
+		t.Fatalf("expected preferred role selection, got %+v err=%v", role, err)
+	}
+
+	if _, err := selectOktaRole(roles, "arn:aws:iam::1:role/Missing"); err == nil {
+		t.Fatal("expected error for a preferred role missing from the assertion")
+	}
+
+	if _, err := selectOktaRole(roles, ""); err == nil || !strings.Contains(err.Error(), "set role_arn") {
+		t.Fatalf("expected multi-role error asking for role_arn, got %v", err)
+	}
+
+	single := roles[:1]
+	role, err = selectOktaRole(single, "")
+	if err != nil || role.RoleARN != "arn:aws:iam::1:role/Dev" {
+		t.Fatalf("expected single role auto-selection, got %+v err=%v", role, err)
+	}
+}
+
+func newOktaTestServer(t *testing.T, authnStatus string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/authn", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST authn, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"status":%q,"sessionToken":"tok-123"}`, authnStatus)
+	})
+	mux.HandleFunc("/home/amazon_aws/app123/272", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("sessionToken") != "tok-123" {
+			t.Fatalf("expected session token on embed link, got %q", r.URL.RawQuery)
+		}
+		fmt.Fprintf(w, `<html><form><input type="hidden" name="SAMLResponse" value="%s"/></form></html>`, testAssertionB64())
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+func oktaTestConfig(orgURL string) *config.Config {
+	return &config.Config{
+		ContextName: "okta-prod",
+		Region:      "us-east-1",
+		AuthType:    config.AuthTypeOktaSAML,
+		OktaOrgURL:  orgURL,
+		OktaAppID:   "amazon_aws/app123/272",
+		RoleArn:     "arn:aws:iam::111111111111:role/Admin",
+	}
+}
+
+func stubOktaSeams(t *testing.T) (saved *awsservice.OktaSAMLSession) {
+	t.Helper()
+	origPrompt := promptOktaCredentialsFn
+	origSTS := stsAssumeRoleWithSAMLFn
+	origCached := cachedOktaSessionFn
+	origSave := saveOktaSessionFn
+	t.Cleanup(func() {
+		promptOktaCredentialsFn = origPrompt
+		stsAssumeRoleWithSAMLFn = origSTS
+		cachedOktaSessionFn = origCached
+		saveOktaSessionFn = origSave
+	})
+
+	promptOktaCredentialsFn = func(string) (string, string, error) {
+		return "user@example.com", "hunter2", nil
+	}
+	cachedOktaSessionFn = func(*config.Config) (awsservice.OktaSAMLSession, bool) {
+		return awsservice.OktaSAMLSession{}, false
+	}
+	saved = &awsservice.OktaSAMLSession{}
+	saveOktaSessionFn = func(_ *config.Config, session awsservice.OktaSAMLSession) error {
+		*saved = session
+		return nil
+	}
+	expiry := time.Now().Add(time.Hour)
+	stsAssumeRoleWithSAMLFn = func(_ context.Context, _ string, input *sts.AssumeRoleWithSAMLInput) (*sts.AssumeRoleWithSAMLOutput, error) {
+		if aws.ToString(input.RoleArn) != "arn:aws:iam::111111111111:role/Admin" {
+			return nil, fmt.Errorf("unexpected role %q", aws.ToString(input.RoleArn))
+		}
+		if aws.ToString(input.SAMLAssertion) == "" {
+			return nil, fmt.Errorf("missing SAML assertion")
+		}
+		return &sts.AssumeRoleWithSAMLOutput{Credentials: &ststypes.Credentials{
+			AccessKeyId:     aws.String("AKIAOKTA"),
+			SecretAccessKey: aws.String("secret"),
+			SessionToken:    aws.String("token"),
+			Expiration:      &expiry,
+		}}, nil
+	}
+	return saved
+}
+
+func TestResolveOktaSAMLSessionEndToEnd(t *testing.T) {
+	server := newOktaTestServer(t, "SUCCESS")
+	saved := stubOktaSeams(t)
+
+	session, err := ResolveOktaSAMLSession(context.Background(), oktaTestConfig(server.URL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if session.AccessKeyID != "AKIAOKTA" || session.SessionToken != "token" {
+		t.Fatalf("expected exchanged credentials, got %+v", session)
+	}
+	if saved.AccessKeyID != "AKIAOKTA" {
+		t.Fatalf("expected session to be cached, got %+v", saved)
+	}
+}
+
+func TestResolveOktaSAMLSessionReusesCache(t *testing.T) {
+	stubOktaSeams(t)
+	prompted := false
+	promptOktaCredentialsFn = func(string) (string, string, error) {
+		prompted = true
+		return "", "", fmt.Errorf("should not prompt")
+	}
+	cachedOktaSessionFn = func(*config.Config) (awsservice.OktaSAMLSession, bool) {
+		return awsservice.OktaSAMLSession{
+			AccessKeyID: "AKIACACHED", Expiration: time.Now().Add(time.Hour),
+		}, true
+	}
+
+	session, err := ResolveOktaSAMLSession(context.Background(), oktaTestConfig("https://acme.okta.com"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if prompted || session.AccessKeyID != "AKIACACHED" {
+		t.Fatalf("expected cached session without prompting, got %+v prompted=%v", session, prompted)
+	}
+}
+
+func TestResolveOktaSAMLSessionRejectsMFARequired(t *testing.T) {
+	server := newOktaTestServer(t, "MFA_REQUIRED")
+	stubOktaSeams(t)
+
+	_, err := ResolveOktaSAMLSession(context.Background(), oktaTestConfig(server.URL))
+	if err == nil || !strings.Contains(err.Error(), "MFA challenge") {
+		t.Fatalf("expected MFA-not-supported error, got %v", err)
+	}
+}
+
+func TestOktaPrimaryAuthRejectsBadCredentials(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := oktaPrimaryAuth(context.Background(), server.Client(), server.URL, "user", "wrong")
+	if err == nil || !strings.Contains(err.Error(), "401") {
+		t.Fatalf("expected credential rejection error, got %v", err)
+	}
+}

--- a/internal/auth/okta_test.go
+++ b/internal/auth/okta_test.go
@@ -208,3 +208,27 @@ func TestOktaPrimaryAuthRejectsBadCredentials(t *testing.T) {
 		t.Fatalf("expected credential rejection error, got %v", err)
 	}
 }
+
+func TestSAMLResponseFromHTMLIsAttributeOrderAgnostic(t *testing.T) {
+	assertion := testAssertionB64()
+	pages := []string{
+		// canonical: name before value, double quotes
+		`<html><form><input type="hidden" name="SAMLResponse" value="` + assertion + `"/></form></html>`,
+		// value before name
+		`<html><form><input value="` + assertion + `" type="hidden" name="SAMLResponse"></form></html>`,
+		// single quotes and extra attributes
+		`<html><form><input id='x' value='` + assertion + `' name='SAMLResponse'/></form></html>`,
+		// unquoted name attribute
+		`<html><form><input name=SAMLResponse value="` + assertion + `"></form></html>`,
+	}
+	for i, page := range pages {
+		got, ok := samlResponseFromHTML([]byte(page))
+		if !ok || got != assertion {
+			t.Fatalf("variant %d: expected assertion to be extracted, ok=%v", i, ok)
+		}
+	}
+
+	if _, ok := samlResponseFromHTML([]byte(`<html><input name="RelayState" value="x"/></html>`)); ok {
+		t.Fatal("expected no match without a SAMLResponse input")
+	}
+}

--- a/internal/services/aws/okta_saml_cache.go
+++ b/internal/services/aws/okta_saml_cache.go
@@ -1,0 +1,88 @@
+package aws
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"unic/internal/config"
+)
+
+// OktaSAMLSession holds cached AWS credentials obtained through the Okta SAML
+// exchange. The Okta password and session token are never cached.
+type OktaSAMLSession struct {
+	AccessKeyID     string    `json:"access_key_id"`
+	SecretAccessKey string    `json:"secret_access_key"`
+	SessionToken    string    `json:"session_token"`
+	Expiration      time.Time `json:"expiration"`
+}
+
+// Valid reports whether the session is still usable with a small clock skew margin.
+func (s OktaSAMLSession) Valid() bool {
+	return s.AccessKeyID != "" && time.Now().Add(2*time.Minute).Before(s.Expiration)
+}
+
+// oktaSAMLCacheDirFn is a test seam for redirecting the cache directory.
+var oktaSAMLCacheDirFn = defaultOktaSAMLCacheDir
+
+func defaultOktaSAMLCacheDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "unic", "cache", "okta-saml"), nil
+}
+
+func oktaSAMLCachePath(cfg *config.Config) (string, error) {
+	dir, err := oktaSAMLCacheDirFn()
+	if err != nil {
+		return "", err
+	}
+	hash := sha1.Sum([]byte(cfg.OktaOrgURL + "|" + cfg.OktaAppID + "|" + cfg.RoleArn))
+	return filepath.Join(dir, hex.EncodeToString(hash[:])+".json"), nil
+}
+
+// CachedOktaSAMLSession returns the cached session for the context when it
+// exists and has not expired.
+func CachedOktaSAMLSession(cfg *config.Config) (OktaSAMLSession, bool) {
+	path, err := oktaSAMLCachePath(cfg)
+	if err != nil {
+		return OktaSAMLSession{}, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return OktaSAMLSession{}, false
+	}
+	var session OktaSAMLSession
+	if err := json.Unmarshal(data, &session); err != nil {
+		return OktaSAMLSession{}, false
+	}
+	if !session.Valid() {
+		return OktaSAMLSession{}, false
+	}
+	return session, true
+}
+
+// SaveOktaSAMLSession caches the session with owner-only permissions so the
+// TUI can reuse it passively until expiry.
+func SaveOktaSAMLSession(cfg *config.Config, session OktaSAMLSession) error {
+	path, err := oktaSAMLCachePath(cfg)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("failed to create okta-saml cache directory: %w", err)
+	}
+	data, err := json.Marshal(session)
+	if err != nil {
+		return fmt.Errorf("failed to marshal okta-saml session: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("failed to write okta-saml session cache: %w", err)
+	}
+	return nil
+}

--- a/internal/services/aws/okta_saml_cache_test.go
+++ b/internal/services/aws/okta_saml_cache_test.go
@@ -1,0 +1,88 @@
+package aws
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"unic/internal/config"
+)
+
+func oktaCacheTestConfig() *config.Config {
+	return &config.Config{
+		ContextName: "okta-prod",
+		Region:      "us-east-1",
+		AuthType:    config.AuthTypeOktaSAML,
+		OktaOrgURL:  "https://acme.okta.com",
+		OktaAppID:   "amazon_aws/app123/272",
+	}
+}
+
+func stubOktaCacheDir(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	orig := oktaSAMLCacheDirFn
+	t.Cleanup(func() { oktaSAMLCacheDirFn = orig })
+	oktaSAMLCacheDirFn = func() (string, error) { return dir, nil }
+}
+
+func TestOktaSAMLSessionCacheRoundTripAndExpiry(t *testing.T) {
+	stubOktaCacheDir(t)
+	cfg := oktaCacheTestConfig()
+
+	if _, ok := CachedOktaSAMLSession(cfg); ok {
+		t.Fatal("expected empty cache before save")
+	}
+
+	session := OktaSAMLSession{
+		AccessKeyID:     "AKIAOKTA",
+		SecretAccessKey: "secret",
+		SessionToken:    "token",
+		Expiration:      time.Now().Add(time.Hour),
+	}
+	if err := SaveOktaSAMLSession(cfg, session); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, ok := CachedOktaSAMLSession(cfg)
+	if !ok || got.AccessKeyID != "AKIAOKTA" {
+		t.Fatalf("expected cached session, got %+v ok=%v", got, ok)
+	}
+
+	expired := session
+	expired.Expiration = time.Now().Add(30 * time.Second)
+	if err := SaveOktaSAMLSession(cfg, expired); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := CachedOktaSAMLSession(cfg); ok {
+		t.Fatal("expected near-expiry session to be rejected")
+	}
+}
+
+func TestNewAwsRepositoryOktaSAMLUsesCachedSession(t *testing.T) {
+	stubOktaCacheDir(t)
+	cfg := oktaCacheTestConfig()
+
+	_, err := NewAwsRepository(context.Background(), cfg)
+	if err == nil || !strings.Contains(err.Error(), "unic env okta-prod") {
+		t.Fatalf("expected cache-miss error pointing at unic env, got %v", err)
+	}
+
+	session := OktaSAMLSession{
+		AccessKeyID:     "AKIAOKTA",
+		SecretAccessKey: "secret",
+		SessionToken:    "token",
+		Expiration:      time.Now().Add(time.Hour),
+	}
+	if err := SaveOktaSAMLSession(cfg, session); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	repo, err := NewAwsRepository(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	creds, err := repo.awsCfg.Credentials.Retrieve(context.Background())
+	if err != nil || creds.AccessKeyID != "AKIAOKTA" {
+		t.Fatalf("expected cached credentials in repository, got %+v err=%v", creds, err)
+	}
+}

--- a/internal/services/aws/repository.go
+++ b/internal/services/aws/repository.go
@@ -357,9 +357,24 @@ func NewAwsRepository(ctx context.Context, cfg *config.Config) (*AwsRepository, 
 		}
 
 	case config.AuthTypeOktaSAML:
-		// Schema-only for now: runtime credential exchange lands with the
-		// Okta SAML provider (#85).
-		return nil, fmt.Errorf("context %q uses okta_saml, whose runtime credential exchange is not implemented yet", cfg.ContextName)
+		// The TUI cannot prompt for Okta credentials: reuse the cached
+		// session written by the CLI flows, or fail with a pointer to them.
+		session, ok := CachedOktaSAMLSession(cfg)
+		if !ok {
+			return nil, fmt.Errorf(
+				"context %q has no valid Okta SAML session; run 'unic env %s' first to sign in to Okta",
+				cfg.ContextName, cfg.ContextName,
+			)
+		}
+		awsCfg, err = LoadBaseConfig(ctx, cfg.Region, "")
+		if err != nil {
+			return nil, fmt.Errorf("failed to load AWS config: %w", err)
+		}
+		awsCfg.Credentials = credentials.NewStaticCredentialsProvider(
+			session.AccessKeyID,
+			session.SecretAccessKey,
+			session.SessionToken,
+		)
 
 	default:
 		// Legacy / no auth_type — auto-detect from config fields.

--- a/internal/services/aws/repository_test.go
+++ b/internal/services/aws/repository_test.go
@@ -4,13 +4,10 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
-
-	"unic/internal/config"
 )
 
 func TestLoadBaseConfig_ExplicitProfileOverridesEnvCredentials(t *testing.T) {
@@ -83,16 +80,5 @@ func TestLoadBaseConfig_UsesEnvCredentialsWhenProfileUnset(t *testing.T) {
 
 	if creds.AccessKeyID != "ENVKEY" {
 		t.Fatalf("expected env credentials, got %q from %q", creds.AccessKeyID, creds.Source)
-	}
-}
-
-func TestNewAwsRepositoryRejectsOktaSAMLForNow(t *testing.T) {
-	_, err := NewAwsRepository(context.Background(), &config.Config{
-		ContextName: "okta-prod",
-		AuthType:    config.AuthTypeOktaSAML,
-		Region:      "us-east-1",
-	})
-	if err == nil || !strings.Contains(err.Error(), "okta_saml") {
-		t.Fatalf("expected okta_saml not-implemented error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Implements #85 and #86 (Okta SAML track #26). Stacked on the #84 schema PR (base branch: `feature/issue-84-okta-saml-schema`); merge that first.

- **Exchange provider** (`internal/auth/okta.go`): Okta primary authentication (`/api/v1/authn`) → one-time session token → SAML assertion scraped from the app embed link's auto-submit form → `sts:AssumeRoleWithSAML` with anonymous credentials.
- **Credential input**: prompt on stderr with no-echo password input (`golang.org/x/term`); `UNIC_OKTA_USERNAME`/`UNIC_OKTA_PASSWORD` env vars override prompting for automation. Passwords, session tokens, and MFA secrets are never persisted.
- **Deterministic role selection**: the context's `role_arn` wins; a single assertion role is auto-selected; multiple roles without a preference produce an explicit error listing the ARNs.
- **Session cache** (`internal/services/aws/okta_saml_cache.go`): exchanged AWS credentials cached under `~/.config/unic/cache/okta-saml/` (0700 dir / 0600 files, keyed by org|app|role hash) with a 2-minute expiry skew, mirroring the SSO and assume-role MFA cache patterns.
- **Wiring**: `unic env` resolves cached-or-fresh sessions; the TUI (`NewAwsRepository`) passively reuses a valid cached session and otherwise fails fast with `run 'unic env <context>' first to sign in to Okta`.
- Okta `MFA_REQUIRED`/`MFA_ENROLL` responses are rejected with a clear pointer to the upcoming #87 challenge flow.

## Testing

- `go test ./...` passes: SAML role parsing (both role/provider orderings), role selection (preferred/single/multiple/missing), end-to-end resolve against an `httptest` Okta (success, MFA_REQUIRED, 401), cache reuse without prompting, cache round-trip/expiry, and repository cache-hit/cache-miss paths.
- `make build` passes.

Closes #85
Closes #86

Part of #26
