### PR TITLE
feat: support role chaining for profile-backed contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,8 +222,8 @@ contexts:
 
 | Auth Type | Meaning | Required Fields |
 |---|---|---|
-| `credential` | Use shared AWS profile credentials | `profile` |
-| `console_login` | Run `aws login` during `unic context setup`, then use the resulting profile-backed console credentials | `profile` |
+| `credential` | Use shared AWS profile credentials, optionally chaining into a role | `profile`; optional `role_arn` (+ `external_id`, `mfa_serial`) |
+| `console_login` | Run `aws login` during `unic context setup`, then use the resulting profile-backed console credentials, optionally chaining into a role | `profile`; optional `role_arn` (+ `external_id`, `mfa_serial`) |
 | `assume_role` | Assume a role from a base profile, optionally with MFA | `profile`, `role_arn`; optional `mfa_serial` |
 | `sso` | Use AWS IAM Identity Center / SSO, reusing a valid AWS CLI SSO cache and prompting for login only when needed | `sso_start_url`, and for concrete contexts `sso_account_id`, `sso_role_name`; `profile` is optional |
 | `okta_saml` | Okta SAML federation: `unic env` signs in to Okta (prompt on stderr, password without echo; `UNIC_OKTA_USERNAME`/`UNIC_OKTA_PASSWORD` for automation), exchanges the SAML assertion via `sts:AssumeRoleWithSAML`, and caches the session under `~/.config/unic/cache/okta-saml/`. The TUI reuses a valid cached session passively. Okta MFA challenges support TOTP codes and Okta Verify push in v1 | `okta_org_url`, `okta_app_id`; `role_arn` required when the assertion carries multiple roles. Passwords and MFA secrets are never stored |

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -178,7 +178,7 @@ UNIC supports five main auth modes.
 - uses a shared AWS profile plus AWS CLI `aws login`
 - `unic context setup` runs `aws login --profile <profile> --region <region>`
 - remains profile-backed after login, so `unic env` exports `AWS_PROFILE` and region variables
-- currently supported only as a standalone context and does not chain with `role_arn`
+- with `role_arn` set, the login profile credentials chain into STS AssumeRole through the same path as assume_role (including the MFA session cache)
 
 ### `assume_role`
 

--- a/docs/architecture.ko.md
+++ b/docs/architecture.ko.md
@@ -187,7 +187,7 @@ UNIC은 현재 다섯 가지 인증 모드를 지원한다.
 - shared AWS profile과 AWS CLI `aws login`을 함께 사용
 - `unic context setup`이 `aws login --profile <profile> --region <region>`을 실행
 - login 이후에도 profile 기반이므로 `unic env`는 `AWS_PROFILE`과 region 변수를 export
-- 현재는 standalone context로만 지원하며 `role_arn` chaining은 지원하지 않음
+- `role_arn`이 설정되면 login profile 자격증명에서 STS AssumeRole로 체이닝하며, assume_role과 동일한 경로(MFA 세션 캐시 포함)를 사용한다
 
 ### `okta_saml`
 

--- a/internal/app/context_add.go
+++ b/internal/app/context_add.go
@@ -34,6 +34,9 @@ var fieldsByAuthType = map[string][]fieldDef{
 		{key: "region", label: "Region", required: true},
 		{key: "regions", label: "Other Resource Regions (optional, comma-separated)", required: false},
 		{key: "profile", label: "Profile", required: true},
+		{key: "role_arn", label: "Role ARN to chain into (optional)", required: false},
+		{key: "external_id", label: "External ID (optional)", required: false},
+		{key: "mfa_serial", label: "MFA Device ARN (optional)", required: false},
 	},
 	"console_login": {
 		{key: "name", label: "Name", required: true},
@@ -41,6 +44,9 @@ var fieldsByAuthType = map[string][]fieldDef{
 		{key: "region", label: "Region", required: true},
 		{key: "regions", label: "Other Resource Regions (optional, comma-separated)", required: false},
 		{key: "profile", label: "Profile", required: true},
+		{key: "role_arn", label: "Role ARN to chain into (optional)", required: false},
+		{key: "external_id", label: "External ID (optional)", required: false},
+		{key: "mfa_serial", label: "MFA Device ARN (optional)", required: false},
 	},
 	"assume_role": {
 		{key: "name", label: "Name", required: true},
@@ -50,6 +56,7 @@ var fieldsByAuthType = map[string][]fieldDef{
 		{key: "profile", label: "Profile", required: true},
 		{key: "role_arn", label: "Role ARN", required: true},
 		{key: "external_id", label: "External ID (optional)", required: false},
+		{key: "mfa_serial", label: "MFA Device ARN (optional)", required: false},
 	},
 	// okta_saml stores only non-secret metadata; passwords and MFA secrets
 	// never go into config.yaml. Runtime credential exchange is tracked in #85.
@@ -150,6 +157,7 @@ func (m Model) saveContext() tea.Cmd {
 				Profile:      m.addValues["profile"],
 				RoleArn:      m.addValues["role_arn"],
 				ExternalID:   m.addValues["external_id"],
+				MFASerial:    m.addValues["mfa_serial"],
 				SSOStartURL:  m.addValues["sso_start_url"],
 				SSORegion:    m.addValues["sso_region"],
 				SSOAccountID: m.addValues["sso_account_id"],

--- a/internal/app/context_add_test.go
+++ b/internal/app/context_add_test.go
@@ -36,8 +36,8 @@ func TestContextAddSelectsConsoleLoginFields(t *testing.T) {
 	if model.addValues["auth_type"] != "console_login" {
 		t.Fatalf("expected console_login selection, got %q", model.addValues["auth_type"])
 	}
-	if len(model.addFields) != 5 {
-		t.Fatalf("expected 5 fields for console_login, got %d", len(model.addFields))
+	if len(model.addFields) != 8 {
+		t.Fatalf("expected 8 fields for console_login (incl. optional chaining), got %d", len(model.addFields))
 	}
 	if model.addFields[3].key != "regions" || model.addFields[4].key != "profile" {
 		t.Fatalf("expected regions and profile fields, got %+v", model.addFields)
@@ -107,5 +107,31 @@ func TestContextAddSelectsOktaSAMLFields(t *testing.T) {
 		if strings.Contains(key, "password") || strings.Contains(key, "secret") || strings.Contains(key, "mfa") {
 			t.Fatalf("okta_saml wizard must not collect secrets, got field %q", key)
 		}
+	}
+}
+
+func TestContextAddOffersChainingFieldsForProfileBackedTypes(t *testing.T) {
+	for _, authType := range []string{"credential", "console_login"} {
+		keys := map[string]bool{}
+		required := map[string]bool{}
+		for _, field := range fieldsByAuthType[authType] {
+			keys[field.key] = true
+			required[field.key] = field.required
+		}
+		for _, want := range []string{"role_arn", "external_id", "mfa_serial"} {
+			if !keys[want] {
+				t.Fatalf("%s: expected optional %s field for role chaining", authType, want)
+			}
+			if required[want] {
+				t.Fatalf("%s: expected %s to be optional", authType, want)
+			}
+		}
+	}
+	keys := map[string]bool{}
+	for _, field := range fieldsByAuthType["assume_role"] {
+		keys[field.key] = true
+	}
+	if !keys["mfa_serial"] {
+		t.Fatal("assume_role: expected mfa_serial field")
 	}
 }

--- a/internal/auth/env.go
+++ b/internal/auth/env.go
@@ -74,6 +74,19 @@ func BuildEnvExports(ctx context.Context, cfg *config.Config) (string, error) {
 				return "", err
 			}
 		}
+		if cfg.RoleArn != "" {
+			// Role chaining: export the assumed-role session credentials
+			// instead of the base profile.
+			var err error
+			values, err = assumeRoleFn(ctx, cfg)
+			if err != nil {
+				return "", err
+			}
+			values["AWS_REGION"] = cfg.Region
+			values["AWS_DEFAULT_REGION"] = cfg.Region
+			values["AWS_PROFILE"] = ""
+			break
+		}
 		profile := cfg.Profile
 		if profile == "" {
 			profile = "default"

--- a/internal/auth/env_mfa_test.go
+++ b/internal/auth/env_mfa_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -101,5 +102,57 @@ func TestAssumeRoleEnvMFAPropagatesPromptError(t *testing.T) {
 
 	if _, err := assumeRoleEnv(context.Background(), mfaEnvConfig()); err == nil {
 		t.Fatal("expected prompt error to propagate")
+	}
+}
+
+func TestBuildEnvExportsChainsRoleForProfileBackedContexts(t *testing.T) {
+	origAssume := assumeRoleFn
+	t.Cleanup(func() { assumeRoleFn = origAssume })
+	assumed := false
+	assumeRoleFn = func(_ context.Context, cfg *config.Config) (map[string]string, error) {
+		assumed = true
+		if cfg.RoleArn != "arn:aws:iam::123456789012:role/Chained" {
+			t.Fatalf("expected chained role arn, got %q", cfg.RoleArn)
+		}
+		return map[string]string{
+			"AWS_ACCESS_KEY_ID":     "AKIACHAIN",
+			"AWS_SECRET_ACCESS_KEY": "secret",
+			"AWS_SESSION_TOKEN":     "token",
+		}, nil
+	}
+
+	for _, authType := range []config.AuthType{config.AuthTypeCredential, config.AuthTypeConsoleLogin} {
+		assumed = false
+		exports, err := BuildEnvExports(context.Background(), &config.Config{
+			ContextName: "chained",
+			Profile:     "login-profile",
+			Region:      "us-east-1",
+			AuthType:    authType,
+			RoleArn:     "arn:aws:iam::123456789012:role/Chained",
+		})
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", authType, err)
+		}
+		if !assumed {
+			t.Fatalf("%s: expected role chaining to assume the role", authType)
+		}
+		if !strings.Contains(exports, "AKIACHAIN") || !strings.Contains(exports, "unset AWS_PROFILE") {
+			t.Fatalf("%s: expected session credential exports without a profile, got:\n%s", authType, exports)
+		}
+	}
+}
+
+func TestBuildEnvExportsCredentialWithoutRoleStillUsesProfile(t *testing.T) {
+	exports, err := BuildEnvExports(context.Background(), &config.Config{
+		ContextName: "plain",
+		Profile:     "plain-profile",
+		Region:      "us-east-1",
+		AuthType:    config.AuthTypeCredential,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(exports, "export AWS_PROFILE='plain-profile'") {
+		t.Fatalf("expected profile export without chaining, got:\n%s", exports)
 	}
 }

--- a/internal/services/aws/login.go
+++ b/internal/services/aws/login.go
@@ -45,8 +45,5 @@ func ValidateConsoleLoginContext(cfg *config.Config) error {
 	if cfg.Profile == "" {
 		return fmt.Errorf("console_login context %q requires profile", cfg.ContextName)
 	}
-	if cfg.RoleArn != "" {
-		return fmt.Errorf("console_login context %q does not support role_arn", cfg.ContextName)
-	}
 	return nil
 }

--- a/internal/services/aws/login_test.go
+++ b/internal/services/aws/login_test.go
@@ -22,15 +22,15 @@ func TestBuildConsoleLoginCmd(t *testing.T) {
 	}
 }
 
-func TestBuildConsoleLoginCmdRejectsRoleArn(t *testing.T) {
-	_, err := BuildConsoleLoginCmd(&config.Config{
+func TestValidateConsoleLoginContextAllowsRoleChaining(t *testing.T) {
+	err := ValidateConsoleLoginContext(&config.Config{
 		ContextName: "local-dev",
 		AuthType:    config.AuthTypeConsoleLogin,
 		Profile:     "local-dev",
 		Region:      "ap-northeast-2",
 		RoleArn:     "arn:aws:iam::123456789012:role/Admin",
 	})
-	if err == nil {
-		t.Fatal("expected role_arn rejection")
+	if err != nil {
+		t.Fatalf("expected role_arn to be allowed for chaining, got %v", err)
 	}
 }

--- a/internal/services/aws/repository.go
+++ b/internal/services/aws/repository.go
@@ -347,6 +347,16 @@ func NewAwsRepository(ctx context.Context, cfg *config.Config) (*AwsRepository, 
 				return nil, err
 			}
 		}
+		if cfg.RoleArn != "" {
+			// Role chaining: start from the profile-backed credentials and
+			// assume the configured role (shares the assume_role path,
+			// including the MFA session cache).
+			awsCfg, err = resolveAssumeRoleCredentials(ctx, cfg)
+			if err != nil {
+				return nil, err
+			}
+			break
+		}
 		awsCfg, err = LoadBaseConfig(ctx, cfg.Region, cfg.Profile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load AWS config: %w", err)


### PR DESCRIPTION
## Summary

Implements #267: `credential` and `console_login` contexts can now chain into a role, closing the gap the docs previously listed as unsupported.

- With `role_arn` set on a profile-backed context, both the TUI (`NewAwsRepository`) and `unic env` route through the existing assume-role resolution — so `external_id` and `mfa_serial` work identically to `assume_role` contexts, including the MFA session cache and its TUI-passive behavior.
- `unic env` exports the chained session credentials (and unsets `AWS_PROFILE`) instead of the base profile; contexts without `role_arn` keep the current profile-export behavior.
- The `console_login` validation that rejected `role_arn` is removed.

## Testing

- `go test ./...` passes: env chaining for both auth types (session exports, profile unset), profile-export behavior preserved without `role_arn`, and validation now accepting chained console_login contexts.
- `make build` passes.

## Docs

- README auth type table rows for `credential`/`console_login`; architecture docs (EN/KO) replace the "chaining unsupported" note with the chained-resolution behavior.

Closes #267