### PR TITLE
feat: add prompt-based checklist creation to Checklist Inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Context ordering:
 
 Security Inspector ships built-in rule packs for Security Group exposure, RDS encryption/public access/backups and public snapshot sharing, IAM access key age/root-account hardening/wildcard policies, Secrets Manager rotation age, S3 public access/Block Public Access/versioning, CloudTrail baseline coverage, GuardDuty and AWS Config baseline controls, and ElastiCache for Valkey encryption/backup/access-control checks.
 
-Checklist Inspector can load a YAML file either from the Inspector-mode file picker or from `--checklist` at startup, and currently supports:
+Checklist Inspector can load a YAML file either from the Inspector-mode file picker or from `--checklist` at startup. Press `a` on the checklist results screen to add a check through type-specific prompts instead of editing YAML: pick one of the twelve rule types, fill the prompted fields (empty skips optional expectations), and the check is appended to the loaded checklist file — or a new `unic-checklist.yaml` when none is loaded — validated through the same `LoadChecklist` rules before anything is written, then the checklist reruns so the new result shows immediately. Currently supported types:
 
 - `rds` for expected DB instance state such as status, engine, class, Multi-AZ, encryption, public access, and backup retention
 - `security_group` for required or forbidden ingress/egress rule matchers
@@ -433,7 +433,7 @@ checks:
 | FIS | `Enter` template detail/run detail, `/` filter, `h` selected-template history, `H` all experiment history, `r` refresh, template detail includes safe-run preview and detail scrolls through targets/actions/stop conditions |
 | Inspector Mode | `i` open mode from the service list, `Enter` open the selected workflow, `l` open the checklist file picker |
 | Security Inspector | `r` run/rescan, `1`-`5` severity filter, `Enter` finding detail |
-| Checklist Inspector | `l` load or switch checklist files, `r` run/rerun the loaded checklist, `Enter` result detail |
+| Checklist Inspector | `l` load or switch checklist files, `a` add a check through type-specific prompts, `r` run/rerun the loaded checklist, `Enter` result detail |
 | Settings | `Enter`/`Space` toggle selected setting, `Esc`/`q` back |
 | Context Picker | `a` add context, `f` favorite/unfavorite selected context, type or `/` filter, `s` setup selected context and quit, `y` copy selected exports and quit, filter-mode `Ctrl+S` setup selected filtered context, filter-mode `Ctrl+Y` copy selected filtered exports, `u` clear shell context and quit with a final confirmation message |
 | ECR | `Enter` images, `d` repository detail, `/` filter, `r` refresh, image detail `c` copy digest, `t` copy tag |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -104,6 +104,7 @@ const (
 	screenInspectorHome
 	screenInspectorWorkflowPlaceholder
 	screenInspectorChecklistPicker
+	screenInspectorChecklistAdd
 	screenInspectorScanning
 	screenInspectorResults
 	screenInspectorFindingDetail
@@ -431,6 +432,9 @@ func (m Model) isTextEntryScreen() bool {
 		return true
 	}
 	if m.screen == screenCloudTrailEventList && m.cloudTrail.lookupInput {
+		return true
+	}
+	if m.screen == screenInspectorChecklistAdd && m.inspector.addStep > 0 {
 		return true
 	}
 	switch m.screen {

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -687,6 +687,7 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 		return []helpShortcut{
 			{"↑/↓, j/k", "Move between checklist folders and files"},
 			{"/", "Start filtering entries"},
+			{"a", "Create a check through prompts (starts a new checklist when none is loaded)"},
 			{"enter", "Open the selected folder or load the selected checklist"},
 			{"q / esc", "Go back to Inspector mode"},
 		}

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -712,8 +712,23 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 			{"↑/↓, j/k", "Move between checklist results"},
 			{"enter", "Open the selected checklist result"},
 			{"l", "Open the checklist file picker"},
+			{"a", "Add a check through prompts"},
 			{"r", "Run the checklist again"},
 			{"q / esc", "Go back to Inspector mode"},
+		}
+	case screenInspectorChecklistAdd:
+		if m.inspector.addStep == 0 {
+			return []helpShortcut{
+				{"↑/↓, j/k", "Move between check types"},
+				{"enter", "Select the check type"},
+				{"esc", "Cancel adding a check"},
+			}
+		}
+		return []helpShortcut{
+			{"type", "Enter the field value"},
+			{"backspace", "Delete the previous character"},
+			{"enter", "Confirm the field (empty skips optional fields); saving runs the checklist"},
+			{"esc", "Go back to the previous field"},
 		}
 	case screenInspectorChecklistDetail:
 		return []helpShortcut{
@@ -1052,6 +1067,8 @@ func (m Model) helpScreenTitle() string {
 		return "Inspector Finding Detail"
 	case screenInspectorChecklistResults:
 		return "Checklist Inspector Results"
+	case screenInspectorChecklistAdd:
+		return "Checklist Add Check"
 	case screenInspectorChecklistDetail:
 		return "Checklist Inspector Detail"
 	case screenContextPicker:

--- a/internal/app/screen_inspector.go
+++ b/internal/app/screen_inspector.go
@@ -49,6 +49,15 @@ type inspectorModel struct {
 	checklistReport         *inspector.ChecklistReport
 	checklistIdx            int
 	selectedChecklistResult *inspector.ChecklistResult
+
+	// Add-check wizard
+	addStep     int
+	addTypeIdx  int
+	addFields   []checkFieldDef
+	addFieldIdx int
+	addInput    string
+	addValues   map[string]string
+	addError    string
 }
 
 func newInspectorModel(checklistPath string) inspectorModel {
@@ -257,6 +266,9 @@ func (im *inspectorModel) HandleKey(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cm
 	case screenInspectorChecklistPicker:
 		newM, cmd := im.updateChecklistPicker(m, msg)
 		return newM, cmd, true
+	case screenInspectorChecklistAdd:
+		newM, cmd := im.updateChecklistAdd(m, msg)
+		return newM, cmd, true
 	case screenInspectorResults:
 		newM, cmd := im.updateResults(m, msg)
 		return newM, cmd, true
@@ -282,6 +294,8 @@ func (im inspectorModel) View(m Model) (string, bool) {
 		return im.viewWorkflowPlaceholder(m), true
 	case screenInspectorChecklistPicker:
 		return im.viewChecklistPicker(m), true
+	case screenInspectorChecklistAdd:
+		return im.viewChecklistAdd(m), true
 	case screenInspectorScanning:
 		return im.viewScanning(m), true
 	case screenInspectorResults:
@@ -416,6 +430,8 @@ func (im *inspectorModel) updateChecklistResults(m *Model, msg tea.KeyMsg) (tea.
 		m.screen = screenInspectorHome
 	case "l":
 		return im.openChecklistPicker(m)
+	case "a":
+		return im.openChecklistAdd(m)
 	case "up", "k":
 		if im.checklistReport != nil {
 			im.checklistIdx = previousListIndex(im.checklistIdx, len(im.checklistReport.Results))
@@ -442,6 +458,8 @@ func (im *inspectorModel) updateChecklistDetail(m *Model, msg tea.KeyMsg) (tea.M
 		m.screen = screenInspectorChecklistResults
 	case "l":
 		return im.openChecklistPicker(m)
+	case "a":
+		return im.openChecklistAdd(m)
 	case "r":
 		return im.startWorkflow(m, inspector.WorkflowChecklist)
 	}

--- a/internal/app/screen_inspector.go
+++ b/internal/app/screen_inspector.go
@@ -51,13 +51,14 @@ type inspectorModel struct {
 	selectedChecklistResult *inspector.ChecklistResult
 
 	// Add-check wizard
-	addStep     int
-	addTypeIdx  int
-	addFields   []checkFieldDef
-	addFieldIdx int
-	addInput    string
-	addValues   map[string]string
-	addError    string
+	addPrevScreen screen
+	addStep       int
+	addTypeIdx    int
+	addFields     []checkFieldDef
+	addFieldIdx   int
+	addInput      string
+	addValues     map[string]string
+	addError      string
 }
 
 func newInspectorModel(checklistPath string) inspectorModel {
@@ -480,6 +481,10 @@ func (im *inspectorModel) updateChecklistPicker(m *Model, msg tea.KeyMsg) (tea.M
 		im.checklistFileIdx = nextListIndex(im.checklistFileIdx, len(im.filteredChecklistFiles))
 	case "/":
 		return *m, m.activateFilter(filterInspectorChecklistFiles)
+	case "a":
+		// Creating the first check must be reachable before any checklist
+		// has been loaded; the wizard writes to a new default file then.
+		return im.openChecklistAdd(m)
 	case "enter":
 		if len(im.filteredChecklistFiles) == 0 || im.checklistFileIdx >= len(im.filteredChecklistFiles) {
 			return *m, nil

--- a/internal/app/screen_inspector_add.go
+++ b/internal/app/screen_inspector_add.go
@@ -1,0 +1,384 @@
+package app
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"unic/internal/inspector"
+)
+
+// The checklist add wizard builds one ChecklistCheck from type-specific
+// prompts and appends it to the loaded checklist file (or a new one), always
+// through AppendCheck's whole-file validation, then reruns the checklist.
+
+type checkFieldDef struct {
+	key      string
+	label    string
+	required bool
+	kind     string // "string", "bool", "int", "csv"
+}
+
+var checklistCommonFields = []checkFieldDef{
+	{key: "resource", label: "Resource (name/ID/ARN)", required: true, kind: "string"},
+}
+
+// checklistPromptFields defines the expectation prompts per rule type. Empty
+// inputs skip a field; baseline wrappers need only the resource label.
+var checklistPromptFields = map[inspector.ChecklistCheckType][]checkFieldDef{
+	inspector.ChecklistCheckRDS: {
+		{key: "status", label: "Expected status (optional)", kind: "string"},
+		{key: "engine", label: "Expected engine (optional)", kind: "string"},
+		{key: "instance_class", label: "Expected instance class (optional)", kind: "string"},
+		{key: "multi_az", label: "Multi-AZ true/false (optional)", kind: "bool"},
+		{key: "storage_encrypted", label: "Storage encrypted true/false (optional)", kind: "bool"},
+		{key: "publicly_accessible", label: "Publicly accessible true/false (optional)", kind: "bool"},
+		{key: "backup_retention_days", label: "Backup retention days (optional)", kind: "int"},
+	},
+	inspector.ChecklistCheckSecurityGroup: {
+		{key: "rule_mode", label: "Rule mode: ingress_present/ingress_absent/egress_present/egress_absent", required: true, kind: "string"},
+		{key: "protocol", label: "Protocol (tcp/udp/..., optional)", kind: "string"},
+		{key: "from_port", label: "From port (optional)", kind: "int"},
+		{key: "to_port", label: "To port (optional)", kind: "int"},
+		{key: "cidr", label: "IPv4 CIDR (optional)", kind: "string"},
+	},
+	inspector.ChecklistCheckSecret: {
+		{key: "rotation_enabled", label: "Rotation enabled true/false (optional)", kind: "bool"},
+		{key: "kms_key_id", label: "Expected KMS key ID (optional)", kind: "string"},
+		{key: "value_keys", label: "Required JSON value keys (comma-separated, optional)", kind: "csv"},
+	},
+	inspector.ChecklistCheckHostedZone: {
+		{key: "private_zone", label: "Private zone true/false (optional)", kind: "bool"},
+	},
+	inspector.ChecklistCheckRoute53Record: {
+		{key: "zone", label: "Hosted zone name or ID", required: true, kind: "string"},
+		{key: "record_type", label: "Record type (A/CNAME/..., optional)", kind: "string"},
+		{key: "ttl", label: "Expected TTL (optional)", kind: "int"},
+		{key: "values", label: "Expected values (comma-separated, optional)", kind: "csv"},
+		{key: "alias_target", label: "Alias target DNS name (optional)", kind: "string"},
+	},
+	inspector.ChecklistCheckVPC: {
+		{key: "cidr", label: "Expected CIDR (optional)", kind: "string"},
+		{key: "default_vpc", label: "Default VPC true/false (optional)", kind: "bool"},
+		{key: "subnet_count", label: "Expected subnet count (optional)", kind: "int"},
+	},
+	inspector.ChecklistCheckSubnet: {
+		{key: "vpc", label: "Owning VPC name or ID (optional)", kind: "string"},
+		{key: "cidr", label: "Expected CIDR (optional)", kind: "string"},
+		{key: "availability_zone", label: "Expected availability zone (optional)", kind: "string"},
+		{key: "available_ip_count_min", label: "Minimum available IPs (optional)", kind: "int"},
+	},
+	inspector.ChecklistCheckCloudWatchLogGroup: {
+		{key: "retention_days", label: "Expected retention days (optional)", kind: "int"},
+	},
+	inspector.ChecklistCheckCloudTrailBaseline:        {},
+	inspector.ChecklistCheckGuardDutyBaseline:         {},
+	inspector.ChecklistCheckConfigBaseline:            {},
+	inspector.ChecklistCheckElastiCacheValkeyBaseline: {},
+}
+
+var checklistPromptTypes = []inspector.ChecklistCheckType{
+	inspector.ChecklistCheckRDS,
+	inspector.ChecklistCheckSecurityGroup,
+	inspector.ChecklistCheckSecret,
+	inspector.ChecklistCheckHostedZone,
+	inspector.ChecklistCheckRoute53Record,
+	inspector.ChecklistCheckVPC,
+	inspector.ChecklistCheckSubnet,
+	inspector.ChecklistCheckCloudWatchLogGroup,
+	inspector.ChecklistCheckCloudTrailBaseline,
+	inspector.ChecklistCheckGuardDutyBaseline,
+	inspector.ChecklistCheckConfigBaseline,
+	inspector.ChecklistCheckElastiCacheValkeyBaseline,
+}
+
+// buildChecklistCheck parses the prompted values into a typed check.
+func buildChecklistCheck(checkType inspector.ChecklistCheckType, values map[string]string) (inspector.ChecklistCheck, error) {
+	check := inspector.ChecklistCheck{
+		Type:     checkType,
+		Resource: strings.TrimSpace(values["resource"]),
+	}
+
+	str := func(key string) *string {
+		if v := strings.TrimSpace(values[key]); v != "" {
+			return &v
+		}
+		return nil
+	}
+	boolVal := func(key string) (*bool, error) {
+		v := strings.TrimSpace(values[key])
+		if v == "" {
+			return nil, nil
+		}
+		parsed, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, fmt.Errorf("%s must be true or false", key)
+		}
+		return &parsed, nil
+	}
+	intVal := func(key string) (*int, error) {
+		v := strings.TrimSpace(values[key])
+		if v == "" {
+			return nil, nil
+		}
+		parsed, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("%s must be a number", key)
+		}
+		return &parsed, nil
+	}
+	csv := func(key string) []string {
+		var out []string
+		for _, part := range strings.Split(values[key], ",") {
+			if part = strings.TrimSpace(part); part != "" {
+				out = append(out, part)
+			}
+		}
+		return out
+	}
+
+	var err error
+	switch checkType {
+	case inspector.ChecklistCheckRDS:
+		check.Expect.Status = str("status")
+		check.Expect.Engine = str("engine")
+		check.Expect.InstanceClass = str("instance_class")
+		if check.Expect.MultiAZ, err = boolVal("multi_az"); err != nil {
+			return check, err
+		}
+		if check.Expect.StorageEncrypted, err = boolVal("storage_encrypted"); err != nil {
+			return check, err
+		}
+		if check.Expect.PubliclyAccessible, err = boolVal("publicly_accessible"); err != nil {
+			return check, err
+		}
+		if check.Expect.BackupRetentionDays, err = intVal("backup_retention_days"); err != nil {
+			return check, err
+		}
+	case inspector.ChecklistCheckSecurityGroup:
+		rule := inspector.ChecklistSecurityGroupRule{
+			Protocol: strings.TrimSpace(values["protocol"]),
+			CIDR:     strings.TrimSpace(values["cidr"]),
+		}
+		var fromPort, toPort *int
+		if fromPort, err = intVal("from_port"); err != nil {
+			return check, err
+		}
+		if toPort, err = intVal("to_port"); err != nil {
+			return check, err
+		}
+		rule.FromPort = fromPort
+		rule.ToPort = toPort
+		if !rule.Valid() {
+			return check, fmt.Errorf("security group rules need at least one of protocol, ports, or CIDR")
+		}
+		switch strings.TrimSpace(values["rule_mode"]) {
+		case "ingress_present":
+			check.Expect.IngressPresent = []inspector.ChecklistSecurityGroupRule{rule}
+		case "ingress_absent":
+			check.Expect.IngressAbsent = []inspector.ChecklistSecurityGroupRule{rule}
+		case "egress_present":
+			check.Expect.EgressPresent = []inspector.ChecklistSecurityGroupRule{rule}
+		case "egress_absent":
+			check.Expect.EgressAbsent = []inspector.ChecklistSecurityGroupRule{rule}
+		default:
+			return check, fmt.Errorf("rule_mode must be one of ingress_present, ingress_absent, egress_present, egress_absent")
+		}
+	case inspector.ChecklistCheckSecret:
+		if check.Expect.RotationEnabled, err = boolVal("rotation_enabled"); err != nil {
+			return check, err
+		}
+		check.Expect.KMSKeyID = str("kms_key_id")
+		check.Expect.ValueKeys = csv("value_keys")
+	case inspector.ChecklistCheckHostedZone:
+		if check.Expect.PrivateZone, err = boolVal("private_zone"); err != nil {
+			return check, err
+		}
+	case inspector.ChecklistCheckRoute53Record:
+		check.Expect.Zone = strings.TrimSpace(values["zone"])
+		check.Expect.RecordType = str("record_type")
+		if check.Expect.TTL, err = intVal("ttl"); err != nil {
+			return check, err
+		}
+		check.Expect.Values = csv("values")
+		check.Expect.AliasTarget = str("alias_target")
+	case inspector.ChecklistCheckVPC:
+		check.Expect.CIDR = str("cidr")
+		if check.Expect.DefaultVPC, err = boolVal("default_vpc"); err != nil {
+			return check, err
+		}
+		if check.Expect.SubnetCount, err = intVal("subnet_count"); err != nil {
+			return check, err
+		}
+	case inspector.ChecklistCheckSubnet:
+		check.Expect.VPC = strings.TrimSpace(values["vpc"])
+		check.Expect.CIDR = str("cidr")
+		check.Expect.AvailabilityZone = str("availability_zone")
+		if check.Expect.AvailableIPCountMin, err = intVal("available_ip_count_min"); err != nil {
+			return check, err
+		}
+	case inspector.ChecklistCheckCloudWatchLogGroup:
+		if check.Expect.RetentionDays, err = intVal("retention_days"); err != nil {
+			return check, err
+		}
+	}
+	return check, nil
+}
+
+func (im *inspectorModel) openChecklistAdd(m *Model) (tea.Model, tea.Cmd) {
+	im.addStep = 0
+	im.addTypeIdx = 0
+	im.addFieldIdx = 0
+	im.addInput = ""
+	im.addValues = map[string]string{}
+	im.addError = ""
+	m.screen = screenInspectorChecklistAdd
+	return *m, nil
+}
+
+// checklistAddTargetPath resolves where the new check is persisted: the
+// loaded checklist, or a new custom checklist in the picker directory.
+func (im inspectorModel) checklistAddTargetPath() string {
+	if path := strings.TrimSpace(im.checklistPath); path != "" {
+		return path
+	}
+	return filepath.Join(im.initialChecklistPickerDir(), "unic-checklist.yaml")
+}
+
+func (im *inspectorModel) updateChecklistAdd(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	key := msg.String()
+
+	// Step 0: choose the check type.
+	if im.addStep == 0 {
+		switch key {
+		case "q", "esc":
+			m.screen = screenInspectorChecklistResults
+			if im.checklistReport == nil {
+				m.screen = screenInspectorHome
+			}
+		case "up", "k":
+			im.addTypeIdx = previousListIndex(im.addTypeIdx, len(checklistPromptTypes))
+		case "down", "j":
+			im.addTypeIdx = nextListIndex(im.addTypeIdx, len(checklistPromptTypes))
+		case "enter":
+			checkType := checklistPromptTypes[im.addTypeIdx]
+			im.addFields = append(append([]checkFieldDef(nil), checklistCommonFields...), checklistPromptFields[checkType]...)
+			im.addFieldIdx = 0
+			im.addInput = ""
+			im.addError = ""
+			im.addStep = 1
+		}
+		return *m, nil
+	}
+
+	switch key {
+	case "esc":
+		if im.addFieldIdx > 0 {
+			im.addFieldIdx--
+			im.addInput = im.addValues[im.addFields[im.addFieldIdx].key]
+		} else {
+			im.addStep = 0
+			im.addInput = ""
+		}
+	case "enter":
+		field := im.addFields[im.addFieldIdx]
+		value := strings.TrimSpace(im.addInput)
+		if field.required && value == "" {
+			return *m, nil
+		}
+		im.addValues[field.key] = value
+		im.addInput = ""
+		im.addFieldIdx++
+		if im.addFieldIdx >= len(im.addFields) {
+			return im.saveChecklistAdd(m)
+		}
+	case "backspace":
+		if runes := []rune(im.addInput); len(runes) > 0 {
+			im.addInput = string(runes[:len(runes)-1])
+		}
+	default:
+		if runes := msg.Runes; len(runes) > 0 {
+			im.addInput += string(runes)
+		}
+	}
+	return *m, nil
+}
+
+func (im *inspectorModel) saveChecklistAdd(m *Model) (tea.Model, tea.Cmd) {
+	checkType := checklistPromptTypes[im.addTypeIdx]
+	check, err := buildChecklistCheck(checkType, im.addValues)
+	if err == nil {
+		err = inspector.AppendCheck(im.checklistAddTargetPath(), check)
+	}
+	if err != nil {
+		// Return to the first expectation field so the mistake can be fixed
+		// without retyping everything.
+		im.addError = err.Error()
+		im.addFieldIdx = len(checklistCommonFields)
+		if im.addFieldIdx >= len(im.addFields) {
+			im.addFieldIdx = 0
+		}
+		im.addInput = im.addValues[im.addFields[im.addFieldIdx].key]
+		return *m, nil
+	}
+
+	im.checklistPath = im.checklistAddTargetPath()
+	im.addError = ""
+	return im.startWorkflow(m, inspector.WorkflowChecklist)
+}
+
+func (im inspectorModel) viewChecklistAdd(m Model) string {
+	var b strings.Builder
+	b.WriteString(m.renderStatusBar())
+	b.WriteString(titleStyle.Render("Add Checklist Check"))
+	b.WriteString("\n")
+	b.WriteString(dimStyle.Render("  Target: " + im.checklistAddTargetPath()))
+	b.WriteString("\n\n")
+
+	if im.addStep == 0 {
+		b.WriteString(normalStyle.Render("  Select a check type:"))
+		b.WriteString("\n\n")
+		for i, checkType := range checklistPromptTypes {
+			cursor := "  "
+			style := normalStyle
+			if i == im.addTypeIdx {
+				cursor = "> "
+				style = selectedStyle
+			}
+			b.WriteString(style.Render("  " + cursor + string(checkType)))
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+		b.WriteString(m.renderHelpBar("↑/↓: navigate • enter: select • esc: cancel"))
+		return b.String()
+	}
+
+	b.WriteString(dimStyle.Render(fmt.Sprintf("  type: %s", checklistPromptTypes[im.addTypeIdx])))
+	b.WriteString("\n")
+	if im.addError != "" {
+		b.WriteString(errorStyle.Render("  " + im.addError))
+		b.WriteString("\n")
+	}
+	for i := 0; i < im.addFieldIdx && i < len(im.addFields); i++ {
+		field := im.addFields[i]
+		b.WriteString(dimStyle.Render(fmt.Sprintf("  %s: %s", field.label, im.addValues[field.key])))
+		b.WriteString("\n")
+	}
+	if im.addFieldIdx < len(im.addFields) {
+		field := im.addFields[im.addFieldIdx]
+		b.WriteString("\n")
+		b.WriteString(normalStyle.Render(fmt.Sprintf("  %s: ", field.label)))
+		b.WriteString(filterStyle.Render(fmt.Sprintf("%s▏", im.addInput)))
+		b.WriteString("\n")
+		if !field.required {
+			b.WriteString(dimStyle.Render("  (press enter to skip)"))
+			b.WriteString("\n")
+		}
+	}
+	b.WriteString("\n")
+	b.WriteString(m.renderHelpBar("type: value • enter: next/save • esc: previous field"))
+	return b.String()
+}

--- a/internal/app/screen_inspector_add.go
+++ b/internal/app/screen_inspector_add.go
@@ -32,6 +32,7 @@ var checklistPromptFields = map[inspector.ChecklistCheckType][]checkFieldDef{
 	inspector.ChecklistCheckRDS: {
 		{key: "status", label: "Expected status (optional)", kind: "string"},
 		{key: "engine", label: "Expected engine (optional)", kind: "string"},
+		{key: "engine_version", label: "Expected engine version (optional)", kind: "string"},
 		{key: "instance_class", label: "Expected instance class (optional)", kind: "string"},
 		{key: "multi_az", label: "Multi-AZ true/false (optional)", kind: "bool"},
 		{key: "storage_encrypted", label: "Storage encrypted true/false (optional)", kind: "bool"},
@@ -44,6 +45,8 @@ var checklistPromptFields = map[inspector.ChecklistCheckType][]checkFieldDef{
 		{key: "from_port", label: "From port (optional)", kind: "int"},
 		{key: "to_port", label: "To port (optional)", kind: "int"},
 		{key: "cidr", label: "IPv4 CIDR (optional)", kind: "string"},
+		{key: "cidr_v6", label: "IPv6 CIDR (optional)", kind: "string"},
+		{key: "referenced_sg_id", label: "Referenced security group ID (optional)", kind: "string"},
 	},
 	inspector.ChecklistCheckSecret: {
 		{key: "rotation_enabled", label: "Rotation enabled true/false (optional)", kind: "bool"},
@@ -59,6 +62,7 @@ var checklistPromptFields = map[inspector.ChecklistCheckType][]checkFieldDef{
 		{key: "ttl", label: "Expected TTL (optional)", kind: "int"},
 		{key: "values", label: "Expected values (comma-separated, optional)", kind: "csv"},
 		{key: "alias_target", label: "Alias target DNS name (optional)", kind: "string"},
+		{key: "alias_hosted_zone_id", label: "Alias hosted zone ID (optional)", kind: "string"},
 	},
 	inspector.ChecklistCheckVPC: {
 		{key: "cidr", label: "Expected CIDR (optional)", kind: "string"},
@@ -145,6 +149,7 @@ func buildChecklistCheck(checkType inspector.ChecklistCheckType, values map[stri
 	case inspector.ChecklistCheckRDS:
 		check.Expect.Status = str("status")
 		check.Expect.Engine = str("engine")
+		check.Expect.EngineVersion = str("engine_version")
 		check.Expect.InstanceClass = str("instance_class")
 		if check.Expect.MultiAZ, err = boolVal("multi_az"); err != nil {
 			return check, err
@@ -160,8 +165,10 @@ func buildChecklistCheck(checkType inspector.ChecklistCheckType, values map[stri
 		}
 	case inspector.ChecklistCheckSecurityGroup:
 		rule := inspector.ChecklistSecurityGroupRule{
-			Protocol: strings.TrimSpace(values["protocol"]),
-			CIDR:     strings.TrimSpace(values["cidr"]),
+			Protocol:       strings.TrimSpace(values["protocol"]),
+			CIDR:           strings.TrimSpace(values["cidr"]),
+			CIDRv6:         strings.TrimSpace(values["cidr_v6"]),
+			ReferencedSGID: strings.TrimSpace(values["referenced_sg_id"]),
 		}
 		var fromPort, toPort *int
 		if fromPort, err = intVal("from_port"); err != nil {
@@ -205,6 +212,7 @@ func buildChecklistCheck(checkType inspector.ChecklistCheckType, values map[stri
 		}
 		check.Expect.Values = csv("values")
 		check.Expect.AliasTarget = str("alias_target")
+		check.Expect.AliasHostedZoneID = str("alias_hosted_zone_id")
 	case inspector.ChecklistCheckVPC:
 		check.Expect.CIDR = str("cidr")
 		if check.Expect.DefaultVPC, err = boolVal("default_vpc"); err != nil {
@@ -229,6 +237,7 @@ func buildChecklistCheck(checkType inspector.ChecklistCheckType, values map[stri
 }
 
 func (im *inspectorModel) openChecklistAdd(m *Model) (tea.Model, tea.Cmd) {
+	im.addPrevScreen = m.screen
 	im.addStep = 0
 	im.addTypeIdx = 0
 	im.addFieldIdx = 0
@@ -255,8 +264,8 @@ func (im *inspectorModel) updateChecklistAdd(m *Model, msg tea.KeyMsg) (tea.Mode
 	if im.addStep == 0 {
 		switch key {
 		case "q", "esc":
-			m.screen = screenInspectorChecklistResults
-			if im.checklistReport == nil {
+			m.screen = im.addPrevScreen
+			if m.screen == screenInspectorChecklistAdd || m.screen == 0 {
 				m.screen = screenInspectorHome
 			}
 		case "up", "k":

--- a/internal/app/screen_inspector_add_test.go
+++ b/internal/app/screen_inspector_add_test.go
@@ -1,0 +1,136 @@
+package app
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"unic/internal/config"
+	"unic/internal/inspector"
+)
+
+func inspectorAddTestModel(t *testing.T) Model {
+	t.Helper()
+	m := New(testConfig(), "", "dev")
+	m.cfg = &config.Config{Region: "us-east-1", ContextName: "dev"}
+	m.inspector.checklistPath = filepath.Join(t.TempDir(), "readiness.yaml")
+	m.screen = screenInspectorChecklistResults
+	return m
+}
+
+func typeIntoChecklistAdd(m *Model, text string) {
+	for _, r := range text {
+		m.inspector.updateChecklistAdd(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+}
+
+func selectChecklistType(t *testing.T, m *Model, want inspector.ChecklistCheckType) {
+	t.Helper()
+	for i, checkType := range checklistPromptTypes {
+		if checkType == want {
+			m.inspector.addTypeIdx = i
+			m.inspector.updateChecklistAdd(m, tea.KeyMsg{Type: tea.KeyEnter})
+			return
+		}
+	}
+	t.Fatalf("check type %s not offered", want)
+}
+
+func TestChecklistAddWizardPersistsAndReruns(t *testing.T) {
+	m := inspectorAddTestModel(t)
+
+	m.inspector.openChecklistAdd(&m)
+	if m.screen != screenInspectorChecklistAdd {
+		t.Fatalf("expected add screen, got %v", m.screen)
+	}
+
+	selectChecklistType(t, &m, inspector.ChecklistCheckCloudWatchLogGroup)
+	typeIntoChecklistAdd(&m, "/aws/ecs/app")
+	m.inspector.updateChecklistAdd(&m, tea.KeyMsg{Type: tea.KeyEnter}) // resource
+	typeIntoChecklistAdd(&m, "30")
+	newM, cmd := m.inspector.updateChecklistAdd(&m, tea.KeyMsg{Type: tea.KeyEnter}) // retention -> save
+	model := newM.(Model)
+	if cmd == nil || model.screen != screenInspectorScanning {
+		t.Fatalf("expected checklist rerun after save, got screen=%v", model.screen)
+	}
+
+	loaded, err := inspector.LoadChecklist(m.inspector.checklistPath)
+	if err != nil {
+		t.Fatalf("expected generated checklist to load through validation: %v", err)
+	}
+	if len(loaded.Checks) != 1 || loaded.Checks[0].Type != inspector.ChecklistCheckCloudWatchLogGroup ||
+		loaded.Checks[0].Resource != "/aws/ecs/app" || loaded.Checks[0].Expect.RetentionDays == nil {
+		t.Fatalf("expected persisted log-group check, got %+v", loaded.Checks)
+	}
+}
+
+func TestChecklistAddSecurityGroupRuleMapping(t *testing.T) {
+	values := map[string]string{
+		"resource":  "sg-web",
+		"rule_mode": "ingress_absent",
+		"protocol":  "tcp",
+		"from_port": "22",
+		"to_port":   "22",
+		"cidr":      "0.0.0.0/0",
+	}
+	check, err := buildChecklistCheck(inspector.ChecklistCheckSecurityGroup, values)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(check.Expect.IngressAbsent) != 1 {
+		t.Fatalf("expected one forbidden ingress rule, got %+v", check.Expect)
+	}
+	rule := check.Expect.IngressAbsent[0]
+	if rule.Protocol != "tcp" || rule.CIDR != "0.0.0.0/0" || rule.FromPort == nil || *rule.FromPort != 22 {
+		t.Fatalf("expected mapped rule fields, got %+v", rule)
+	}
+
+	values["rule_mode"] = "sideways"
+	if _, err := buildChecklistCheck(inspector.ChecklistCheckSecurityGroup, values); err == nil {
+		t.Fatal("expected invalid rule_mode rejection")
+	}
+}
+
+func TestChecklistAddValidationFailureKeepsWizardOpen(t *testing.T) {
+	m := inspectorAddTestModel(t)
+	m.inspector.openChecklistAdd(&m)
+	selectChecklistType(t, &m, inspector.ChecklistCheckRDS)
+
+	typeIntoChecklistAdd(&m, "prod-db")
+	m.inspector.updateChecklistAdd(&m, tea.KeyMsg{Type: tea.KeyEnter}) // resource
+	// Skip every expectation: AppendCheck must reject a check with none.
+	for range checklistPromptFields[inspector.ChecklistCheckRDS] {
+		m.inspector.updateChecklistAdd(&m, tea.KeyMsg{Type: tea.KeyEnter})
+	}
+	if m.screen != screenInspectorChecklistAdd || m.inspector.addError == "" {
+		t.Fatalf("expected validation error to keep the wizard open, screen=%v err=%q", m.screen, m.inspector.addError)
+	}
+	if _, err := inspector.LoadChecklist(m.inspector.checklistPath); err == nil {
+		t.Fatal("expected nothing to be written on validation failure")
+	}
+
+	view, ok := m.inspector.View(m)
+	if !ok || !strings.Contains(view, m.inspector.addError) {
+		t.Fatalf("expected the error to render in the wizard, got:\n%s", view)
+	}
+}
+
+func TestChecklistAddBadNumberReturnsFieldError(t *testing.T) {
+	values := map[string]string{"resource": "/aws/ecs/app", "retention_days": "thirty"}
+	if _, err := buildChecklistCheck(inspector.ChecklistCheckCloudWatchLogGroup, values); err == nil ||
+		!strings.Contains(err.Error(), "retention_days") {
+		t.Fatalf("expected numeric validation error, got %v", err)
+	}
+}
+
+func TestChecklistAddDefaultsTargetPathWithoutLoadedChecklist(t *testing.T) {
+	m := inspectorAddTestModel(t)
+	m.inspector.checklistPath = ""
+
+	target := m.inspector.checklistAddTargetPath()
+	if !strings.HasSuffix(target, "unic-checklist.yaml") {
+		t.Fatalf("expected default checklist target, got %q", target)
+	}
+}

--- a/internal/app/screen_inspector_add_test.go
+++ b/internal/app/screen_inspector_add_test.go
@@ -134,3 +134,77 @@ func TestChecklistAddDefaultsTargetPathWithoutLoadedChecklist(t *testing.T) {
 		t.Fatalf("expected default checklist target, got %q", target)
 	}
 }
+
+func TestChecklistAddReachableFromPickerWithoutLoadedChecklist(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.cfg = &config.Config{Region: "us-east-1", ContextName: "dev"}
+	m.inspector.checklistPath = ""
+	m.inspector.checklistDir = t.TempDir()
+	m.screen = screenInspectorChecklistPicker
+
+	// `a` on the picker opens the wizard even with nothing loaded.
+	newM, _, handled := m.inspector.HandleKey(&m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	model := newM.(Model)
+	if !handled || model.screen != screenInspectorChecklistAdd {
+		t.Fatalf("expected wizard from the picker, got %v", model.screen)
+	}
+
+	// Complete the wizard end to end: a baseline check needs only a resource.
+	m = model
+	selectChecklistType(t, &m, inspector.ChecklistCheckCloudTrailBaseline)
+	typeIntoChecklistAdd(&m, "cloudtrail")
+	newM2, cmd := m.inspector.updateChecklistAdd(&m, tea.KeyMsg{Type: tea.KeyEnter})
+	model = newM2.(Model)
+	if cmd == nil || model.screen != screenInspectorScanning {
+		t.Fatalf("expected rerun after first-check save, got %v", model.screen)
+	}
+
+	target := filepath.Join(m.inspector.checklistDir, "unic-checklist.yaml")
+	loaded, err := inspector.LoadChecklist(target)
+	if err != nil || len(loaded.Checks) != 1 {
+		t.Fatalf("expected the default checklist to be created at %s, got %+v err=%v", target, loaded, err)
+	}
+
+	// esc from the wizard's type step returns to where it was opened.
+	m = model
+	m.inspector.openChecklistAdd(&m)
+	m.screen = screenInspectorChecklistAdd
+	m.inspector.addPrevScreen = screenInspectorChecklistPicker
+	m.inspector.updateChecklistAdd(&m, tea.KeyMsg{Type: tea.KeyEsc})
+	if m.screen != screenInspectorChecklistPicker {
+		t.Fatalf("expected esc to return to the picker, got %v", m.screen)
+	}
+}
+
+func TestChecklistAddSecurityGroupExtendedFields(t *testing.T) {
+	values := map[string]string{
+		"resource":         "sg-web",
+		"rule_mode":        "ingress_present",
+		"cidr_v6":          "::/0",
+		"referenced_sg_id": "sg-db",
+	}
+	check, err := buildChecklistCheck(inspector.ChecklistCheckSecurityGroup, values)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rule := check.Expect.IngressPresent[0]
+	if rule.CIDRv6 != "::/0" || rule.ReferencedSGID != "sg-db" {
+		t.Fatalf("expected IPv6 and referenced-SG fields mapped, got %+v", rule)
+	}
+}
+
+func TestChecklistAddSchemaCoverageExtras(t *testing.T) {
+	check, err := buildChecklistCheck(inspector.ChecklistCheckRDS, map[string]string{
+		"resource": "prod-db", "engine_version": "16.3",
+	})
+	if err != nil || check.Expect.EngineVersion == nil || *check.Expect.EngineVersion != "16.3" {
+		t.Fatalf("expected engine_version mapped, got %+v err=%v", check.Expect, err)
+	}
+
+	check, err = buildChecklistCheck(inspector.ChecklistCheckRoute53Record, map[string]string{
+		"resource": "api.example.com", "zone": "example.com", "alias_hosted_zone_id": "Z123",
+	})
+	if err != nil || check.Expect.AliasHostedZoneID == nil || *check.Expect.AliasHostedZoneID != "Z123" {
+		t.Fatalf("expected alias_hosted_zone_id mapped, got %+v err=%v", check.Expect, err)
+	}
+}

--- a/internal/inspector/checklist.go
+++ b/internal/inspector/checklist.go
@@ -1186,8 +1186,31 @@ func AppendCheck(path string, check ChecklistCheck) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return fmt.Errorf("failed to create checklist directory: %w", err)
 	}
-	if err := os.WriteFile(path, out, 0644); err != nil {
-		return fmt.Errorf("failed to write checklist %s: %w", path, err)
+	// Replace atomically via temp file + rename so an I/O failure mid-write
+	// can never truncate an existing hand-maintained checklist.
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".checklist-*.yaml.tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create temp checklist file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
+	if _, err := tmp.Write(out); err != nil {
+		tmp.Close()
+		cleanup()
+		return fmt.Errorf("failed to write temp checklist file: %w", err)
+	}
+	if err := tmp.Chmod(0644); err != nil {
+		tmp.Close()
+		cleanup()
+		return fmt.Errorf("failed to chmod temp checklist file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("failed to close temp checklist file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return fmt.Errorf("failed to replace checklist %s: %w", path, err)
 	}
 	return nil
 }

--- a/internal/inspector/checklist.go
+++ b/internal/inspector/checklist.go
@@ -1152,3 +1152,42 @@ func normalizedDNSNameKey(value string) string {
 func normalizedChecklistKey(value string) string {
 	return strings.ToLower(strings.TrimSpace(value))
 }
+
+// AppendCheck adds a check to the checklist file at path, creating the file
+// when it does not exist. The combined checklist is validated through the
+// same rules as LoadChecklist before anything is written, so a bad prompt
+// result can never corrupt an existing file.
+func AppendCheck(path string, check ChecklistCheck) error {
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("checklist path is required")
+	}
+
+	checklist := &Checklist{}
+	if data, err := os.ReadFile(path); err == nil {
+		decoder := yaml.NewDecoder(bytes.NewReader(data))
+		decoder.KnownFields(true)
+		if err := decoder.Decode(checklist); err != nil {
+			return fmt.Errorf("failed to parse checklist %s: %w", path, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read checklist %s: %w", path, err)
+	}
+
+	checklist.Checks = append(checklist.Checks, check)
+	checklist.SourcePath = path
+	if err := checklist.validate(); err != nil {
+		return err
+	}
+
+	out, err := yaml.Marshal(checklist)
+	if err != nil {
+		return fmt.Errorf("failed to marshal checklist: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("failed to create checklist directory: %w", err)
+	}
+	if err := os.WriteFile(path, out, 0644); err != nil {
+		return fmt.Errorf("failed to write checklist %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/inspector/checklist_test.go
+++ b/internal/inspector/checklist_test.go
@@ -599,3 +599,53 @@ func TestAppendCheckRejectsInvalidWithoutWriting(t *testing.T) {
 
 func boolPtr(v bool) *bool { return &v }
 func intPtr(v int) *int    { return &v }
+
+func TestAppendCheckWriteFailureLeavesOriginalIntact(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "readiness.yaml")
+	valid := ChecklistCheck{
+		Type:     ChecklistCheckRDS,
+		Resource: "prod-db",
+		Expect:   ChecklistExpectations{StorageEncrypted: boolPtr(true)},
+	}
+	if err := AppendCheck(path, valid); err != nil {
+		t.Fatal(err)
+	}
+	original, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Make the directory unwritable so the temp-file stage fails before the
+	// original can be touched.
+	if err := os.Chmod(dir, 0500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0755) })
+
+	second := ChecklistCheck{
+		Type:     ChecklistCheckCloudWatchLogGroup,
+		Resource: "/aws/ecs/app",
+		Expect:   ChecklistExpectations{RetentionDays: intPtr(30)},
+	}
+	if err := AppendCheck(path, second); err == nil {
+		t.Fatal("expected write failure in a read-only directory")
+	}
+
+	if err := os.Chmod(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil || string(after) != string(original) {
+		t.Fatalf("expected original checklist byte-identical after failed append, err=%v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.Contains(entry.Name(), ".tmp") {
+			t.Fatalf("expected no temp files to linger, found %q", entry.Name())
+		}
+	}
+}

--- a/internal/inspector/checklist_test.go
+++ b/internal/inspector/checklist_test.go
@@ -544,3 +544,58 @@ func TestRunChecklistLogGroupAndBaselineChecks(t *testing.T) {
 		t.Fatalf("expected baseline finding details, got %+v", report.Results[3].Details)
 	}
 }
+
+func TestAppendCheckCreatesValidatesAndRoundTrips(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "custom.yaml")
+
+	check := ChecklistCheck{
+		Type:     ChecklistCheckRDS,
+		Resource: "prod-db",
+		Expect:   ChecklistExpectations{StorageEncrypted: boolPtr(true)},
+	}
+	if err := AppendCheck(path, check); err != nil {
+		t.Fatalf("unexpected error creating checklist: %v", err)
+	}
+
+	second := ChecklistCheck{
+		Type:     ChecklistCheckCloudWatchLogGroup,
+		Resource: "/aws/ecs/app",
+		Expect:   ChecklistExpectations{RetentionDays: intPtr(30)},
+	}
+	if err := AppendCheck(path, second); err != nil {
+		t.Fatalf("unexpected error appending: %v", err)
+	}
+
+	loaded, err := LoadChecklist(path)
+	if err != nil {
+		t.Fatalf("expected generated file to load through validation: %v", err)
+	}
+	if len(loaded.Checks) != 2 || loaded.Checks[1].Resource != "/aws/ecs/app" {
+		t.Fatalf("expected both checks persisted, got %+v", loaded.Checks)
+	}
+}
+
+func TestAppendCheckRejectsInvalidWithoutWriting(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "custom.yaml")
+	valid := ChecklistCheck{
+		Type:     ChecklistCheckRDS,
+		Resource: "prod-db",
+		Expect:   ChecklistExpectations{StorageEncrypted: boolPtr(true)},
+	}
+	if err := AppendCheck(path, valid); err != nil {
+		t.Fatal(err)
+	}
+
+	invalid := ChecklistCheck{Type: ChecklistCheckRDS, Resource: "no-expectations"}
+	if err := AppendCheck(path, invalid); err == nil {
+		t.Fatal("expected validation rejection for a check without expectations")
+	}
+
+	loaded, err := LoadChecklist(path)
+	if err != nil || len(loaded.Checks) != 1 {
+		t.Fatalf("expected file untouched after rejection, got %+v err=%v", loaded, err)
+	}
+}
+
+func boolPtr(v bool) *bool { return &v }
+func intPtr(v int) *int    { return &v }


### PR DESCRIPTION
## Summary

Implements #154: checklist content can now be added from in-TUI prompts instead of hand-editing YAML.

- **Entry points**: `a` on the checklist results and result detail screens opens the add-check wizard.
- **Type-driven prompts**: step one picks one of the twelve supported rule types; step two walks type-specific fields mapping 1:1 to the YAML schema (RDS status/engine/class/Multi-AZ/encryption/public-access/backups, secret rotation/KMS/value keys, Route53 record zone/type/TTL/values/alias, VPC/subnet expectations, log-group retention, and the four baseline wrappers needing only a resource label). Security groups prompt for a rule mode (`ingress_present`/`ingress_absent`/`egress_present`/`egress_absent`) plus protocol/ports/CIDR, building one required-or-forbidden rule. Empty input skips optional expectations; bools and numbers are parsed with per-field error messages.
- **Safe persistence**: `inspector.AppendCheck` appends to the loaded checklist file — or creates `unic-checklist.yaml` in the picker directory when none is loaded — and validates the **combined** checklist through the same rules as `LoadChecklist` before writing, so a bad prompt result can never corrupt an existing file. Validation failures keep the wizard open at the first expectation field with the error rendered.
- **Immediate feedback**: a successful save sets the file as the loaded checklist and reruns it, so the new check's pass/fail shows right away. The file picker and `--checklist` flows are untouched; prompt-based creation is purely additive.
- Wizard input counts as a text-entry surface so global single-key shortcuts stay out of typed values.

## Testing

- `go test ./...` passes: AppendCheck round-trip through LoadChecklist and reject-without-write, full wizard flow (persist + rerun transition), security-group rule mapping incl. invalid mode, numeric field validation, validation-failure wizard state with rendered error, and the default target path.
- `make build` passes.

## Docs

- README: Checklist Inspector key bindings and the checklist section document the prompt flow and default file behavior.

Closes #154