### PR TITLE
feat: add saved views for repeatable operational workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,13 @@ favorites:
   contexts:
     - prod-admin
 
+views:
+  - name: incident-rds
+    context: prod-admin
+    service: RDS
+    feature: RDS Browser
+    filter: prod-db
+
 ui:
   boot_splash: false
   last_boot_splash_version: 0.1.3
@@ -395,6 +402,7 @@ checks:
 | `R` | Switch between the active context's configured resource regions |
 | `S` | Open settings |
 | `P` | Open the command palette (fuzzy search across features, contexts, and indexed resources) |
+| `V` | Open saved views (save/apply/delete repeatable feature + filter + context jumps) |
 | `/` | Toggle filter mode on supported screens |
 | `f` | Favorite/unfavorite the selected service or context on supported lists |
 | `?` | Toggle context-aware shortcut help |
@@ -428,6 +436,8 @@ checks:
 | Lambda | `Enter` invoke, `d` detail, `l` view CloudWatch Logs, `/` filter, `r` refresh |
 
 The command palette (`P`) fuzzy-searches three kinds of items from anywhere outside text-entry screens: service features (jump straight into a browser), contexts (switch without opening the picker), and resources indexed across services. Opening the palette starts an async index of EC2 instances, RDS instances, Lambda functions, S3 buckets, ECS clusters, and Route53 zones in the current context; results stream in as they load, per-service failures are shown inline, and matching covers names, IDs, and ARNs where available. Selecting a resource jumps to the owning browser with the shared filter prefilled to that resource.
+
+Saved views (`V`) capture repeatable operational workflows: pressing `s` on the views screen snapshots the last opened service feature, its active shared filter, and the current context under a name you type; `enter` reapplies a view in one step — switching to the view's context first when it differs — and `d` deletes one. Views persist under `views:` in `config.yaml` (fields: `name`, `context`, `service`, `feature`, `filter`); the format is additive so future fields extend it without breaking existing files.
 
 The service list defaults to favorites first, then alphabetical order. Press `f` to favorite or unfavorite the selected service; favorites are saved under `favorites.services` in `config.yaml` and rendered with a distinct marker/style. The context picker also supports `f`; context favorites are saved under `favorites.contexts`, displayed first in the picker, and rendered with a distinct color style while preserving the configured context order within favorite and non-favorite groups. The service list supports `/` filtering across service names, feature names, and feature descriptions. Shared list filters use fuzzy matching with inline match highlighting. While filter mode stays active, `↑`/`↓` continue to move through the filtered results without requiring an extra Enter first. Filtering is currently available on the service list, EC2 SSM instances, EC2 inventory instances, IAM users, VPCs, subnets, RDS instances, Route53 zones/records, CloudWatch metrics, CloudWatch log groups/streams, Secrets Manager resources, ECS clusters/services, EKS clusters/node groups/add-ons, ECR repositories/images, FIS experiment templates/history, S3 buckets/objects, Lambda functions, Bedrock API keys, and the context picker.
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -140,8 +140,9 @@ type Model struct {
 	favoriteServices map[domain.AwsService]struct{}
 
 	// Feature selection
-	features []domain.Feature
-	featIdx  int
+	activeService domain.AwsService // identity of the service whose features are loaded
+	features      []domain.Feature
+	featIdx       int
 
 	// Instance list with filtering
 	instances []awsservice.EC2Instance
@@ -493,6 +494,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.loadingSpinner, cmd = m.loadingSpinner.Update(msg)
 		return m, cmd
 	case errMsg:
+		// A failed view-triggered context switch must not leave its deferred
+		// jump armed for the next unrelated switch.
+		m.pendingView = nil
 		m.errMsg = msg.err.Error()
 		m.loadingTitle = ""
 		m.loadingDetails = nil
@@ -668,6 +672,7 @@ func (m Model) updateServiceList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.inspector.Enter(&m)
 	case "enter":
 		if service, ok := m.selectedService(); ok {
+			m.activeService = service.Name
 			m.features = service.Features
 			m.featIdx = 0
 			m.screen = screenFeatureList

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -111,6 +111,7 @@ const (
 	screenContextSSORoleList
 	screenRegionPicker
 	screenCommandPalette
+	screenViewList
 	screenSettings
 	screenLoading
 	screenError
@@ -194,6 +195,10 @@ type Model struct {
 
 	// Command palette
 	palette paletteModel
+
+	// Saved views
+	views       viewsModel
+	pendingView *config.ViewEntry
 
 	// Context add wizard
 	addStep     int // 0=auth_type select, 1+=field input, -1=confirm
@@ -408,6 +413,14 @@ func (m Model) startLoadingWithMessage(title string, details []string, cmd tea.C
 // (or confirmation) input, so global single-letter shortcuts like S must not
 // fire and steal a keystroke from the active field.
 func (m Model) isTextEntryScreen() bool {
+	// The command palette query and the saved-view name input consume free
+	// typing, so global single-key shortcuts must stay out of their way.
+	if m.screen == screenCommandPalette {
+		return true
+	}
+	if m.screen == screenViewList && m.views.naming {
+		return true
+	}
 	switch m.screen {
 	case screenContextAdd,
 		screenRoute53RecordCreate,
@@ -523,7 +536,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.quitting = true
 			return m, tea.Quit
 		}
-		if msg.String() == "?" {
+		if msg.String() == "?" && !m.filterTI.Focused() && !m.isTextEntryScreen() {
 			m.helpVisible = !m.helpVisible
 			return m, nil
 		}
@@ -536,18 +549,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// Global home — return to service list from any screen (skip text-input screens)
 		if msg.String() == "H" && m.screen != screenServiceList && m.screen != screenContextPicker &&
-			m.screen != screenSecurityGroupAddRule && m.screen != screenSecurityGroupDeleteConfirm &&
-			m.screen != screenLambdaInvokeInput && m.screen != screenBedrockKeyCreate &&
-			m.screen != screenBedrockKeyConfirm && m.screen != screenFISTemplateList {
+			!m.isTextEntryScreen() && m.screen != screenFISTemplateList {
 			m.deactivateFilter()
 			m.screen = screenServiceList
 			return m, nil
 		}
 		// Global context switch — C key opens context picker (skip text-input screens)
-		if msg.String() == "C" && m.screen != screenContextPicker &&
-			m.screen != screenSecurityGroupAddRule && m.screen != screenSecurityGroupDeleteConfirm &&
-			m.screen != screenLambdaInvokeInput && m.screen != screenBedrockKeyCreate &&
-			m.screen != screenBedrockKeyConfirm {
+		if msg.String() == "C" && m.screen != screenContextPicker && !m.isTextEntryScreen() {
 			m.deactivateFilter()
 			m.ctxPrevScreen = m.screen
 			return m, m.loadContexts()
@@ -577,6 +585,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.deactivateFilter()
 			return m.openPalette()
 		}
+		// Global saved views — V opens the saved views screen (skip
+		// text-entry screens and the views screen's own name input).
+		if msg.String() == "V" && !m.filterTI.Focused() && m.screen != screenViewList &&
+			!m.isTextEntryScreen() {
+			m.deactivateFilter()
+			return m.openViews()
+		}
 
 		for _, submodel := range m.featureSubmodels() {
 			if newM, cmd, handled := submodel.HandleKey(&m, msg); handled {
@@ -603,6 +618,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateRegionPicker(msg)
 		case screenCommandPalette:
 			return m.updatePalette(msg)
+		case screenViewList:
+			return m.updateViews(msg)
 		case screenSettings:
 			return m.updateSettings(msg)
 		case screenError:
@@ -773,6 +790,8 @@ func (m Model) View() string {
 		v = m.viewRegionPicker()
 	case screenCommandPalette:
 		v = m.viewPalette()
+	case screenViewList:
+		v = m.viewViews()
 	case screenSettings:
 		v = m.viewSettings()
 	case screenLoading:

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -90,6 +90,9 @@ func (m Model) globalHelpShortcuts() []helpShortcut {
 	if m.screen != screenCommandPalette && !m.isTextEntryScreen() {
 		shortcuts = append(shortcuts, helpShortcut{"P", "Open the command palette"})
 	}
+	if m.screen != screenViewList && !m.isTextEntryScreen() {
+		shortcuts = append(shortcuts, helpShortcut{"V", "Open saved views"})
+	}
 	return shortcuts
 }
 
@@ -744,6 +747,21 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 			{"esc", "Go back to the account list"},
 			{"q", "Cancel and return to the context picker"},
 		}
+	case screenViewList:
+		if m.views.naming {
+			return []helpShortcut{
+				{"type", "Enter a name for the current view"},
+				{"enter", "Save the view"},
+				{"esc", "Cancel saving"},
+			}
+		}
+		return []helpShortcut{
+			{"↑/↓, j/k", "Move between saved views"},
+			{"enter", "Apply the selected view"},
+			{"s", "Save the current feature, filter, and context as a view"},
+			{"d", "Delete the selected view"},
+			{"q / esc", "Go back"},
+		}
 	case screenCommandPalette:
 		return []helpShortcut{
 			{"type", "Fuzzy-search features, contexts, and resources"},
@@ -1010,6 +1028,8 @@ func (m Model) helpScreenTitle() string {
 		return "Resource Region Picker"
 	case screenCommandPalette:
 		return "Command Palette"
+	case screenViewList:
+		return "Saved Views"
 	case screenSettings:
 		return "Settings"
 	case screenLoading:

--- a/internal/app/screen_context.go
+++ b/internal/app/screen_context.go
@@ -60,6 +60,14 @@ func (m Model) handleContextMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		m.cfg = msg.cfg
 		m.callerIdentity = msg.identity
 		m.awsRepo = nil
+		if m.pendingView != nil {
+			// A saved view triggered this switch: continue the jump now that
+			// the new context is active.
+			view := *m.pendingView
+			m.pendingView = nil
+			newM, cmd := m.jumpToView(view)
+			return newM, tea.Batch(tea.ClearScreen, cmd), true
+		}
 		m.screen = m.ctxPrevScreen
 		return m, tea.ClearScreen, true
 

--- a/internal/app/screen_palette.go
+++ b/internal/app/screen_palette.go
@@ -154,12 +154,14 @@ func (m Model) executePaletteItem(item paletteItem) (tea.Model, tea.Cmd) {
 
 // enterServiceForPalette aligns the service/feature list state with the jump
 // target so esc-navigation behaves as if the user drilled in manually.
+// svcIdx indexes the rendered (sorted/filtered) service list, so it is
+// resolved against filteredServices; activeService carries the identity.
 func (m *Model) enterServiceForPalette(item paletteItem) {
-	for i, svc := range m.services {
+	for _, svc := range m.services {
 		if svc.Name != item.service {
 			continue
 		}
-		m.svcIdx = i
+		m.activeService = svc.Name
 		m.features = svc.Features
 		for j, feat := range svc.Features {
 			if feat.Kind == item.feature {
@@ -167,7 +169,13 @@ func (m *Model) enterServiceForPalette(item paletteItem) {
 				break
 			}
 		}
-		return
+		break
+	}
+	for i, svc := range m.filteredServices {
+		if svc.Name == item.service {
+			m.svcIdx = i
+			break
+		}
 	}
 }
 

--- a/internal/app/screen_views.go
+++ b/internal/app/screen_views.go
@@ -1,0 +1,258 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"unic/internal/config"
+	"unic/internal/domain"
+)
+
+// Saved views capture a repeatable operational jump: service feature, the
+// context it ran in, and the browser filter that was active. Applying a view
+// replays that in one step, switching context first when needed.
+
+// featurePrimaryFilter maps a feature to the shared filter its list screen
+// applies on load, so views (and the palette) can prefill it.
+var featurePrimaryFilter = map[domain.FeatureKind]filterTarget{
+	domain.FeatureEC2InstanceBrowser:    filterEC2BrowserInstances,
+	domain.FeatureSSMSession:            filterInstances,
+	domain.FeatureRDSBrowser:            filterRDS,
+	domain.FeatureRoute53Browser:        filterRoute53Zones,
+	domain.FeatureSecretsBrowser:        filterSecrets,
+	domain.FeatureSecurityGroupBrowser:  filterSecurityGroups,
+	domain.FeatureIAMUsersBrowser:       filterIAMUsers,
+	domain.FeatureCloudWatchMetrics:     filterCWMetrics,
+	domain.FeatureCloudWatchLogsBrowser: filterCWLogGroups,
+	domain.FeatureECSExec:               filterECSClusters,
+	domain.FeatureEKSBrowser:            filterEKSClusters,
+	domain.FeatureECRRepositoryBrowser:  filterECRRepositories,
+	domain.FeatureFISTemplateBrowser:    filterFISTemplates,
+	domain.FeatureS3Browser:             filterS3Buckets,
+	domain.FeatureLambdaBrowser:         filterLambdaFunctions,
+	domain.FeatureBedrockAPIKeys:        filterBedrockKeys,
+	domain.FeatureVPCBrowser:            filterVPCs,
+}
+
+type viewsModel struct {
+	views      []config.ViewEntry
+	idx        int
+	naming     bool
+	nameInput  string
+	notice     string
+	prevScreen screen
+}
+
+// pendingView carries a view application across an async context switch.
+
+func (m Model) openViews() (tea.Model, tea.Cmd) {
+	views, err := config.Views(m.configPath)
+	if err != nil {
+		return m, func() tea.Msg { return errMsg{err: err} }
+	}
+	m.views.views = views
+	m.views.idx = 0
+	m.views.naming = false
+	m.views.nameInput = ""
+	m.views.notice = ""
+	m.views.prevScreen = m.screen
+	m.screen = screenViewList
+	return m, nil
+}
+
+// captureCurrentView snapshots the last drilled service feature, its primary
+// filter value, and the active context.
+func (m Model) captureCurrentView() (config.ViewEntry, bool) {
+	if m.svcIdx >= len(m.services) || m.featIdx >= len(m.features) {
+		return config.ViewEntry{}, false
+	}
+	svc := m.services[m.svcIdx]
+	feat := m.features[m.featIdx]
+	view := config.ViewEntry{
+		Service: string(svc.Name),
+		Feature: string(feat.Kind),
+	}
+	if m.cfg != nil {
+		view.Context = m.cfg.ContextName
+	}
+	if target, ok := featurePrimaryFilter[feat.Kind]; ok {
+		view.Filter = m.filterValue(target)
+	}
+	return view, true
+}
+
+func (m Model) updateViews(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	key := msg.String()
+
+	if m.views.naming {
+		switch key {
+		case "esc":
+			m.views.naming = false
+			m.views.nameInput = ""
+		case "enter":
+			name := strings.TrimSpace(m.views.nameInput)
+			if name == "" {
+				return m, nil
+			}
+			view, ok := m.captureCurrentView()
+			if !ok {
+				m.views.naming = false
+				m.views.notice = "Nothing to save: open a service feature first"
+				return m, nil
+			}
+			view.Name = name
+			if err := config.SaveView(m.configPath, view); err != nil {
+				return m, func() tea.Msg { return errMsg{err: err} }
+			}
+			views, err := config.Views(m.configPath)
+			if err != nil {
+				return m, func() tea.Msg { return errMsg{err: err} }
+			}
+			m.views.views = views
+			m.views.naming = false
+			m.views.nameInput = ""
+			m.views.notice = fmt.Sprintf("Saved view %q", name)
+		case "backspace":
+			if runes := []rune(m.views.nameInput); len(runes) > 0 {
+				m.views.nameInput = string(runes[:len(runes)-1])
+			}
+		default:
+			if runes := msg.Runes; len(runes) > 0 {
+				m.views.nameInput += string(runes)
+			}
+		}
+		return m, nil
+	}
+
+	switch key {
+	case "q", "esc":
+		m.screen = m.views.prevScreen
+	case "up", "k":
+		m.views.idx = previousListIndex(m.views.idx, len(m.views.views))
+	case "down", "j":
+		m.views.idx = nextListIndex(m.views.idx, len(m.views.views))
+	case "s":
+		m.views.naming = true
+		m.views.nameInput = ""
+		m.views.notice = ""
+	case "d":
+		if len(m.views.views) == 0 || m.views.idx >= len(m.views.views) {
+			return m, nil
+		}
+		name := m.views.views[m.views.idx].Name
+		if err := config.DeleteView(m.configPath, name); err != nil {
+			return m, func() tea.Msg { return errMsg{err: err} }
+		}
+		views, err := config.Views(m.configPath)
+		if err != nil {
+			return m, func() tea.Msg { return errMsg{err: err} }
+		}
+		m.views.views = views
+		if m.views.idx >= len(m.views.views) && m.views.idx > 0 {
+			m.views.idx--
+		}
+		m.views.notice = fmt.Sprintf("Deleted view %q", name)
+	case "enter":
+		if len(m.views.views) == 0 || m.views.idx >= len(m.views.views) {
+			return m, nil
+		}
+		return m.applyView(m.views.views[m.views.idx])
+	}
+	return m, nil
+}
+
+// applyView replays a saved view: switch context first when the view names a
+// different one (the jump continues from contextSwitchedMsg), otherwise jump
+// straight into the feature with the filter prefilled.
+func (m Model) applyView(view config.ViewEntry) (tea.Model, tea.Cmd) {
+	if view.Context != "" && (m.cfg == nil || m.cfg.ContextName != view.Context) {
+		m.pendingView = &view
+		m.ctxPrevScreen = screenServiceList
+		return m.startLoading(m.switchContext(view.Context))
+	}
+	return m.jumpToView(view)
+}
+
+func (m Model) jumpToView(view config.ViewEntry) (tea.Model, tea.Cmd) {
+	kind := domain.FeatureKind(view.Feature)
+	m.enterServiceForPalette(paletteItem{
+		service: domain.AwsService(view.Service),
+		feature: kind,
+	})
+	if view.Filter != "" {
+		if target, ok := featurePrimaryFilter[kind]; ok {
+			m.storeFilterValue(target, view.Filter)
+		}
+	}
+	return m.startFeature(kind)
+}
+
+func (m Model) viewViews() string {
+	var b strings.Builder
+	var panel strings.Builder
+	b.WriteString(m.renderStatusBar())
+	b.WriteString(titleStyle.Render("Saved Views"))
+	b.WriteString("\n")
+
+	if m.views.naming {
+		b.WriteString(normalStyle.Render("  Save current view as: "))
+		b.WriteString(filterStyle.Render(fmt.Sprintf("%s▏", m.views.nameInput)))
+		b.WriteString("\n")
+		if view, ok := m.captureCurrentView(); ok {
+			detail := fmt.Sprintf("  %s / %s", view.Service, view.Feature)
+			if view.Filter != "" {
+				detail += fmt.Sprintf("  filter:%q", view.Filter)
+			}
+			if view.Context != "" {
+				detail += fmt.Sprintf("  context:%s", view.Context)
+			}
+			b.WriteString(dimStyle.Render(detail))
+			b.WriteString("\n")
+		}
+	} else if m.views.notice != "" {
+		b.WriteString(dimStyle.Render("  " + m.views.notice))
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+
+	if len(m.views.views) == 0 {
+		panel.WriteString(dimStyle.Render("  No saved views yet — press s to save the current one"))
+		panel.WriteString("\n")
+	} else {
+		visibleLines := max(m.height-10, 5)
+		start := 0
+		if m.views.idx >= visibleLines {
+			start = m.views.idx - visibleLines + 1
+		}
+		end := min(start+visibleLines, len(m.views.views))
+		for i := start; i < end; i++ {
+			view := m.views.views[i]
+			cursor := "  "
+			style := normalStyle
+			if i == m.views.idx {
+				cursor = "> "
+				style = selectedStyle
+			}
+			label := fmt.Sprintf("%-24s %s / %s", view.Name, view.Service, view.Feature)
+			if view.Filter != "" {
+				label += fmt.Sprintf("  filter:%q", view.Filter)
+			}
+			if view.Context != "" {
+				label += fmt.Sprintf("  [%s]", view.Context)
+			}
+			panel.WriteString(style.Render(cursor + label))
+			panel.WriteString("\n")
+		}
+	}
+
+	b.WriteString(m.renderListPanel(panel.String()))
+	b.WriteString("\n\n")
+	help := "enter: open • s: save current • d: delete • esc: back"
+	if m.views.naming {
+		help = "type: name • enter: save • esc: cancel"
+	}
+	b.WriteString(m.renderHelpBar(help))
+	return b.String()
+}

--- a/internal/app/screen_views.go
+++ b/internal/app/screen_views.go
@@ -65,13 +65,15 @@ func (m Model) openViews() (tea.Model, tea.Cmd) {
 // captureCurrentView snapshots the last drilled service feature, its primary
 // filter value, and the active context.
 func (m Model) captureCurrentView() (config.ViewEntry, bool) {
-	if m.svcIdx >= len(m.services) || m.featIdx >= len(m.features) {
+	// activeService is the identity recorded when the feature list was
+	// entered; svcIdx indexes the sorted/filtered display list and must not
+	// be used to resolve the service.
+	if m.activeService == "" || m.featIdx >= len(m.features) {
 		return config.ViewEntry{}, false
 	}
-	svc := m.services[m.svcIdx]
 	feat := m.features[m.featIdx]
 	view := config.ViewEntry{
-		Service: string(svc.Name),
+		Service: string(m.activeService),
 		Feature: string(feat.Kind),
 	}
 	if m.cfg != nil {

--- a/internal/app/screen_views_test.go
+++ b/internal/app/screen_views_test.go
@@ -1,0 +1,158 @@
+package app
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"unic/internal/config"
+	"unic/internal/domain"
+)
+
+func viewsTestModel(t *testing.T) Model {
+	t.Helper()
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	m := New(testConfig(), configPath, "dev")
+	m.cfg = &config.Config{Region: "us-east-1", ContextName: "dev"}
+	m.screen = screenServiceList
+	return m
+}
+
+func typeIntoViews(t *testing.T, m Model, text string) Model {
+	t.Helper()
+	for _, r := range text {
+		next, _ := m.updateViews(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = next.(Model)
+	}
+	return m
+}
+
+func drillToRDS(t *testing.T, m Model) Model {
+	t.Helper()
+	for i, svc := range m.services {
+		if svc.Name == domain.ServiceRDS {
+			m.svcIdx = i
+			m.features = svc.Features
+			m.featIdx = 0
+			return m
+		}
+	}
+	t.Fatal("RDS service not found in catalog")
+	return m
+}
+
+func TestViewsSaveCapturesFeatureFilterAndContext(t *testing.T) {
+	m := viewsTestModel(t)
+	m = drillToRDS(t, m)
+	m.storeFilterValue(filterRDS, "prod-db")
+
+	updated, _ := m.openViews()
+	m = updated.(Model)
+	next, _ := m.updateViews(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	m = next.(Model)
+	m = typeIntoViews(t, m, "incident-rds")
+	next, _ = m.updateViews(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+
+	views, err := config.Views(m.configPath)
+	if err != nil || len(views) != 1 {
+		t.Fatalf("expected one persisted view, got %+v err=%v", views, err)
+	}
+	view := views[0]
+	if view.Name != "incident-rds" || view.Service != "RDS" || view.Filter != "prod-db" || view.Context != "dev" {
+		t.Fatalf("expected captured view fields, got %+v", view)
+	}
+	if !strings.Contains(m.views.notice, "Saved view") {
+		t.Fatalf("expected save notice, got %q", m.views.notice)
+	}
+}
+
+func TestViewsApplySameContextJumpsWithFilterPrefilled(t *testing.T) {
+	m := viewsTestModel(t)
+	view := config.ViewEntry{
+		Name: "incident-rds", Context: "dev",
+		Service: "RDS", Feature: string(domain.FeatureRDSBrowser), Filter: "prod-db",
+	}
+
+	next, cmd := m.applyView(view)
+	model := next.(Model)
+	if cmd == nil {
+		t.Fatal("expected the RDS browser to start loading")
+	}
+	if model.filterValue(filterRDS) != "prod-db" {
+		t.Fatalf("expected prefilled RDS filter, got %q", model.filterValue(filterRDS))
+	}
+	if model.pendingView != nil {
+		t.Fatal("expected no pending view for a same-context apply")
+	}
+}
+
+func TestViewsApplyAcrossContextsDefersJumpUntilSwitch(t *testing.T) {
+	m := viewsTestModel(t)
+	view := config.ViewEntry{
+		Name: "prod-incident", Context: "prod-admin",
+		Service: "RDS", Feature: string(domain.FeatureRDSBrowser), Filter: "prod-db",
+	}
+
+	next, cmd := m.applyView(view)
+	model := next.(Model)
+	if cmd == nil || model.pendingView == nil || model.pendingView.Name != "prod-incident" {
+		t.Fatalf("expected context switch with pending view, got %+v", model.pendingView)
+	}
+	if model.screen != screenLoading {
+		t.Fatalf("expected loading screen during switch, got %v", model.screen)
+	}
+
+	// Context switch completes: the pending view jump continues.
+	switched, _, handled := model.handleContextMsg(contextSwitchedMsg{
+		cfg: &config.Config{Region: "us-east-1", ContextName: "prod-admin"},
+	})
+	if !handled {
+		t.Fatal("expected context switch message to be handled")
+	}
+	after := switched.(Model)
+	if after.pendingView != nil {
+		t.Fatal("expected pending view to be consumed")
+	}
+	if after.filterValue(filterRDS) != "prod-db" {
+		t.Fatalf("expected prefilled filter after switch, got %q", after.filterValue(filterRDS))
+	}
+}
+
+func TestViewsDeleteRemovesPersistedView(t *testing.T) {
+	m := viewsTestModel(t)
+	if err := config.SaveView(m.configPath, config.ViewEntry{
+		Name: "old", Service: "RDS", Feature: string(domain.FeatureRDSBrowser),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	updated, _ := m.openViews()
+	m = updated.(Model)
+	next, _ := m.updateViews(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	m = next.(Model)
+
+	views, err := config.Views(m.configPath)
+	if err != nil || len(views) != 0 {
+		t.Fatalf("expected the view to be deleted, got %+v err=%v", views, err)
+	}
+}
+
+func TestViewsNamingCapturesGlobalShortcutLetters(t *testing.T) {
+	m := viewsTestModel(t)
+	m = drillToRDS(t, m)
+	updated, _ := m.openViews()
+	m = updated.(Model)
+	next, _ := m.updateViews(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	m = next.(Model)
+
+	if !m.isTextEntryScreen() {
+		t.Fatal("expected view naming to count as text entry so global shortcuts stay out")
+	}
+	m = typeIntoViews(t, m, "PSVH")
+	if m.views.nameInput != "PSVH" {
+		t.Fatalf("expected uppercase letters to land in the name input, got %q", m.views.nameInput)
+	}
+}

--- a/internal/app/screen_views_test.go
+++ b/internal/app/screen_views_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -29,17 +30,19 @@ func typeIntoViews(t *testing.T, m Model, text string) Model {
 	return m
 }
 
+// drillToRDS selects RDS through the real sorted/filtered service list, so
+// the capture path is exercised with display indices that differ from the
+// catalog order.
 func drillToRDS(t *testing.T, m Model) Model {
 	t.Helper()
-	for i, svc := range m.services {
+	for i, svc := range m.serviceList() {
 		if svc.Name == domain.ServiceRDS {
 			m.svcIdx = i
-			m.features = svc.Features
-			m.featIdx = 0
-			return m
+			next, _ := m.updateServiceList(tea.KeyMsg{Type: tea.KeyEnter})
+			return next.(Model)
 		}
 	}
-	t.Fatal("RDS service not found in catalog")
+	t.Fatal("RDS service not found in service list")
 	return m
 }
 
@@ -156,3 +159,47 @@ func TestViewsNamingCapturesGlobalShortcutLetters(t *testing.T) {
 		t.Fatalf("expected uppercase letters to land in the name input, got %q", m.views.nameInput)
 	}
 }
+
+func TestViewsCaptureUsesServiceIdentityNotDisplayIndex(t *testing.T) {
+	m := viewsTestModel(t)
+	m = drillToRDS(t, m)
+
+	view, ok := m.captureCurrentView()
+	if !ok {
+		t.Fatal("expected a capturable view after drilling into RDS")
+	}
+	if view.Service != "RDS" || view.Feature != string(m.features[m.featIdx].Kind) {
+		t.Fatalf("expected service identity RDS from the sorted list, got %+v", view)
+	}
+}
+
+func TestFailedViewSwitchClearsPendingView(t *testing.T) {
+	m := viewsTestModel(t)
+	view := config.ViewEntry{
+		Name: "prod-incident", Context: "prod-admin",
+		Service: "RDS", Feature: string(domain.FeatureRDSBrowser), Filter: "prod-db",
+	}
+	next, _ := m.applyView(view)
+	m = next.(Model)
+	if m.pendingView == nil {
+		t.Fatal("expected pending view before the switch completes")
+	}
+
+	// The switch fails: the deferred jump must be disarmed.
+	failed, _ := m.Update(errMsg{err: errViewSwitch})
+	m = failed.(Model)
+	if m.pendingView != nil {
+		t.Fatal("expected failed switch to clear the pending view")
+	}
+
+	// A later unrelated successful switch must not jump anywhere.
+	switched, _, _ := m.handleContextMsg(contextSwitchedMsg{
+		cfg: &config.Config{Region: "us-east-1", ContextName: "other"},
+	})
+	after := switched.(Model)
+	if after.filterValue(filterRDS) != "" {
+		t.Fatalf("expected no stale view application, filter=%q", after.filterValue(filterRDS))
+	}
+}
+
+var errViewSwitch = errors.New("sso login failed")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,7 +27,20 @@ type fileConfig struct {
 	Defaults  fileDefaults   `yaml:"defaults"`
 	Favorites fileFavorites  `yaml:"favorites,omitempty"`
 	UI        fileUI         `yaml:"ui,omitempty"`
+	Views     []ViewEntry    `yaml:"views,omitempty"`
 	Contexts  []contextEntry `yaml:"contexts"`
+}
+
+// ViewEntry is a saved operational view: a jump target (service feature, an
+// optional context to switch into, and an optional prefilled filter) that can
+// be reapplied in one step. The format is additive: future fields extend it
+// without breaking existing files.
+type ViewEntry struct {
+	Name    string `yaml:"name"`
+	Context string `yaml:"context,omitempty"`
+	Service string `yaml:"service"`
+	Feature string `yaml:"feature"`
+	Filter  string `yaml:"filter,omitempty"`
 }
 
 type fileDefaults struct {
@@ -845,6 +858,53 @@ func SetBootSplashEnabled(configPath string, enabled bool) error {
 func SetBootSplashSeenVersion(configPath, version string) error {
 	return mutateFileConfig(configPath, defaultsIfMissing, func(fc *fileConfig) error {
 		fc.UI.LastBootSplashVersion = strings.TrimSpace(version)
+		return nil
+	})
+}
+
+// Views returns the saved views from config, in file order.
+func Views(configPath string) ([]ViewEntry, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read config: %w", err)
+	}
+	var fc fileConfig
+	if err := yaml.Unmarshal(data, &fc); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", configPath, err)
+	}
+	return fc.Views, nil
+}
+
+// SaveView adds a view or replaces an existing one with the same name.
+func SaveView(configPath string, view ViewEntry) error {
+	if strings.TrimSpace(view.Name) == "" {
+		return fmt.Errorf("view name is required")
+	}
+	return mutateFileConfig(configPath, defaultsIfMissing, func(fc *fileConfig) error {
+		for i := range fc.Views {
+			if fc.Views[i].Name == view.Name {
+				fc.Views[i] = view
+				return nil
+			}
+		}
+		fc.Views = append(fc.Views, view)
+		return nil
+	})
+}
+
+// DeleteView removes the named view; deleting a missing view is not an error.
+func DeleteView(configPath, name string) error {
+	return mutateFileConfig(configPath, failIfMissing, func(fc *fileConfig) error {
+		kept := fc.Views[:0]
+		for _, view := range fc.Views {
+			if view.Name != name {
+				kept = append(kept, view)
+			}
+		}
+		fc.Views = kept
 		return nil
 	})
 }


### PR DESCRIPTION
## Summary

Implements #133: named, persistent views that replay a repeated operational setup in one step.

- **`V`** opens the saved views screen from anywhere outside text-entry surfaces. **`s`** snapshots the last opened service feature, its active shared filter, and the current context under a typed name (the capture preview is shown while naming). **`enter`** reapplies a view; **`d`** deletes one.
- **Cross-context apply**: when a view names a different context, unic switches context first (existing switch flow, passive SSO included) and continues the jump after `contextSwitchedMsg` lands via a `pendingView` handoff — one keypress from anywhere to "prod-admin › RDS Browser filtered to prod-db".
- **Persistence**: `views:` entries in `config.yaml` (`name`, `context`, `service`, `feature`, `filter`), written through the atomic config store; documented in README and additive for future fields (sort state, team sharing).
- **Keyboard-consistency fix folded in**: the palette query and the view name input now count as text-entry surfaces, so global single-key shortcuts (`H`/`C`/`S`/`R`/`P`/`V`/`?`) no longer steal typed uppercase letters while searching or naming (this also fixes typing `H`/`C`/`?` into the palette query, which previously navigated away).
- A shared `featurePrimaryFilter` map now names each feature's primary shared filter, used by views for capture/prefill.

Loading a view from the CLI (`unic --view <name>`) is left out per the TUI-first product rule; it can land later as a secondary helper if needed.

## Testing

- `go test ./...` passes: save capture (feature+filter+context persisted), same-context apply with filter prefill, cross-context apply deferring the jump until the switch completes, delete persistence, and the text-entry guard keeping uppercase shortcut letters in the name input.
- `make build` passes.

## Docs

- README: `V` key binding, a saved-views behavior paragraph, and a `views:` block in the config example.

Closes #133