### PR TITLE
feat: add global command palette with cross-service fuzzy search

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ checks:
 | `C` | Open context picker |
 | `R` | Switch between the active context's configured resource regions |
 | `S` | Open settings |
+| `P` | Open the command palette (fuzzy search across features, contexts, and indexed resources) |
 | `/` | Toggle filter mode on supported screens |
 | `f` | Favorite/unfavorite the selected service or context on supported lists |
 | `?` | Toggle context-aware shortcut help |
@@ -425,6 +426,8 @@ checks:
 | Context Picker | `a` add context, `f` favorite/unfavorite selected context, type or `/` filter, `s` setup selected context and quit, `y` copy selected exports and quit, filter-mode `Ctrl+S` setup selected filtered context, filter-mode `Ctrl+Y` copy selected filtered exports, `u` clear shell context and quit with a final confirmation message |
 | ECR | `Enter` images, `d` repository detail, `/` filter, `r` refresh, image detail `c` copy digest, `t` copy tag |
 | Lambda | `Enter` invoke, `d` detail, `l` view CloudWatch Logs, `/` filter, `r` refresh |
+
+The command palette (`P`) fuzzy-searches three kinds of items from anywhere outside text-entry screens: service features (jump straight into a browser), contexts (switch without opening the picker), and resources indexed across services. Opening the palette starts an async index of EC2 instances, RDS instances, Lambda functions, S3 buckets, ECS clusters, and Route53 zones in the current context; results stream in as they load, per-service failures are shown inline, and matching covers names, IDs, and ARNs where available. Selecting a resource jumps to the owning browser with the shared filter prefilled to that resource.
 
 The service list defaults to favorites first, then alphabetical order. Press `f` to favorite or unfavorite the selected service; favorites are saved under `favorites.services` in `config.yaml` and rendered with a distinct marker/style. The context picker also supports `f`; context favorites are saved under `favorites.contexts`, displayed first in the picker, and rendered with a distinct color style while preserving the configured context order within favorite and non-favorite groups. The service list supports `/` filtering across service names, feature names, and feature descriptions. Shared list filters use fuzzy matching with inline match highlighting. While filter mode stays active, `↑`/`↓` continue to move through the filtered results without requiring an extra Enter first. Filtering is currently available on the service list, EC2 SSM instances, EC2 inventory instances, IAM users, VPCs, subnets, RDS instances, Route53 zones/records, CloudWatch metrics, CloudWatch log groups/streams, Secrets Manager resources, ECS clusters/services, EKS clusters/node groups/add-ons, ECR repositories/images, FIS experiment templates/history, S3 buckets/objects, Lambda functions, Bedrock API keys, and the context picker.
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -110,6 +110,7 @@ const (
 	screenContextSSOAccountList
 	screenContextSSORoleList
 	screenRegionPicker
+	screenCommandPalette
 	screenSettings
 	screenLoading
 	screenError
@@ -190,6 +191,9 @@ type Model struct {
 	contextSSORoleIdx    int
 	regionIdx            int
 	regionPrevScreen     screen
+
+	// Command palette
+	palette paletteModel
 
 	// Context add wizard
 	addStep     int // 0=auth_type select, 1+=field input, -1=confirm
@@ -454,6 +458,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.updateAvailable = msg.version
 		}
 		return m, nil
+	case paletteResourcesIndexedMsg:
+		m.palette.indexing = false
+		m.palette.resources = msg.items
+		m.palette.indexErrs = msg.errs
+		if m.screen == screenCommandPalette {
+			m.palette.refilter()
+		}
+		return m, nil
 	case spinner.TickMsg:
 		if m.screen != screenLoading && m.screen != screenInspectorScanning {
 			return m, nil
@@ -552,6 +564,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.screen = screenSettings
 			return m, nil
 		}
+		// Global command palette — P opens fuzzy search across features,
+		// contexts, and indexed resources (skip text-entry screens).
+		if msg.String() == "P" && !m.filterTI.Focused() && m.screen != screenCommandPalette &&
+			!m.isTextEntryScreen() {
+			m.deactivateFilter()
+			return m.openPalette()
+		}
 
 		for _, submodel := range m.featureSubmodels() {
 			if newM, cmd, handled := submodel.HandleKey(&m, msg); handled {
@@ -576,6 +595,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateContextSSORoleList(msg)
 		case screenRegionPicker:
 			return m.updateRegionPicker(msg)
+		case screenCommandPalette:
+			return m.updatePalette(msg)
 		case screenSettings:
 			return m.updateSettings(msg)
 		case screenError:
@@ -642,52 +663,58 @@ func (m Model) updateFeatureList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.featIdx = nextListIndex(m.featIdx, len(m.features))
 	case "enter":
 		if m.featIdx < len(m.features) {
-			feat := m.features[m.featIdx]
-			switch feat.Kind {
-			case domain.FeatureSSMSession:
-				return m.startLoading(m.loadInstances())
-			case domain.FeatureEC2InstanceBrowser:
-				return m.ec2Browser.Start(&m)
-			case domain.FeatureVPCBrowser:
-				return m.vpc.Start(&m)
-			case domain.FeatureReachabilityAnalyzer:
-				return m.reachability.Start(&m)
-			case domain.FeatureRDSBrowser:
-				return m.rds.Start(&m)
-			case domain.FeatureRoute53Browser:
-				return m.route53.Start(&m)
-			case domain.FeatureSecretsBrowser:
-				return m.secrets.Start(&m)
-			case domain.FeatureCloudWatchMetrics:
-				return m.cwMetrics.Start(&m)
-			case domain.FeatureCloudWatchLogsBrowser:
-				return m.cwLogs.Start(&m)
-			case domain.FeatureS3Browser:
-				return m.s3.Start(&m)
-			case domain.FeatureSecurityGroupBrowser:
-				return m.security.Start(&m)
-			case domain.FeatureIAMUsersBrowser:
-				return m.iam.StartUsers(&m)
-			case domain.FeatureListAccessKeys:
-				return m.iam.StartKeys(&m, false)
-			case domain.FeatureRotateAccessKey:
-				return m.iam.StartKeys(&m, true)
-			case domain.FeatureECSExec:
-				return m.ecs.Start(&m)
-			case domain.FeatureECRRepositoryBrowser:
-				return m.ecr.Start(&m)
-			case domain.FeatureECRLoginHelper:
-				return m.ecr.StartLogin(&m)
-			case domain.FeatureEKSBrowser:
-				return m.eks.Start(&m)
-			case domain.FeatureFISTemplateBrowser:
-				return m.fis.Start(&m)
-			case domain.FeatureLambdaBrowser:
-				return m.lambda.Start(&m)
-			case domain.FeatureBedrockAPIKeys:
-				return m.bedrock.Start(&m)
-			}
+			return m.startFeature(m.features[m.featIdx].Kind)
 		}
+	}
+	return m, nil
+}
+
+// startFeature launches the given feature. It is shared between the feature
+// list and the command palette.
+func (m Model) startFeature(kind domain.FeatureKind) (tea.Model, tea.Cmd) {
+	switch kind {
+	case domain.FeatureSSMSession:
+		return m.startLoading(m.loadInstances())
+	case domain.FeatureEC2InstanceBrowser:
+		return m.ec2Browser.Start(&m)
+	case domain.FeatureVPCBrowser:
+		return m.vpc.Start(&m)
+	case domain.FeatureReachabilityAnalyzer:
+		return m.reachability.Start(&m)
+	case domain.FeatureRDSBrowser:
+		return m.rds.Start(&m)
+	case domain.FeatureRoute53Browser:
+		return m.route53.Start(&m)
+	case domain.FeatureSecretsBrowser:
+		return m.secrets.Start(&m)
+	case domain.FeatureCloudWatchMetrics:
+		return m.cwMetrics.Start(&m)
+	case domain.FeatureCloudWatchLogsBrowser:
+		return m.cwLogs.Start(&m)
+	case domain.FeatureS3Browser:
+		return m.s3.Start(&m)
+	case domain.FeatureSecurityGroupBrowser:
+		return m.security.Start(&m)
+	case domain.FeatureIAMUsersBrowser:
+		return m.iam.StartUsers(&m)
+	case domain.FeatureListAccessKeys:
+		return m.iam.StartKeys(&m, false)
+	case domain.FeatureRotateAccessKey:
+		return m.iam.StartKeys(&m, true)
+	case domain.FeatureECSExec:
+		return m.ecs.Start(&m)
+	case domain.FeatureECRRepositoryBrowser:
+		return m.ecr.Start(&m)
+	case domain.FeatureECRLoginHelper:
+		return m.ecr.StartLogin(&m)
+	case domain.FeatureEKSBrowser:
+		return m.eks.Start(&m)
+	case domain.FeatureFISTemplateBrowser:
+		return m.fis.Start(&m)
+	case domain.FeatureLambdaBrowser:
+		return m.lambda.Start(&m)
+	case domain.FeatureBedrockAPIKeys:
+		return m.bedrock.Start(&m)
 	}
 	return m, nil
 }
@@ -738,6 +765,8 @@ func (m Model) View() string {
 		v = m.viewContextSSORoleList()
 	case screenRegionPicker:
 		v = m.viewRegionPicker()
+	case screenCommandPalette:
+		v = m.viewPalette()
 	case screenSettings:
 		v = m.viewSettings()
 	case screenLoading:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -459,6 +459,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case paletteResourcesIndexedMsg:
+		// Ignore results from a superseded palette invocation; a slow index
+		// started under an earlier open (or another context) must not
+		// overwrite the current session.
+		if msg.generation != m.palette.generation {
+			return m, nil
+		}
 		m.palette.indexing = false
 		m.palette.resources = msg.items
 		m.palette.indexErrs = msg.errs

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -87,6 +87,9 @@ func (m Model) globalHelpShortcuts() []helpShortcut {
 	if m.canSwitchResourceRegion() {
 		shortcuts = append(shortcuts, helpShortcut{"R", "Switch the active resource region"})
 	}
+	if m.screen != screenCommandPalette && !m.isTextEntryScreen() {
+		shortcuts = append(shortcuts, helpShortcut{"P", "Open the command palette"})
+	}
 	return shortcuts
 }
 
@@ -741,6 +744,13 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 			{"esc", "Go back to the account list"},
 			{"q", "Cancel and return to the context picker"},
 		}
+	case screenCommandPalette:
+		return []helpShortcut{
+			{"type", "Fuzzy-search features, contexts, and resources"},
+			{"↑/↓", "Move between results"},
+			{"enter", "Jump to the selected result"},
+			{"esc", "Close the palette"},
+		}
 	case screenRegionPicker:
 		return []helpShortcut{
 			{"↑/↓, j/k", "Move between configured resource regions"},
@@ -998,6 +1008,8 @@ func (m Model) helpScreenTitle() string {
 		return "Select SSO Role"
 	case screenRegionPicker:
 		return "Resource Region Picker"
+	case screenCommandPalette:
+		return "Command Palette"
 	case screenSettings:
 		return "Settings"
 	case screenLoading:

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -47,8 +47,9 @@ type callerIdentityMsg struct {
 }
 
 type paletteResourcesIndexedMsg struct {
-	items []paletteItem
-	errs  []string
+	generation int
+	items      []paletteItem
+	errs       []string
 }
 
 type screenReadyMsg struct{}

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -46,6 +46,11 @@ type callerIdentityMsg struct {
 	identity *awsservice.CallerIdentity
 }
 
+type paletteResourcesIndexedMsg struct {
+	items []paletteItem
+	errs  []string
+}
+
 type screenReadyMsg struct{}
 
 type bootupStartMsg struct{}

--- a/internal/app/screen_palette.go
+++ b/internal/app/screen_palette.go
@@ -1,0 +1,347 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"unic/internal/domain"
+	awsservice "unic/internal/services/aws"
+)
+
+// The command palette is a global fuzzy finder over three item kinds:
+// service features (jump to a browser), contexts (switch), and resources
+// indexed across services (jump to the owning browser with the filter
+// prefilled to the resource). Features and contexts are available instantly;
+// resources stream in from an async index built when the palette opens.
+
+type paletteItemKind int
+
+const (
+	paletteItemFeature paletteItemKind = iota
+	paletteItemContext
+	paletteItemResource
+)
+
+type paletteItem struct {
+	kind         paletteItemKind
+	label        string
+	filterText   string
+	feature      domain.FeatureKind
+	service      domain.AwsService
+	filterTarget filterTarget
+	resourceKey  string
+	contextName  string
+}
+
+func (i paletteItem) DisplayTitle() string { return i.label }
+func (i paletteItem) FilterText() string   { return strings.ToLower(i.filterText) }
+
+type paletteModel struct {
+	static     []paletteItem
+	resources  []paletteItem
+	filtered   []paletteItem
+	idx        int
+	query      string
+	indexing   bool
+	indexErrs  []string
+	prevScreen screen
+}
+
+// openPalette builds the instantly-available items (features, contexts) and
+// starts the async resource index for the current context.
+func (m Model) openPalette() (tea.Model, tea.Cmd) {
+	m.palette.prevScreen = m.screen
+	m.palette.query = ""
+	m.palette.idx = 0
+	m.palette.resources = nil
+	m.palette.indexErrs = nil
+	m.palette.indexing = true
+
+	var static []paletteItem
+	for _, svc := range domain.Catalog() {
+		for _, feat := range svc.Features {
+			static = append(static, paletteItem{
+				kind:       paletteItemFeature,
+				label:      fmt.Sprintf("%-10s %s", svc.Name, feat.Kind),
+				filterText: fmt.Sprintf("%s %s %s", svc.Name, feat.Kind, feat.Description),
+				feature:    feat.Kind,
+				service:    svc.Name,
+			})
+		}
+	}
+	for _, ctx := range m.ctxList {
+		static = append(static, paletteItem{
+			kind:        paletteItemContext,
+			label:       fmt.Sprintf("%-10s switch to %s", "Context", ctx.Name),
+			filterText:  fmt.Sprintf("context switch %s", ctx.FilterText()),
+			contextName: ctx.Name,
+		})
+	}
+	m.palette.static = static
+	m.palette.filtered = m.palette.allItems()
+
+	m.screen = screenCommandPalette
+	return m, m.indexPaletteResources()
+}
+
+func (pm paletteModel) allItems() []paletteItem {
+	items := make([]paletteItem, 0, len(pm.static)+len(pm.resources))
+	items = append(items, pm.resources...)
+	items = append(items, pm.static...)
+	return items
+}
+
+func (pm *paletteModel) refilter() {
+	pm.filtered = applyFilter(pm.allItems(), pm.query)
+	if pm.idx >= len(pm.filtered) {
+		pm.idx = 0
+	}
+}
+
+func (m Model) updatePalette(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.screen = m.palette.prevScreen
+	case "up":
+		m.palette.idx = previousListIndex(m.palette.idx, len(m.palette.filtered))
+	case "down":
+		m.palette.idx = nextListIndex(m.palette.idx, len(m.palette.filtered))
+	case "backspace":
+		if len(m.palette.query) > 0 {
+			m.palette.query = m.palette.query[:len(m.palette.query)-1]
+			m.palette.refilter()
+		}
+	case "enter":
+		if len(m.palette.filtered) == 0 || m.palette.idx >= len(m.palette.filtered) {
+			return m, nil
+		}
+		return m.executePaletteItem(m.palette.filtered[m.palette.idx])
+	default:
+		if runes := msg.Runes; len(runes) > 0 {
+			m.palette.query += string(runes)
+			m.palette.refilter()
+		}
+	}
+	return m, nil
+}
+
+func (m Model) executePaletteItem(item paletteItem) (tea.Model, tea.Cmd) {
+	switch item.kind {
+	case paletteItemContext:
+		return m.startLoading(m.switchContext(item.contextName))
+	case paletteItemFeature, paletteItemResource:
+		m.enterServiceForPalette(item)
+		if item.kind == paletteItemResource && item.filterTarget != filterNone {
+			// Prefill the browser's shared filter so the target resource is
+			// selected as soon as the list loads.
+			m.storeFilterValue(item.filterTarget, item.resourceKey)
+		}
+		return m.startFeature(item.feature)
+	}
+	return m, nil
+}
+
+// enterServiceForPalette aligns the service/feature list state with the jump
+// target so esc-navigation behaves as if the user drilled in manually.
+func (m *Model) enterServiceForPalette(item paletteItem) {
+	for i, svc := range m.services {
+		if svc.Name != item.service {
+			continue
+		}
+		m.svcIdx = i
+		m.features = svc.Features
+		for j, feat := range svc.Features {
+			if feat.Kind == item.feature {
+				m.featIdx = j
+				break
+			}
+		}
+		return
+	}
+}
+
+// indexPaletteResources lists resources across services concurrently. Per-
+// service failures surface as notes without hiding other services' results.
+func (m Model) indexPaletteResources() tea.Cmd {
+	cfg := m.cfg
+	return func() tea.Msg {
+		ctx := context.Background()
+		repo, err := awsservice.NewAwsRepository(ctx, cfg)
+		if err != nil {
+			return paletteResourcesIndexedMsg{errs: []string{err.Error()}}
+		}
+
+		type source struct {
+			name  string
+			fetch func() ([]paletteItem, error)
+		}
+		sources := []source{
+			{"EC2", func() ([]paletteItem, error) {
+				instances, err := repo.ListEC2Instances(ctx)
+				if err != nil {
+					return nil, err
+				}
+				items := make([]paletteItem, 0, len(instances))
+				for _, inst := range instances {
+					items = append(items, paletteResourceItem("EC2", inst.DisplayTitle(), inst.FilterText(),
+						domain.FeatureEC2InstanceBrowser, domain.ServiceEC2, filterEC2BrowserInstances, inst.InstanceID))
+				}
+				return items, nil
+			}},
+			{"RDS", func() ([]paletteItem, error) {
+				instances, err := repo.ListDBInstances(ctx)
+				if err != nil {
+					return nil, err
+				}
+				items := make([]paletteItem, 0, len(instances))
+				for _, inst := range instances {
+					items = append(items, paletteResourceItem("RDS", inst.DisplayTitle(), inst.FilterText(),
+						domain.FeatureRDSBrowser, domain.ServiceRDS, filterRDS, inst.DBInstanceID))
+				}
+				return items, nil
+			}},
+			{"Lambda", func() ([]paletteItem, error) {
+				functions, err := repo.ListFunctions(ctx)
+				if err != nil {
+					return nil, err
+				}
+				items := make([]paletteItem, 0, len(functions))
+				for _, fn := range functions {
+					items = append(items, paletteResourceItem("Lambda", fn.DisplayTitle(), fn.FilterText(),
+						domain.FeatureLambdaBrowser, domain.ServiceLambda, filterLambdaFunctions, fn.Name))
+				}
+				return items, nil
+			}},
+			{"S3", func() ([]paletteItem, error) {
+				buckets, err := repo.ListBuckets(ctx)
+				if err != nil {
+					return nil, err
+				}
+				items := make([]paletteItem, 0, len(buckets))
+				for _, bucket := range buckets {
+					items = append(items, paletteResourceItem("S3", bucket.DisplayTitle(), bucket.FilterText(),
+						domain.FeatureS3Browser, domain.ServiceS3, filterS3Buckets, bucket.Name))
+				}
+				return items, nil
+			}},
+			{"ECS", func() ([]paletteItem, error) {
+				clusters, err := repo.ListClusters(ctx)
+				if err != nil {
+					return nil, err
+				}
+				items := make([]paletteItem, 0, len(clusters))
+				for _, cluster := range clusters {
+					items = append(items, paletteResourceItem("ECS", cluster.DisplayTitle(), cluster.FilterText(),
+						domain.FeatureECSExec, domain.ServiceECS, filterECSClusters, cluster.Name))
+				}
+				return items, nil
+			}},
+			{"Route53", func() ([]paletteItem, error) {
+				zones, err := repo.ListHostedZones(ctx)
+				if err != nil {
+					return nil, err
+				}
+				items := make([]paletteItem, 0, len(zones))
+				for _, zone := range zones {
+					items = append(items, paletteResourceItem("Route53", zone.DisplayTitle(), zone.FilterText(),
+						domain.FeatureRoute53Browser, domain.ServiceRoute53, filterRoute53Zones, zone.Name))
+				}
+				return items, nil
+			}},
+		}
+
+		results := make([][]paletteItem, len(sources))
+		errs := make([]string, len(sources))
+		var wg sync.WaitGroup
+		for i, src := range sources {
+			wg.Add(1)
+			go func(i int, src source) {
+				defer wg.Done()
+				items, err := src.fetch()
+				if err != nil {
+					errs[i] = fmt.Sprintf("%s: %v", src.name, err)
+					return
+				}
+				results[i] = items
+			}(i, src)
+		}
+		wg.Wait()
+
+		var items []paletteItem
+		var failures []string
+		for i := range sources {
+			items = append(items, results[i]...)
+			if errs[i] != "" {
+				failures = append(failures, errs[i])
+			}
+		}
+		sort.SliceStable(items, func(i, j int) bool { return items[i].label < items[j].label })
+		return paletteResourcesIndexedMsg{items: items, errs: failures}
+	}
+}
+
+func paletteResourceItem(typeLabel, title, filterText string, feature domain.FeatureKind, service domain.AwsService, target filterTarget, key string) paletteItem {
+	return paletteItem{
+		kind:         paletteItemResource,
+		label:        fmt.Sprintf("%-10s %s", typeLabel, title),
+		filterText:   fmt.Sprintf("%s %s", typeLabel, filterText),
+		feature:      feature,
+		service:      service,
+		filterTarget: target,
+		resourceKey:  key,
+	}
+}
+
+func (m Model) viewPalette() string {
+	var b strings.Builder
+	var panel strings.Builder
+	b.WriteString(m.renderStatusBar())
+	b.WriteString(titleStyle.Render("Command Palette"))
+	b.WriteString("\n")
+	b.WriteString(filterStyle.Render(fmt.Sprintf("  > %s▏", m.palette.query)))
+	b.WriteString("\n")
+	if m.palette.indexing {
+		b.WriteString(dimStyle.Render("  Indexing resources across services..."))
+		b.WriteString("\n")
+	}
+	for _, indexErr := range m.palette.indexErrs {
+		b.WriteString(errorStyle.Render("  " + indexErr))
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+
+	if len(m.palette.filtered) == 0 {
+		panel.WriteString(dimStyle.Render("  No matches"))
+		panel.WriteString("\n")
+	} else {
+		visibleLines := max(m.height-11, 5)
+		start := 0
+		if m.palette.idx >= visibleLines {
+			start = m.palette.idx - visibleLines + 1
+		}
+		end := min(start+visibleLines, len(m.palette.filtered))
+		for i := start; i < end; i++ {
+			item := m.palette.filtered[i]
+			cursor := "  "
+			style := normalStyle
+			if i == m.palette.idx {
+				cursor = "> "
+				style = selectedStyle
+			}
+			panel.WriteString(style.Render(cursor + item.label))
+			panel.WriteString("\n")
+		}
+		panel.WriteString("\n")
+		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d items", len(m.palette.filtered), len(m.palette.allItems()))))
+	}
+
+	b.WriteString(m.renderListPanel(panel.String()))
+	b.WriteString("\n\n")
+	b.WriteString(m.renderHelpBar("type: search • ↑/↓: navigate • enter: jump • esc: close"))
+	return b.String()
+}

--- a/internal/app/screen_palette.go
+++ b/internal/app/screen_palette.go
@@ -50,6 +50,11 @@ type paletteModel struct {
 	indexing   bool
 	indexErrs  []string
 	prevScreen screen
+	// generation identifies the current palette invocation; index results
+	// carry the generation they were started for, so a slow index from an
+	// earlier open (possibly under a different context) can never overwrite
+	// a newer session's results.
+	generation int
 }
 
 // openPalette builds the instantly-available items (features, contexts) and
@@ -61,6 +66,7 @@ func (m Model) openPalette() (tea.Model, tea.Cmd) {
 	m.palette.resources = nil
 	m.palette.indexErrs = nil
 	m.palette.indexing = true
+	m.palette.generation++
 
 	var static []paletteItem
 	for _, svc := range domain.Catalog() {
@@ -112,8 +118,8 @@ func (m Model) updatePalette(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "down":
 		m.palette.idx = nextListIndex(m.palette.idx, len(m.palette.filtered))
 	case "backspace":
-		if len(m.palette.query) > 0 {
-			m.palette.query = m.palette.query[:len(m.palette.query)-1]
+		if runes := []rune(m.palette.query); len(runes) > 0 {
+			m.palette.query = string(runes[:len(runes)-1])
 			m.palette.refilter()
 		}
 	case "enter":
@@ -169,11 +175,12 @@ func (m *Model) enterServiceForPalette(item paletteItem) {
 // service failures surface as notes without hiding other services' results.
 func (m Model) indexPaletteResources() tea.Cmd {
 	cfg := m.cfg
+	generation := m.palette.generation
 	return func() tea.Msg {
 		ctx := context.Background()
 		repo, err := awsservice.NewAwsRepository(ctx, cfg)
 		if err != nil {
-			return paletteResourcesIndexedMsg{errs: []string{err.Error()}}
+			return paletteResourcesIndexedMsg{generation: generation, errs: []string{err.Error()}}
 		}
 
 		type source struct {
@@ -281,7 +288,7 @@ func (m Model) indexPaletteResources() tea.Cmd {
 			}
 		}
 		sort.SliceStable(items, func(i, j int) bool { return items[i].label < items[j].label })
-		return paletteResourcesIndexedMsg{items: items, errs: failures}
+		return paletteResourcesIndexedMsg{generation: generation, items: items, errs: failures}
 	}
 }
 

--- a/internal/app/screen_palette_test.go
+++ b/internal/app/screen_palette_test.go
@@ -93,7 +93,7 @@ func TestPaletteIndexedResourcesStreamIn(t *testing.T) {
 
 	items := []paletteItem{paletteResourceItem("EC2", "web-1 (i-123)", "web-1 i-123",
 		domain.FeatureEC2InstanceBrowser, domain.ServiceEC2, filterEC2BrowserInstances, "i-123")}
-	next, _ := m.Update(paletteResourcesIndexedMsg{items: items, errs: []string{"Route53: access denied"}})
+	next, _ := m.Update(paletteResourcesIndexedMsg{generation: m.palette.generation, items: items, errs: []string{"Route53: access denied"}})
 	model := next.(Model)
 
 	if model.palette.indexing {
@@ -124,5 +124,59 @@ func TestPaletteEscReturnsToPreviousScreen(t *testing.T) {
 	model := next.(Model)
 	if model.screen != screenFeatureList {
 		t.Fatalf("expected esc to restore the previous screen, got %v", model.screen)
+	}
+}
+
+func TestPaletteIgnoresStaleIndexGenerations(t *testing.T) {
+	m := paletteTestModel()
+
+	// First open (generation 1), close, reopen (generation 2).
+	updated, _ := m.openPalette()
+	m = updated.(Model)
+	staleGen := m.palette.generation
+	next, _ := m.updatePalette(tea.KeyMsg{Type: tea.KeyEsc})
+	m = next.(Model)
+	updated, _ = m.openPalette()
+	m = updated.(Model)
+
+	// The slow index from the first open finishes last: it must be dropped.
+	staleItems := []paletteItem{paletteResourceItem("EC2", "stale (i-old)", "stale i-old",
+		domain.FeatureEC2InstanceBrowser, domain.ServiceEC2, filterEC2BrowserInstances, "i-old")}
+	next, _ = m.Update(paletteResourcesIndexedMsg{generation: staleGen, items: staleItems, errs: []string{"stale error"}})
+	m = next.(Model)
+	if !m.palette.indexing {
+		t.Fatal("expected stale results to leave the current indexing state untouched")
+	}
+	if len(m.palette.resources) != 0 || len(m.palette.indexErrs) != 0 {
+		t.Fatalf("expected stale results to be dropped, got %d resources %v", len(m.palette.resources), m.palette.indexErrs)
+	}
+
+	// The current generation's results still apply.
+	freshItems := []paletteItem{paletteResourceItem("EC2", "fresh (i-new)", "fresh i-new",
+		domain.FeatureEC2InstanceBrowser, domain.ServiceEC2, filterEC2BrowserInstances, "i-new")}
+	next, _ = m.Update(paletteResourcesIndexedMsg{generation: m.palette.generation, items: freshItems})
+	m = next.(Model)
+	if m.palette.indexing || len(m.palette.resources) != 1 || m.palette.resources[0].resourceKey != "i-new" {
+		t.Fatalf("expected current-generation results to apply, got %+v indexing=%v", m.palette.resources, m.palette.indexing)
+	}
+}
+
+func TestPaletteBackspaceIsRuneSafe(t *testing.T) {
+	m := paletteTestModel()
+	updated, _ := m.openPalette()
+	m = updated.(Model)
+
+	next, _ := m.updatePalette(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'한'}})
+	m = next.(Model)
+	next, _ = m.updatePalette(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'글'}})
+	m = next.(Model)
+	if m.palette.query != "한글" {
+		t.Fatalf("expected multibyte query, got %q", m.palette.query)
+	}
+
+	next, _ = m.updatePalette(tea.KeyMsg{Type: tea.KeyBackspace})
+	m = next.(Model)
+	if m.palette.query != "한" {
+		t.Fatalf("expected backspace to remove one rune, got %q", m.palette.query)
 	}
 }

--- a/internal/app/screen_palette_test.go
+++ b/internal/app/screen_palette_test.go
@@ -1,0 +1,128 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"unic/internal/config"
+	"unic/internal/domain"
+)
+
+func paletteTestModel() Model {
+	m := New(testConfig(), "", "dev")
+	m.cfg = &config.Config{Region: "us-east-1", ContextName: "dev"}
+	m.ctxList = []config.ContextInfo{{Name: "prod-admin"}, {Name: "dev"}}
+	m.screen = screenServiceList
+	return m
+}
+
+func TestOpenPaletteBuildsFeatureAndContextItems(t *testing.T) {
+	m := paletteTestModel()
+
+	updated, cmd := m.openPalette()
+	model := updated.(Model)
+	if model.screen != screenCommandPalette {
+		t.Fatalf("expected palette screen, got %v", model.screen)
+	}
+	if cmd == nil {
+		t.Fatal("expected resource indexing to start")
+	}
+	if !model.palette.indexing {
+		t.Fatal("expected indexing flag while the resource index builds")
+	}
+
+	var hasFeature, hasContext bool
+	for _, item := range model.palette.filtered {
+		if item.kind == paletteItemFeature && item.feature == domain.FeatureRDSBrowser {
+			hasFeature = true
+		}
+		if item.kind == paletteItemContext && item.contextName == "prod-admin" {
+			hasContext = true
+		}
+	}
+	if !hasFeature || !hasContext {
+		t.Fatalf("expected feature and context items, feature=%v context=%v", hasFeature, hasContext)
+	}
+}
+
+func TestPaletteQueryFiltersItems(t *testing.T) {
+	m := paletteTestModel()
+	updated, _ := m.openPalette()
+	m = updated.(Model)
+
+	for _, r := range "rds browser" {
+		next, _ := m.updatePalette(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = next.(Model)
+	}
+	if len(m.palette.filtered) == 0 {
+		t.Fatal("expected fuzzy matches for 'rds browser'")
+	}
+	for _, item := range m.palette.filtered {
+		if !strings.Contains(item.FilterText(), "rds") {
+			t.Fatalf("expected only RDS-related matches, got %q", item.label)
+		}
+	}
+}
+
+func TestPaletteResourceJumpPrefillsBrowserFilter(t *testing.T) {
+	m := paletteTestModel()
+	updated, _ := m.openPalette()
+	m = updated.(Model)
+
+	item := paletteResourceItem("RDS", "prod-db", "prod-db postgres",
+		domain.FeatureRDSBrowser, domain.ServiceRDS, filterRDS, "prod-db")
+	next, cmd := m.executePaletteItem(item)
+	model := next.(Model)
+	if cmd == nil {
+		t.Fatal("expected the RDS browser to start loading")
+	}
+	if model.filterValue(filterRDS) != "prod-db" {
+		t.Fatalf("expected RDS filter prefilled with the resource key, got %q", model.filterValue(filterRDS))
+	}
+	if model.screen != screenLoading {
+		t.Fatalf("expected loading screen for the jump, got %v", model.screen)
+	}
+}
+
+func TestPaletteIndexedResourcesStreamIn(t *testing.T) {
+	m := paletteTestModel()
+	updated, _ := m.openPalette()
+	m = updated.(Model)
+
+	items := []paletteItem{paletteResourceItem("EC2", "web-1 (i-123)", "web-1 i-123",
+		domain.FeatureEC2InstanceBrowser, domain.ServiceEC2, filterEC2BrowserInstances, "i-123")}
+	next, _ := m.Update(paletteResourcesIndexedMsg{items: items, errs: []string{"Route53: access denied"}})
+	model := next.(Model)
+
+	if model.palette.indexing {
+		t.Fatal("expected indexing flag to clear")
+	}
+	found := false
+	for _, item := range model.palette.filtered {
+		if item.kind == paletteItemResource && item.resourceKey == "i-123" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected indexed resource to appear in results")
+	}
+	view := model.viewPalette()
+	if !strings.Contains(view, "Route53: access denied") {
+		t.Fatalf("expected per-service index error surfaced, got:\n%s", view)
+	}
+}
+
+func TestPaletteEscReturnsToPreviousScreen(t *testing.T) {
+	m := paletteTestModel()
+	m.screen = screenFeatureList
+	updated, _ := m.openPalette()
+	m = updated.(Model)
+
+	next, _ := m.updatePalette(tea.KeyMsg{Type: tea.KeyEsc})
+	model := next.(Model)
+	if model.screen != screenFeatureList {
+		t.Fatalf("expected esc to restore the previous screen, got %v", model.screen)
+	}
+}


### PR DESCRIPTION
## Summary

Implements #132: a global command palette (`P`) with cross-service fuzzy search, usable from anywhere outside text-entry screens.

- **Three item kinds in one list**: service features (jump straight into a browser), contexts (switch without opening the picker), and resources indexed across services.
- **Async cross-service index**: opening the palette concurrently lists EC2 instances, RDS instances, Lambda functions, S3 buckets, ECS clusters, and Route53 hosted zones for the current context. Features/contexts are searchable instantly; resources stream in when the index completes, and per-service failures render inline without hiding other services' results.
- **Fuzzy matching** reuses the shared filter machinery and covers names, IDs, and ARNs where the resource models expose them.
- **Navigation**: selecting a feature launches it through the same dispatch as the feature list (now factored into `startFeature`); selecting a resource jumps to the owning browser with its shared filter prefilled to that resource, so it is selected the moment the list loads; selecting a context runs the existing switch flow (including passive SSO handling). `esc` restores the previous screen, and service/feature list state is aligned so back-navigation behaves as if the user drilled in manually.

## Testing

- `go test ./...` passes: palette open (feature+context items, index kickoff), query filtering, resource-jump filter prefill and loading transition, streamed index results with per-service error surfacing, and esc restore.
- `make build` passes.

## Docs

- README: global key bindings table and a palette behavior paragraph.

Closes #132