### PR TITLE
feat: add CloudWatch alarm browser as an incident entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ Context ordering:
 | RDS | Instance Class Modification |
 | Route53 | Route53 Browser |
 | Secrets Manager | Secrets Browser |
+| CloudWatch | Alarm Browser |
 | CloudWatch | Metrics Viewer |
 | CloudWatch Logs | Logs Browser |
 | ECR | ECR Login Helper |
@@ -420,6 +421,7 @@ checks:
 | Route53 | `c` create, `e` edit, `d` delete |
 | IAM Key Rotation | `r` rotate, `c` copy exports, `a` apply and verify, `d` deactivate old key, `x` delete old key |
 | Bedrock API Keys | `c` create, choose current IAM user or another user, `r` rotate secret, `d` delete, type the IAM user/key ID to confirm, `c` copy one-time key without printing it, `e` copy `AWS_BEARER_TOKEN_BEDROCK` export |
+| CloudWatch Alarms | `tab` cycle state filter (ALL/ALARM/INSUFFICIENT_DATA/OK), `/` filter, `r` refresh, `Enter` detail with recent transitions, detail `g` jump to related resource (RDS/EC2/ECS/Lambda dimensions), `l` jump to logs when derivable |
 | CloudWatch Metrics | preset-driven metric list/detail flow, `/` filter, `space` select related series, `g` preset cycle, `t/p/s` range-period-stat controls, `r` refresh, in-terminal single-series and comparison charts |
 | CloudWatch Logs | log groups/streams load 10 at a time, `n` load more, `1`-`6` time presets, `t` live tail, `f` filter pattern, `w` wrap toggle, `h/l` horizontal scroll |
 | ECR Login Helper | `c` copy Docker login command, `p` copy Podman login command, `r` refresh; CLI helper for scripting: `unic ecr login [--runtime docker|podman] [--copy]` |
@@ -446,6 +448,8 @@ The EKS Browser includes a managed add-on status view for each cluster. Add-on r
 The ECR Login Helper resolves the private registry URI for the active context and shows copyable Docker and Podman login commands without leaving the TUI. The copied commands are prefixed with `eval "$(unic env <context>)"` so they authenticate with the active unic context rather than whatever ambient AWS credentials the shell happens to have; `unic ecr login` remains as a secondary CLI helper for scripting. The ECR Repository Browser opens image/tag lists from each repository. Image rows include tags, digest, pushed time, and size, and mark untagged images or images older than 90 days as cleanup candidates. Image detail exposes digest and tag values for clipboard copy.
 
 The RDS detail screen can resize an instance with `m`: unic loads the orderable DB instance classes for the instance's engine/version in the active region into a filterable picker (current class marked), then a confirmation screen shows the current and new class with a `Tab`-toggleable apply-immediately choice (default: next maintenance window) and requires typing the instance identifier before calling ModifyDBInstance. After submitting, the detail screen polls the instance status until the change settles.
+
+The CloudWatch Alarm Browser is an alarm-first incident entry point: alarms list firing-first (ALARM, then INSUFFICIENT_DATA, then OK) with a `tab`-cycled state filter and text filtering across names, states, metrics, and dimensions. Alarm detail shows the state reason, condition, dimensions, and the most recent state transitions. When an alarm's dimensions map to a supported browser (`DBInstanceIdentifier`, `InstanceId`, `ClusterName`, `FunctionName`), `g` jumps into that resource browser with the filter prefilled to the unhealthy resource, and `l` opens CloudWatch Logs prefilled with the derived log group (e.g. `/aws/lambda/<function>`).
 
 The FIS Experiment Template Browser lists experiment templates in the active region and opens a detail screen with role ARN, targets, actions, target mappings, parameters, filters, and stop condition summaries without leaving the TUI. Template detail includes a Safe Run Preview that summarizes blast radius, target selection modes, action count, active stop conditions, IAM role, and warnings for missing stop conditions, missing role ARN, broad selection, or unbounded selectors. The preview also states the template ID that any future execution path must type to confirm before a run can start. Press `h` on a selected template or template detail to inspect recent runs for that template, or `H` from the template list to inspect recent experiment history across the active account/region. History rows include run status, timing, and stop/failure summaries, with failed, stopped, stopping, and cancelled runs visually highlighted; `Enter` opens run detail with start/end times, duration, action states, targets, stop conditions, and failure metadata.
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -61,6 +61,8 @@ const (
 	screenIAMKeyRotateResult
 	screenCWMetricList
 	screenCWMetricDetail
+	screenCWAlarmList
+	screenCWAlarmDetail
 	screenCWLogGroupList
 	screenCWLogStreamList
 	screenCWLogViewer
@@ -161,6 +163,7 @@ type Model struct {
 	vpc          vpcModel
 	reachability reachabilityModel
 	cwMetrics    cloudWatchMetricsModel
+	cwAlarms     cwAlarmsModel
 	cwLogs       cloudWatchLogsModel
 	rds          rdsModel
 	route53      route53Model
@@ -272,6 +275,7 @@ func New(cfg *config.Config, configPath string, version string, checklistPath ..
 	model.vpc = newVPCModel()
 	model.reachability = newReachabilityModel()
 	model.cwMetrics = newCloudWatchMetricsModel()
+	model.cwAlarms = newCWAlarmsModel()
 	model.cwLogs = newCloudWatchLogsModel()
 	model.rds = newRDSModel()
 	model.route53 = newRoute53Model()
@@ -717,6 +721,8 @@ func (m Model) startFeature(kind domain.FeatureKind) (tea.Model, tea.Cmd) {
 		return m.secrets.Start(&m)
 	case domain.FeatureCloudWatchMetrics:
 		return m.cwMetrics.Start(&m)
+	case domain.FeatureCloudWatchAlarms:
+		return m.cwAlarms.Start(&m)
 	case domain.FeatureCloudWatchLogsBrowser:
 		return m.cwLogs.Start(&m)
 	case domain.FeatureS3Browser:

--- a/internal/app/feature_submodel.go
+++ b/internal/app/feature_submodel.go
@@ -13,5 +13,5 @@ type featureSubmodel interface {
 // such as service selection, context selection, SSM session launch, loading, and
 // errors remain root-owned unless a separate shell abstraction is introduced.
 func (m *Model) featureSubmodels() []featureSubmodel {
-	return []featureSubmodel{&m.ec2Browser, &m.ecs, &m.eks, &m.ecr, &m.fis, &m.vpc, &m.reachability, &m.cwMetrics, &m.cwLogs, &m.rds, &m.route53, &m.iam, &m.bedrock, &m.secrets, &m.security, &m.s3, &m.lambda, &m.inspector}
+	return []featureSubmodel{&m.ec2Browser, &m.ecs, &m.eks, &m.ecr, &m.fis, &m.vpc, &m.reachability, &m.cwMetrics, &m.cwAlarms, &m.cwLogs, &m.rds, &m.route53, &m.iam, &m.bedrock, &m.secrets, &m.security, &m.s3, &m.lambda, &m.inspector}
 }

--- a/internal/app/filter.go
+++ b/internal/app/filter.go
@@ -41,6 +41,7 @@ const (
 	filterInspectorChecklistFiles
 	filterLambdaFunctions
 	filterBedrockKeys
+	filterCWAlarms
 )
 
 // Filterable is implemented by any type that supports text-based filtering.

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -408,6 +408,16 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 			{"r", "Refresh the selected metric series"},
 			{"q / esc", "Go back to the metric list"},
 		}
+	case screenCWAlarmList:
+		shortcuts := listScreenShortcuts("open the selected alarm", "go back to the feature list", true, true)
+		return append(shortcuts, helpShortcut{"tab", "Cycle the alarm state filter"})
+	case screenCWAlarmDetail:
+		return []helpShortcut{
+			{"g", "Jump to the related resource browser"},
+			{"l", "Jump to the related CloudWatch Logs group"},
+			{"r", "Reload the transition history"},
+			{"q / esc", "Go back to the alarm list"},
+		}
 	case screenCWLogGroupList:
 		return listScreenShortcuts("open log streams for the selected group", "go back to the feature list", true, false)
 	case screenCWLogStreamList:
@@ -924,6 +934,10 @@ func (m Model) helpScreenTitle() string {
 		return "IAM Access Key Rotation Confirm"
 	case screenIAMKeyRotateResult:
 		return "IAM Access Key Rotation Result"
+	case screenCWAlarmList:
+		return "CloudWatch Alarms"
+	case screenCWAlarmDetail:
+		return "CloudWatch Alarm Detail"
 	case screenCWLogGroupList:
 		return "CloudWatch Log Groups"
 	case screenCWLogStreamList:

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -140,6 +140,15 @@ type cwLogGroupsLoadedMsg struct {
 	append    bool
 }
 
+type cwAlarmsLoadedMsg struct {
+	alarms []awsservice.CloudWatchAlarm
+}
+
+type cwAlarmHistoryLoadedMsg struct {
+	alarmName string
+	items     []awsservice.CloudWatchAlarmHistoryItem
+}
+
 type cwMetricsLoadedMsg struct {
 	metrics []awsservice.CloudWatchMetric
 }

--- a/internal/app/screen_cwalarms.go
+++ b/internal/app/screen_cwalarms.go
@@ -1,0 +1,383 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"unic/internal/domain"
+	awsservice "unic/internal/services/aws"
+)
+
+// The CloudWatch alarm browser is the alarm-first incident entry point: list
+// alarms firing-first, filter by state or text, inspect a transition history,
+// and jump from an alarm's dimensions into the owning resource browser.
+
+var alarmStateFilters = []string{"ALL", "ALARM", "INSUFFICIENT_DATA", "OK"}
+
+type cwAlarmsModel struct {
+	alarms      []awsservice.CloudWatchAlarm
+	filtered    []awsservice.CloudWatchAlarm
+	idx         int
+	stateIdx    int // index into alarmStateFilters
+	selected    *awsservice.CloudWatchAlarm
+	history     []awsservice.CloudWatchAlarmHistoryItem
+	historyName string
+}
+
+func newCWAlarmsModel() cwAlarmsModel {
+	return cwAlarmsModel{}
+}
+
+func (am *cwAlarmsModel) Start(m *Model) (tea.Model, tea.Cmd) {
+	return m.startLoading(am.loadAlarms(*m))
+}
+
+func (am *cwAlarmsModel) HandleMessage(m *Model, msg tea.Msg) (tea.Model, tea.Cmd, bool) {
+	switch msg := msg.(type) {
+	case cwAlarmsLoadedMsg:
+		am.alarms = msg.alarms
+		am.applyStateAndTextFilter(m)
+		am.idx = 0
+		am.selected = nil
+		m.screen = screenCWAlarmList
+		return *m, nil, true
+	case cwAlarmHistoryLoadedMsg:
+		if am.selected == nil || am.selected.Name != msg.alarmName {
+			return *m, nil, true
+		}
+		am.history = msg.items
+		am.historyName = msg.alarmName
+		m.screen = screenCWAlarmDetail
+		return *m, nil, true
+	}
+	return *m, nil, false
+}
+
+func (am *cwAlarmsModel) HandleKey(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
+	switch m.screen {
+	case screenCWAlarmList:
+		newM, cmd := am.updateList(m, msg)
+		return newM, cmd, true
+	case screenCWAlarmDetail:
+		newM, cmd := am.updateDetail(m, msg)
+		return newM, cmd, true
+	default:
+		return *m, nil, false
+	}
+}
+
+func (am cwAlarmsModel) View(m Model) (string, bool) {
+	switch m.screen {
+	case screenCWAlarmList:
+		return am.viewList(m), true
+	case screenCWAlarmDetail:
+		return am.viewDetail(m), true
+	default:
+		return "", false
+	}
+}
+
+func (am *cwAlarmsModel) ApplyFilter(m *Model, target filterTarget) bool {
+	if target != filterCWAlarms {
+		return false
+	}
+	am.applyStateAndTextFilter(m)
+	am.idx = 0
+	return true
+}
+
+// applyStateAndTextFilter composes the state tab with the shared text filter.
+func (am *cwAlarmsModel) applyStateAndTextFilter(m *Model) {
+	state := alarmStateFilters[am.stateIdx]
+	source := am.alarms
+	if state != "ALL" {
+		source = nil
+		for _, alarm := range am.alarms {
+			if alarm.State == state {
+				source = append(source, alarm)
+			}
+		}
+	}
+	am.filtered = applyFilter(source, m.filterValue(filterCWAlarms))
+}
+
+func (am *cwAlarmsModel) updateList(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if cmd, handled := m.updateSharedFilter(msg, filterCWAlarms); handled {
+		return *m, cmd
+	}
+
+	switch msg.String() {
+	case "q", "esc":
+		m.screen = screenFeatureList
+		m.resetFilter(filterCWAlarms)
+	case "up", "k":
+		am.idx = previousListIndex(am.idx, len(am.filtered))
+	case "down", "j":
+		am.idx = nextListIndex(am.idx, len(am.filtered))
+	case "/":
+		return *m, m.activateFilter(filterCWAlarms)
+	case "tab":
+		am.stateIdx = (am.stateIdx + 1) % len(alarmStateFilters)
+		am.applyStateAndTextFilter(m)
+		am.idx = 0
+	case "r":
+		m.resetFilter(filterCWAlarms)
+		return m.startLoading(am.loadAlarms(*m))
+	case "enter":
+		if len(am.filtered) > 0 && am.idx < len(am.filtered) {
+			selected := am.filtered[am.idx]
+			am.selected = &selected
+			am.history = nil
+			return m.startLoadingWithMessage("Loading alarm history...", []string{selected.Name}, am.loadHistory(*m, selected.Name))
+		}
+	}
+	return *m, nil
+}
+
+func (am *cwAlarmsModel) updateDetail(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "esc":
+		m.screen = screenCWAlarmList
+	case "r":
+		if am.selected != nil {
+			return m.startLoadingWithMessage("Loading alarm history...", []string{am.selected.Name}, am.loadHistory(*m, am.selected.Name))
+		}
+	case "g":
+		if am.selected != nil {
+			if feature, target, value, ok := alarmRelatedResource(*am.selected); ok {
+				m.enterServiceForPalette(paletteItem{service: featureService(feature), feature: feature})
+				m.storeFilterValue(target, value)
+				return m.startFeature(feature)
+			}
+		}
+	case "l":
+		if am.selected != nil {
+			if logGroup, ok := alarmRelatedLogGroup(*am.selected); ok {
+				m.enterServiceForPalette(paletteItem{service: domain.ServiceCloudWatchLogs, feature: domain.FeatureCloudWatchLogsBrowser})
+				m.storeFilterValue(filterCWLogGroups, logGroup)
+				return m.startFeature(domain.FeatureCloudWatchLogsBrowser)
+			}
+		}
+	}
+	return *m, nil
+}
+
+// alarmRelatedResource maps well-known alarm dimensions to a resource browser
+// and its prefilled filter.
+func alarmRelatedResource(alarm awsservice.CloudWatchAlarm) (domain.FeatureKind, filterTarget, string, bool) {
+	if value := alarm.Dimension("DBInstanceIdentifier"); value != "" {
+		return domain.FeatureRDSBrowser, filterRDS, value, true
+	}
+	if value := alarm.Dimension("InstanceId"); value != "" {
+		return domain.FeatureEC2InstanceBrowser, filterEC2BrowserInstances, value, true
+	}
+	if value := alarm.Dimension("ClusterName"); value != "" {
+		return domain.FeatureECSExec, filterECSClusters, value, true
+	}
+	if value := alarm.Dimension("FunctionName"); value != "" {
+		return domain.FeatureLambdaBrowser, filterLambdaFunctions, value, true
+	}
+	return "", filterNone, "", false
+}
+
+// alarmRelatedLogGroup derives an obvious log group from alarm dimensions.
+func alarmRelatedLogGroup(alarm awsservice.CloudWatchAlarm) (string, bool) {
+	if fn := alarm.Dimension("FunctionName"); fn != "" {
+		return "/aws/lambda/" + fn, true
+	}
+	if lg := alarm.Dimension("LogGroupName"); lg != "" {
+		return lg, true
+	}
+	return "", false
+}
+
+// featureService resolves the owning service for a feature from the catalog.
+func featureService(kind domain.FeatureKind) domain.AwsService {
+	for _, svc := range domain.Catalog() {
+		for _, feat := range svc.Features {
+			if feat.Kind == kind {
+				return svc.Name
+			}
+		}
+	}
+	return ""
+}
+
+func (am cwAlarmsModel) loadAlarms(m Model) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		m.awsRepo = repo
+
+		alarms, err := repo.ListAlarms(ctx)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		if len(alarms) == 0 {
+			return errMsg{err: fmt.Errorf("no CloudWatch alarms found")}
+		}
+		return cwAlarmsLoadedMsg{alarms: alarms}
+	}
+}
+
+func (am cwAlarmsModel) loadHistory(m Model, alarmName string) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		repo := m.awsRepo
+		if repo == nil {
+			var err error
+			repo, err = awsservice.NewAwsRepository(ctx, m.cfg)
+			if err != nil {
+				return errMsg{err: err}
+			}
+		}
+		items, err := repo.ListAlarmHistory(ctx, alarmName)
+		if err != nil {
+			return errMsg{err: err}
+		}
+		return cwAlarmHistoryLoadedMsg{alarmName: alarmName, items: items}
+	}
+}
+
+func renderAlarmState(state string) string {
+	switch state {
+	case "ALARM":
+		return errorStyle.Render(state)
+	case "OK":
+		return selectedStyle.Render(state)
+	case "INSUFFICIENT_DATA":
+		return filterStyle.Render(state)
+	default:
+		return normalStyle.Render(state)
+	}
+}
+
+func (am cwAlarmsModel) viewList(m Model) string {
+	var b strings.Builder
+	var panel strings.Builder
+	b.WriteString(m.renderStatusBar())
+	b.WriteString(titleStyle.Render("CloudWatch Alarms"))
+	b.WriteString("\n")
+
+	var tabs []string
+	for i, state := range alarmStateFilters {
+		if i == am.stateIdx {
+			tabs = append(tabs, selectedStyle.Render("["+state+"]"))
+		} else {
+			tabs = append(tabs, dimStyle.Render(state))
+		}
+	}
+	b.WriteString("  " + strings.Join(tabs, "  "))
+	b.WriteString("\n")
+	b.WriteString(m.renderFilterValue(filterCWAlarms))
+	b.WriteString("\n\n")
+
+	if len(am.filtered) == 0 {
+		emptyText := "  No alarms found"
+		if len(am.alarms) > 0 {
+			emptyText = "  No matching alarms"
+		}
+		panel.WriteString(dimStyle.Render(emptyText))
+		panel.WriteString("\n")
+	} else {
+		visibleLines := max(m.height-12, 5)
+		start := 0
+		if am.idx >= visibleLines {
+			start = am.idx - visibleLines + 1
+		}
+		end := min(start+visibleLines, len(am.filtered))
+		for i := start; i < end; i++ {
+			alarm := am.filtered[i]
+			cursor := "  "
+			style := normalStyle
+			if i == am.idx {
+				cursor = "> "
+				style = selectedStyle
+			}
+			panel.WriteString(style.Render(cursor + m.renderHighlightedValue(filterCWAlarms, alarm.DisplayTitle())))
+			panel.WriteString("\n")
+		}
+		panel.WriteString("\n")
+		panel.WriteString(dimStyle.Render(fmt.Sprintf("  %d/%d alarms", len(am.filtered), len(am.alarms))))
+	}
+
+	b.WriteString(m.renderListPanel(panel.String()))
+	b.WriteString("\n\n")
+	b.WriteString(m.renderHelpBar("↑/↓: navigate • tab: state filter • /: filter • r: refresh • enter: detail • esc: back"))
+	return b.String()
+}
+
+func (am cwAlarmsModel) viewDetail(m Model) string {
+	if am.selected == nil {
+		return ""
+	}
+	alarm := am.selected
+	var b strings.Builder
+	b.WriteString(m.renderStatusBar())
+	b.WriteString(titleStyle.Render("Alarm Detail"))
+	b.WriteString("\n\n")
+
+	b.WriteString(m.renderEC2DetailLine("Name", alarm.Name))
+	b.WriteString(m.renderEC2StyledDetailLine("State", renderAlarmState(alarm.State)))
+	b.WriteString(m.renderEC2DetailLine("State Since", formatAlarmTime(alarm.StateUpdated)))
+	b.WriteString(m.renderEC2DetailLine("Reason", ec2ValueOrDash(alarm.StateReason)))
+	b.WriteString(m.renderEC2DetailLine("Metric", ec2ValueOrDash(alarm.Namespace+"/"+alarm.MetricName)))
+	b.WriteString(m.renderEC2DetailLine("Condition", fmt.Sprintf("%s %g", alarm.ComparisonOperator, alarm.Threshold)))
+	actions := "disabled"
+	if alarm.ActionsEnabled {
+		actions = "enabled"
+	}
+	b.WriteString(m.renderEC2DetailLine("Actions", actions))
+
+	b.WriteString("\n")
+	b.WriteString(titleStyle.Render("Dimensions"))
+	b.WriteString("\n")
+	if len(alarm.Dimensions) == 0 {
+		b.WriteString(dimStyle.Render("  (none)"))
+		b.WriteString("\n")
+	} else {
+		for _, dim := range alarm.Dimensions {
+			b.WriteString(m.renderEC2DetailLine(dim.Name, dim.Value))
+		}
+	}
+
+	b.WriteString("\n")
+	b.WriteString(titleStyle.Render("Recent Transitions"))
+	b.WriteString("\n")
+	if len(am.history) == 0 {
+		b.WriteString(dimStyle.Render("  (no recent history)"))
+		b.WriteString("\n")
+	} else {
+		shown := min(len(am.history), 10)
+		for _, item := range am.history[:shown] {
+			b.WriteString(dimStyle.Render("  " + formatAlarmTime(item.Timestamp) + "  "))
+			b.WriteString(normalStyle.Render(item.Summary))
+			b.WriteString("\n")
+		}
+	}
+
+	help := "r: reload history • esc: back • H: home"
+	if _, _, _, ok := alarmRelatedResource(*alarm); ok {
+		help = "g: related resource • " + help
+	}
+	if _, ok := alarmRelatedLogGroup(*alarm); ok {
+		help = "l: logs • " + help
+	}
+	b.WriteString("\n")
+	b.WriteString(m.renderHelpBar(help))
+	return b.String()
+}
+
+func formatAlarmTime(t time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	return t.Local().Format("2006-01-02 15:04:05")
+}

--- a/internal/app/screen_cwalarms_test.go
+++ b/internal/app/screen_cwalarms_test.go
@@ -1,0 +1,108 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"unic/internal/config"
+	"unic/internal/domain"
+	awsservice "unic/internal/services/aws"
+)
+
+func alarmsTestModel() Model {
+	m := New(testConfig(), "", "dev")
+	m.cfg = &config.Config{Region: "us-east-1", ContextName: "dev"}
+	m.screen = screenLoading
+	return m
+}
+
+func testAlarms() []awsservice.CloudWatchAlarm {
+	return []awsservice.CloudWatchAlarm{
+		{Name: "db-cpu-high", State: "ALARM", Namespace: "AWS/RDS", MetricName: "CPUUtilization",
+			Dimensions: []awsservice.CloudWatchAlarmDimension{{Name: "DBInstanceIdentifier", Value: "prod-db"}}},
+		{Name: "healthy", State: "OK", Namespace: "AWS/EC2", MetricName: "CPUUtilization",
+			Dimensions: []awsservice.CloudWatchAlarmDimension{{Name: "InstanceId", Value: "i-123"}}},
+	}
+}
+
+func TestAlarmsLoadedOpensListWithStateTabs(t *testing.T) {
+	m := alarmsTestModel()
+
+	_, _, handled := m.cwAlarms.HandleMessage(&m, cwAlarmsLoadedMsg{alarms: testAlarms()})
+	if !handled || m.screen != screenCWAlarmList {
+		t.Fatalf("expected alarm list screen, got %v handled=%v", m.screen, handled)
+	}
+	if len(m.cwAlarms.filtered) != 2 {
+		t.Fatalf("expected all alarms under ALL tab, got %d", len(m.cwAlarms.filtered))
+	}
+
+	view, ok := m.cwAlarms.View(m)
+	if !ok || !strings.Contains(view, "db-cpu-high") || !strings.Contains(view, "[ALL]") {
+		t.Fatalf("expected alarm list view with state tabs, got:\n%s", view)
+	}
+}
+
+func TestAlarmsStateTabFilters(t *testing.T) {
+	m := alarmsTestModel()
+	m.cwAlarms.HandleMessage(&m, cwAlarmsLoadedMsg{alarms: testAlarms()})
+
+	// ALL -> ALARM
+	m.cwAlarms.updateList(&m, tea.KeyMsg{Type: tea.KeyTab})
+	if len(m.cwAlarms.filtered) != 1 || m.cwAlarms.filtered[0].State != "ALARM" {
+		t.Fatalf("expected only firing alarms on the ALARM tab, got %+v", m.cwAlarms.filtered)
+	}
+}
+
+func TestAlarmDetailRelatedResourceJump(t *testing.T) {
+	m := alarmsTestModel()
+	m.cwAlarms.HandleMessage(&m, cwAlarmsLoadedMsg{alarms: testAlarms()})
+	alarm := testAlarms()[0]
+	m.cwAlarms.selected = &alarm
+	m.screen = screenCWAlarmDetail
+
+	newM, cmd, handled := m.cwAlarms.HandleKey(&m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}})
+	if !handled || cmd == nil {
+		t.Fatal("expected related-resource jump to start")
+	}
+	model := newM.(Model)
+	if model.filterValue(filterRDS) != "prod-db" {
+		t.Fatalf("expected RDS filter prefilled from the alarm dimension, got %q", model.filterValue(filterRDS))
+	}
+	if model.activeService != domain.ServiceRDS {
+		t.Fatalf("expected active service RDS, got %v", model.activeService)
+	}
+}
+
+func TestAlarmRelatedLogGroupForLambda(t *testing.T) {
+	alarm := awsservice.CloudWatchAlarm{
+		Dimensions: []awsservice.CloudWatchAlarmDimension{{Name: "FunctionName", Value: "checkout"}},
+	}
+	logGroup, ok := alarmRelatedLogGroup(alarm)
+	if !ok || logGroup != "/aws/lambda/checkout" {
+		t.Fatalf("expected derived lambda log group, got %q ok=%v", logGroup, ok)
+	}
+
+	if _, ok := alarmRelatedLogGroup(awsservice.CloudWatchAlarm{}); ok {
+		t.Fatal("expected no log group without a mappable dimension")
+	}
+}
+
+func TestAlarmHistoryLoadedOpensDetail(t *testing.T) {
+	m := alarmsTestModel()
+	alarm := testAlarms()[0]
+	m.cwAlarms.selected = &alarm
+
+	_, _, handled := m.cwAlarms.HandleMessage(&m, cwAlarmHistoryLoadedMsg{
+		alarmName: "db-cpu-high",
+		items:     []awsservice.CloudWatchAlarmHistoryItem{{Summary: "OK to ALARM"}},
+	})
+	if !handled || m.screen != screenCWAlarmDetail {
+		t.Fatalf("expected detail screen after history load, got %v", m.screen)
+	}
+	view, ok := m.cwAlarms.View(m)
+	if !ok || !strings.Contains(view, "OK to ALARM") || !strings.Contains(view, "prod-db") {
+		t.Fatalf("expected detail view with history and dimensions, got:\n%s", view)
+	}
+}

--- a/internal/app/screen_views.go
+++ b/internal/app/screen_views.go
@@ -25,6 +25,7 @@ var featurePrimaryFilter = map[domain.FeatureKind]filterTarget{
 	domain.FeatureSecurityGroupBrowser:  filterSecurityGroups,
 	domain.FeatureIAMUsersBrowser:       filterIAMUsers,
 	domain.FeatureCloudWatchMetrics:     filterCWMetrics,
+	domain.FeatureCloudWatchAlarms:      filterCWAlarms,
 	domain.FeatureCloudWatchLogsBrowser: filterCWLogGroups,
 	domain.FeatureECSExec:               filterECSClusters,
 	domain.FeatureEKSBrowser:            filterEKSClusters,

--- a/internal/domain/catalog.go
+++ b/internal/domain/catalog.go
@@ -64,6 +64,10 @@ func Catalog() []Service {
 			Name: ServiceCloudWatch,
 			Features: []Feature{
 				{
+					Kind:        FeatureCloudWatchAlarms,
+					Description: "Triage alarm states and recent transitions as an incident entry point",
+				},
+				{
 					Kind:        FeatureCloudWatchMetrics,
 					Description: "Browse CloudWatch metric series with presets, controls, and comparison charts",
 				},

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -39,6 +39,7 @@ const (
 	FeatureListAccessKeys        FeatureKind = "ListAccessKeys"
 	FeatureRotateAccessKey       FeatureKind = "RotateAccessKey"
 	FeatureCloudWatchMetrics     FeatureKind = "CloudWatch Metrics Viewer"
+	FeatureCloudWatchAlarms      FeatureKind = "CloudWatch Alarm Browser"
 	FeatureCloudWatchLogsBrowser FeatureKind = "CloudWatch Logs Browser"
 	FeatureECSExec               FeatureKind = "ECS Browser & Exec"
 	FeatureECRRepositoryBrowser  FeatureKind = "ECR Repository Browser"

--- a/internal/services/aws/cloudwatch_alarms.go
+++ b/internal/services/aws/cloudwatch_alarms.go
@@ -1,0 +1,155 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+
+	uniclog "unic/internal/log"
+)
+
+// CloudWatchAlarm is a metric alarm with the state fields operators triage by.
+type CloudWatchAlarm struct {
+	Name               string
+	State              string
+	StateReason        string
+	StateUpdated       time.Time
+	MetricName         string
+	Namespace          string
+	Dimensions         []CloudWatchAlarmDimension
+	Threshold          float64
+	ComparisonOperator string
+	ActionsEnabled     bool
+}
+
+type CloudWatchAlarmDimension struct {
+	Name  string
+	Value string
+}
+
+// DisplayTitle returns a formatted string for list display.
+func (a CloudWatchAlarm) DisplayTitle() string {
+	metric := a.MetricName
+	if a.Namespace != "" {
+		metric = a.Namespace + "/" + a.MetricName
+	}
+	return fmt.Sprintf("%-17s %-40s %s", a.State, a.Name, metric)
+}
+
+// FilterText returns a lowercase string for keyword matching.
+func (a CloudWatchAlarm) FilterText() string {
+	parts := []string{a.Name, a.State, a.Namespace, a.MetricName, a.StateReason}
+	for _, dim := range a.Dimensions {
+		parts = append(parts, dim.Name, dim.Value)
+	}
+	return strings.ToLower(strings.Join(parts, " "))
+}
+
+// Dimension returns the value of the named dimension, or "".
+func (a CloudWatchAlarm) Dimension(name string) string {
+	for _, dim := range a.Dimensions {
+		if dim.Name == name {
+			return dim.Value
+		}
+	}
+	return ""
+}
+
+// CloudWatchAlarmHistoryItem is one recorded alarm transition or update.
+type CloudWatchAlarmHistoryItem struct {
+	Timestamp time.Time
+	Type      string
+	Summary   string
+}
+
+// alarmStatePriority orders triage-first: firing alarms above unknowns above healthy.
+func alarmStatePriority(state string) int {
+	switch state {
+	case "ALARM":
+		return 0
+	case "INSUFFICIENT_DATA":
+		return 1
+	default:
+		return 2
+	}
+}
+
+// ListAlarms returns all metric alarms in the account/region, firing first.
+func (r *AwsRepository) ListAlarms(ctx context.Context) ([]CloudWatchAlarm, error) {
+	uniclog.Debug("aws", "ListAlarms called")
+
+	var alarms []CloudWatchAlarm
+	paginator := cloudwatch.NewDescribeAlarmsPaginator(r.CloudWatchClient, &cloudwatch.DescribeAlarmsInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to describe alarms: %w", err)
+		}
+		for _, alarm := range page.MetricAlarms {
+			mapped := CloudWatchAlarm{
+				Name:               derefString(alarm.AlarmName),
+				State:              string(alarm.StateValue),
+				StateReason:        derefString(alarm.StateReason),
+				MetricName:         derefString(alarm.MetricName),
+				Namespace:          derefString(alarm.Namespace),
+				ComparisonOperator: string(alarm.ComparisonOperator),
+				ActionsEnabled:     alarm.ActionsEnabled != nil && *alarm.ActionsEnabled,
+			}
+			if alarm.Threshold != nil {
+				mapped.Threshold = *alarm.Threshold
+			}
+			if alarm.StateUpdatedTimestamp != nil {
+				mapped.StateUpdated = *alarm.StateUpdatedTimestamp
+			}
+			for _, dim := range alarm.Dimensions {
+				mapped.Dimensions = append(mapped.Dimensions, CloudWatchAlarmDimension{
+					Name:  derefString(dim.Name),
+					Value: derefString(dim.Value),
+				})
+			}
+			alarms = append(alarms, mapped)
+		}
+	}
+
+	sort.SliceStable(alarms, func(i, j int) bool {
+		left, right := alarmStatePriority(alarms[i].State), alarmStatePriority(alarms[j].State)
+		if left != right {
+			return left < right
+		}
+		return normalizedSortKey(alarms[i].Name) < normalizedSortKey(alarms[j].Name)
+	})
+	return alarms, nil
+}
+
+// ListAlarmHistory returns the most recent history items for an alarm, newest first.
+func (r *AwsRepository) ListAlarmHistory(ctx context.Context, alarmName string) ([]CloudWatchAlarmHistoryItem, error) {
+	uniclog.Debug("aws", "ListAlarmHistory called", "alarm", alarmName)
+
+	maxRecords := int32(20)
+	out, err := r.CloudWatchClient.DescribeAlarmHistory(ctx, &cloudwatch.DescribeAlarmHistoryInput{
+		AlarmName:  &alarmName,
+		MaxRecords: &maxRecords,
+		ScanBy:     cwtypes.ScanByTimestampDescending,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe alarm history for %s: %w", alarmName, err)
+	}
+
+	items := make([]CloudWatchAlarmHistoryItem, 0, len(out.AlarmHistoryItems))
+	for _, item := range out.AlarmHistoryItems {
+		mapped := CloudWatchAlarmHistoryItem{
+			Type:    string(item.HistoryItemType),
+			Summary: derefString(item.HistorySummary),
+		}
+		if item.Timestamp != nil {
+			mapped.Timestamp = *item.Timestamp
+		}
+		items = append(items, mapped)
+	}
+	return items, nil
+}

--- a/internal/services/aws/cloudwatch_alarms.go
+++ b/internal/services/aws/cloudwatch_alarms.go
@@ -25,6 +25,9 @@ type CloudWatchAlarm struct {
 	Threshold          float64
 	ComparisonOperator string
 	ActionsEnabled     bool
+	// Composite marks alarms whose state derives from a rule over other
+	// alarms; they carry no metric, dimensions, or threshold.
+	Composite bool
 }
 
 type CloudWatchAlarmDimension struct {
@@ -38,12 +41,18 @@ func (a CloudWatchAlarm) DisplayTitle() string {
 	if a.Namespace != "" {
 		metric = a.Namespace + "/" + a.MetricName
 	}
+	if a.Composite {
+		metric = "(composite)"
+	}
 	return fmt.Sprintf("%-17s %-40s %s", a.State, a.Name, metric)
 }
 
 // FilterText returns a lowercase string for keyword matching.
 func (a CloudWatchAlarm) FilterText() string {
 	parts := []string{a.Name, a.State, a.Namespace, a.MetricName, a.StateReason}
+	if a.Composite {
+		parts = append(parts, "composite")
+	}
 	for _, dim := range a.Dimensions {
 		parts = append(parts, dim.Name, dim.Value)
 	}
@@ -114,6 +123,19 @@ func (r *AwsRepository) ListAlarms(ctx context.Context) ([]CloudWatchAlarm, erro
 			}
 			alarms = append(alarms, mapped)
 		}
+		for _, alarm := range page.CompositeAlarms {
+			mapped := CloudWatchAlarm{
+				Name:           derefString(alarm.AlarmName),
+				State:          string(alarm.StateValue),
+				StateReason:    derefString(alarm.StateReason),
+				ActionsEnabled: alarm.ActionsEnabled != nil && *alarm.ActionsEnabled,
+				Composite:      true,
+			}
+			if alarm.StateUpdatedTimestamp != nil {
+				mapped.StateUpdated = *alarm.StateUpdatedTimestamp
+			}
+			alarms = append(alarms, mapped)
+		}
 	}
 
 	sort.SliceStable(alarms, func(i, j int) bool {
@@ -132,9 +154,10 @@ func (r *AwsRepository) ListAlarmHistory(ctx context.Context, alarmName string) 
 
 	maxRecords := int32(20)
 	out, err := r.CloudWatchClient.DescribeAlarmHistory(ctx, &cloudwatch.DescribeAlarmHistoryInput{
-		AlarmName:  &alarmName,
-		MaxRecords: &maxRecords,
-		ScanBy:     cwtypes.ScanByTimestampDescending,
+		AlarmName:       &alarmName,
+		MaxRecords:      &maxRecords,
+		ScanBy:          cwtypes.ScanByTimestampDescending,
+		HistoryItemType: cwtypes.HistoryItemTypeStateUpdate,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to describe alarm history for %s: %w", alarmName, err)

--- a/internal/services/aws/cloudwatch_alarms_test.go
+++ b/internal/services/aws/cloudwatch_alarms_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,6 +16,13 @@ func TestListAlarmsSortsFiringFirstAndMapsFields(t *testing.T) {
 	mock := &mockCloudWatchClient{
 		describeAlarmsFunc: func(_ context.Context, _ *cloudwatch.DescribeAlarmsInput, _ ...func(*cloudwatch.Options)) (*cloudwatch.DescribeAlarmsOutput, error) {
 			return &cloudwatch.DescribeAlarmsOutput{
+				CompositeAlarms: []cwtypes.CompositeAlarm{
+					{
+						AlarmName:   awssdk.String("service-health"),
+						StateValue:  cwtypes.StateValueAlarm,
+						StateReason: awssdk.String("Child alarm firing"),
+					},
+				},
 				MetricAlarms: []cwtypes.MetricAlarm{
 					{
 						AlarmName:  awssdk.String("healthy-alarm"),
@@ -51,16 +59,24 @@ func TestListAlarmsSortsFiringFirstAndMapsFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(alarms) != 3 {
-		t.Fatalf("expected 3 alarms, got %d", len(alarms))
+	if len(alarms) != 4 {
+		t.Fatalf("expected 4 alarms including the composite, got %d", len(alarms))
 	}
-	if alarms[0].State != "ALARM" || alarms[1].State != "INSUFFICIENT_DATA" || alarms[2].State != "OK" {
-		t.Fatalf("expected firing-first ordering, got %v %v %v", alarms[0].State, alarms[1].State, alarms[2].State)
+	if alarms[0].State != "ALARM" || alarms[1].State != "ALARM" ||
+		alarms[2].State != "INSUFFICIENT_DATA" || alarms[3].State != "OK" {
+		t.Fatalf("expected firing-first ordering across metric and composite alarms, got %+v", alarms)
 	}
 	firing := alarms[0]
 	if firing.Name != "db-cpu-high" || firing.Dimension("DBInstanceIdentifier") != "prod-db" ||
 		firing.Threshold != 80 || !firing.StateUpdated.Equal(updated) {
 		t.Fatalf("expected mapped alarm fields, got %+v", firing)
+	}
+	composite := alarms[1]
+	if composite.Name != "service-health" || !composite.Composite || composite.StateReason != "Child alarm firing" {
+		t.Fatalf("expected mapped composite alarm, got %+v", composite)
+	}
+	if !strings.Contains(composite.DisplayTitle(), "(composite)") {
+		t.Fatalf("expected composite marker in display title, got %q", composite.DisplayTitle())
 	}
 }
 
@@ -73,6 +89,9 @@ func TestListAlarmHistoryMapsItems(t *testing.T) {
 			}
 			if params.ScanBy != cwtypes.ScanByTimestampDescending {
 				t.Fatalf("expected newest-first scan, got %v", params.ScanBy)
+			}
+			if params.HistoryItemType != cwtypes.HistoryItemTypeStateUpdate {
+				t.Fatalf("expected state-update-only history, got %v", params.HistoryItemType)
 			}
 			return &cloudwatch.DescribeAlarmHistoryOutput{
 				AlarmHistoryItems: []cwtypes.AlarmHistoryItem{

--- a/internal/services/aws/cloudwatch_alarms_test.go
+++ b/internal/services/aws/cloudwatch_alarms_test.go
@@ -1,0 +1,97 @@
+package aws
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+)
+
+func TestListAlarmsSortsFiringFirstAndMapsFields(t *testing.T) {
+	updated := time.Date(2026, 8, 14, 9, 0, 0, 0, time.UTC)
+	mock := &mockCloudWatchClient{
+		describeAlarmsFunc: func(_ context.Context, _ *cloudwatch.DescribeAlarmsInput, _ ...func(*cloudwatch.Options)) (*cloudwatch.DescribeAlarmsOutput, error) {
+			return &cloudwatch.DescribeAlarmsOutput{
+				MetricAlarms: []cwtypes.MetricAlarm{
+					{
+						AlarmName:  awssdk.String("healthy-alarm"),
+						StateValue: cwtypes.StateValueOk,
+						MetricName: awssdk.String("CPUUtilization"),
+						Namespace:  awssdk.String("AWS/EC2"),
+					},
+					{
+						AlarmName:             awssdk.String("db-cpu-high"),
+						StateValue:            cwtypes.StateValueAlarm,
+						StateReason:           awssdk.String("Threshold crossed"),
+						StateUpdatedTimestamp: &updated,
+						MetricName:            awssdk.String("CPUUtilization"),
+						Namespace:             awssdk.String("AWS/RDS"),
+						Threshold:             awssdk.Float64(80),
+						ComparisonOperator:    cwtypes.ComparisonOperatorGreaterThanThreshold,
+						Dimensions: []cwtypes.Dimension{
+							{Name: awssdk.String("DBInstanceIdentifier"), Value: awssdk.String("prod-db")},
+						},
+					},
+					{
+						AlarmName:  awssdk.String("no-data-alarm"),
+						StateValue: cwtypes.StateValueInsufficientData,
+						MetricName: awssdk.String("Invocations"),
+						Namespace:  awssdk.String("AWS/Lambda"),
+					},
+				},
+			}, nil
+		},
+	}
+	repo := &AwsRepository{CloudWatchClient: mock}
+
+	alarms, err := repo.ListAlarms(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(alarms) != 3 {
+		t.Fatalf("expected 3 alarms, got %d", len(alarms))
+	}
+	if alarms[0].State != "ALARM" || alarms[1].State != "INSUFFICIENT_DATA" || alarms[2].State != "OK" {
+		t.Fatalf("expected firing-first ordering, got %v %v %v", alarms[0].State, alarms[1].State, alarms[2].State)
+	}
+	firing := alarms[0]
+	if firing.Name != "db-cpu-high" || firing.Dimension("DBInstanceIdentifier") != "prod-db" ||
+		firing.Threshold != 80 || !firing.StateUpdated.Equal(updated) {
+		t.Fatalf("expected mapped alarm fields, got %+v", firing)
+	}
+}
+
+func TestListAlarmHistoryMapsItems(t *testing.T) {
+	ts := time.Date(2026, 8, 14, 8, 0, 0, 0, time.UTC)
+	mock := &mockCloudWatchClient{
+		describeAlarmHistoryFunc: func(_ context.Context, params *cloudwatch.DescribeAlarmHistoryInput, _ ...func(*cloudwatch.Options)) (*cloudwatch.DescribeAlarmHistoryOutput, error) {
+			if awssdk.ToString(params.AlarmName) != "db-cpu-high" {
+				t.Fatalf("expected alarm name filter, got %+v", params)
+			}
+			if params.ScanBy != cwtypes.ScanByTimestampDescending {
+				t.Fatalf("expected newest-first scan, got %v", params.ScanBy)
+			}
+			return &cloudwatch.DescribeAlarmHistoryOutput{
+				AlarmHistoryItems: []cwtypes.AlarmHistoryItem{
+					{
+						Timestamp:       &ts,
+						HistoryItemType: cwtypes.HistoryItemTypeStateUpdate,
+						HistorySummary:  awssdk.String("Alarm updated from OK to ALARM"),
+					},
+				},
+			}, nil
+		},
+	}
+	repo := &AwsRepository{CloudWatchClient: mock}
+
+	items, err := repo.ListAlarmHistory(context.Background(), "db-cpu-high")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 || items[0].Summary != "Alarm updated from OK to ALARM" || !items[0].Timestamp.Equal(ts) {
+		t.Fatalf("expected mapped history item, got %+v", items)
+	}
+}

--- a/internal/services/aws/cloudwatch_metrics_test.go
+++ b/internal/services/aws/cloudwatch_metrics_test.go
@@ -12,8 +12,24 @@ import (
 )
 
 type mockCloudWatchClient struct {
-	listMetricsFunc   func(ctx context.Context, params *cloudwatch.ListMetricsInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.ListMetricsOutput, error)
-	getMetricDataFunc func(ctx context.Context, params *cloudwatch.GetMetricDataInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.GetMetricDataOutput, error)
+	listMetricsFunc          func(ctx context.Context, params *cloudwatch.ListMetricsInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.ListMetricsOutput, error)
+	getMetricDataFunc        func(ctx context.Context, params *cloudwatch.GetMetricDataInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.GetMetricDataOutput, error)
+	describeAlarmsFunc       func(ctx context.Context, params *cloudwatch.DescribeAlarmsInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.DescribeAlarmsOutput, error)
+	describeAlarmHistoryFunc func(ctx context.Context, params *cloudwatch.DescribeAlarmHistoryInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.DescribeAlarmHistoryOutput, error)
+}
+
+func (m *mockCloudWatchClient) DescribeAlarms(ctx context.Context, params *cloudwatch.DescribeAlarmsInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.DescribeAlarmsOutput, error) {
+	if m.describeAlarmsFunc != nil {
+		return m.describeAlarmsFunc(ctx, params, optFns...)
+	}
+	return &cloudwatch.DescribeAlarmsOutput{}, nil
+}
+
+func (m *mockCloudWatchClient) DescribeAlarmHistory(ctx context.Context, params *cloudwatch.DescribeAlarmHistoryInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.DescribeAlarmHistoryOutput, error) {
+	if m.describeAlarmHistoryFunc != nil {
+		return m.describeAlarmHistoryFunc(ctx, params, optFns...)
+	}
+	return &cloudwatch.DescribeAlarmHistoryOutput{}, nil
 }
 
 func (m *mockCloudWatchClient) ListMetrics(ctx context.Context, params *cloudwatch.ListMetricsInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.ListMetricsOutput, error) {

--- a/internal/services/aws/repository.go
+++ b/internal/services/aws/repository.go
@@ -162,6 +162,8 @@ type STSClientAPI interface {
 type CloudWatchClientAPI interface {
 	ListMetrics(ctx context.Context, params *cloudwatch.ListMetricsInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.ListMetricsOutput, error)
 	GetMetricData(ctx context.Context, params *cloudwatch.GetMetricDataInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.GetMetricDataOutput, error)
+	DescribeAlarms(ctx context.Context, params *cloudwatch.DescribeAlarmsInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.DescribeAlarmsOutput, error)
+	DescribeAlarmHistory(ctx context.Context, params *cloudwatch.DescribeAlarmHistoryInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.DescribeAlarmHistoryOutput, error)
 }
 
 // CloudWatchLogsClientAPI is the interface for CloudWatch Logs operations used by AwsRepository.


### PR DESCRIPTION
## Summary

Implements #129: an alarm-first triage flow under the CloudWatch service, answering "what is broken right now?" before drilling into resources or logs.

- **Alarm list**: firing-first ordering (`ALARM` > `INSUFFICIENT_DATA` > `OK`), a `tab`-cycled state filter (ALL/ALARM/INSUFFICIENT_DATA/OK) composed with the shared text filter, matching names, states, metrics, reasons, and dimensions.
- **Alarm detail**: state + reason + since-timestamp, metric condition (comparison/threshold), dimensions, actions-enabled flag, and the newest transitions from `DescribeAlarmHistory` (newest-first, up to 10 shown).
- **Triage drill-downs**: `g` maps well-known dimensions to their browsers — `DBInstanceIdentifier`→RDS, `InstanceId`→EC2, `ClusterName`→ECS, `FunctionName`→Lambda — jumping in with the shared filter prefilled to the unhealthy resource (reusing the palette/views jump machinery). `l` opens CloudWatch Logs prefilled with a derivable log group (`/aws/lambda/<fn>` or a `LogGroupName` dimension). Keys appear in the help bar only when a mapping exists.
- **Scope boundary respected**: no metric rendering or chart controls; the metrics viewer remains separate per the issue.
- Repository layer adds `ListAlarms`/`ListAlarmHistory` with `DescribeAlarms`/`DescribeAlarmHistory` on `CloudWatchClientAPI`.

## Testing

- `go test ./...` passes: alarm mapping and firing-first sort, history mapping with newest-first scan, list open with state tabs, tab filtering, related-resource jump with filter prefill and service alignment, lambda log-group derivation, and history-loaded detail rendering.
- `make build` passes.

## Docs

- README: service catalog row, key bindings row, and an alarm-browser behavior paragraph.

Closes #129