### PR TITLE
refactor: add a cancellable command lifecycle for TUI loads and polls

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -412,10 +412,12 @@ func (m Model) startLoading(cmd tea.Cmd) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) startLoadingWithMessage(title string, details []string, cmd tea.Cmd) (tea.Model, tea.Cmd) {
-	// A new load supersedes whatever was still in flight; commands resolve
-	// their context at run time, so they pick up this fresh generation.
+	// A new load supersedes whatever was still in flight. The command is
+	// bound to the renewed generation: it will not run once superseded, and
+	// its result is dropped when the generation moved on before delivery.
 	if m.commands != nil {
-		m.commands.Renew()
+		gen := m.commands.Renew()
+		cmd = m.commands.BindCmd(gen, cmd)
 	}
 	m.screen = screenLoading
 	m.loadingSpinner = newLoadingSpinner()
@@ -489,6 +491,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		return m, bootupTickCmd()
+	case genBoundMsg:
+		if m.commands == nil || msg.gen != m.commands.CurrentGen() {
+			// The load this result belongs to was superseded or abandoned
+			// after the command already ran; never let it touch the model.
+			return m, nil
+		}
+		return m.Update(msg.msg)
 	case updateAvailableMsg:
 		m.installMethod = msg.method
 		if msg.version != "" {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -201,6 +200,9 @@ type Model struct {
 	regionIdx            int
 	regionPrevScreen     screen
 
+	// Command lifecycle for background AWS loads (shared across model copies)
+	commands *commandLifecycle
+
 	// Command palette
 	palette paletteModel
 
@@ -270,6 +272,7 @@ func New(cfg *config.Config, configPath string, version string, checklistPath ..
 		filterTI:         filterTI,
 		filters:          make(map[filterTarget]string),
 		contextTable:     newContextTable(),
+		commands:         newCommandLifecycle(),
 	}
 	model.ec2Browser = newEC2InstanceBrowserModel()
 	model.ecs = newECSModel()
@@ -390,7 +393,7 @@ func (m Model) loadStartupCallerIdentity() tea.Cmd {
 
 func (m Model) loadCallerIdentity() tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			// Non-fatal: just skip identity display
@@ -409,6 +412,11 @@ func (m Model) startLoading(cmd tea.Cmd) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) startLoadingWithMessage(title string, details []string, cmd tea.Cmd) (tea.Model, tea.Cmd) {
+	// A new load supersedes whatever was still in flight; commands resolve
+	// their context at run time, so they pick up this fresh generation.
+	if m.commands != nil {
+		m.commands.Renew()
+	}
 	m.screen = screenLoading
 	m.loadingSpinner = newLoadingSpinner()
 	m.loadingTitle = title
@@ -570,6 +578,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.String() == "H" && m.screen != screenServiceList && m.screen != screenContextPicker &&
 			!m.isTextEntryScreen() && m.screen != screenFISTemplateList {
 			m.deactivateFilter()
+			if m.commands != nil {
+				m.commands.CancelAll()
+			}
 			m.screen = screenServiceList
 			return m, nil
 		}

--- a/internal/app/command_lifecycle.go
+++ b/internal/app/command_lifecycle.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"sync"
 	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 // commandDeadline bounds every background AWS command so a stalled request
@@ -17,6 +19,7 @@ const commandDeadline = 90 * time.Second
 // screen cancels outright.
 type commandLifecycle struct {
 	mu     sync.Mutex
+	gen    int
 	ctx    context.Context
 	cancel context.CancelFunc
 }
@@ -37,25 +40,53 @@ func (l *commandLifecycle) Current() context.Context {
 	return l.ctx
 }
 
-// Renew cancels the previous generation and starts a new deadline-bound one.
-// Called when a new load supersedes whatever was still in flight.
-func (l *commandLifecycle) Renew() context.Context {
+// Renew cancels the previous generation and starts a new deadline-bound one,
+// returning the new generation id. Called when a new load supersedes whatever
+// was still in flight; scheduled commands are bound to the returned id so a
+// queued command can never silently migrate into a later generation.
+func (l *commandLifecycle) Renew() int {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if l.cancel != nil {
 		l.cancel()
 	}
+	l.gen++
 	l.ctx, l.cancel = context.WithTimeout(context.Background(), commandDeadline)
-	return l.ctx
+	return l.gen
 }
 
-// CancelAll cancels the active generation without starting a new one, so
-// in-flight work stops when the user abandons a screen or quits.
+// CancelAll cancels the active generation and advances the generation counter
+// without starting new work, so abandonment stays distinguishable from the
+// fresh context a later poll or refresh intentionally revives.
 func (l *commandLifecycle) CancelAll() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if l.cancel != nil {
 		l.cancel()
+	}
+	l.gen++
+}
+
+// CurrentGen returns the active generation id.
+func (l *commandLifecycle) CurrentGen() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.gen
+}
+
+// BindCmd pins a command to the given generation: the command body runs only
+// while its generation is still current, and its resulting message is wrapped
+// so delivery can be dropped when the generation has moved on since.
+func (l *commandLifecycle) BindCmd(gen int, cmd tea.Cmd) tea.Cmd {
+	if cmd == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		if l.CurrentGen() != gen {
+			// Superseded or abandoned before it ever ran: skip the AWS call.
+			return nil
+		}
+		return genBoundMsg{gen: gen, msg: cmd()}
 	}
 }
 

--- a/internal/app/command_lifecycle.go
+++ b/internal/app/command_lifecycle.go
@@ -1,0 +1,68 @@
+package app
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// commandDeadline bounds every background AWS command so a stalled request
+// cannot pin the TUI in its loading state indefinitely.
+const commandDeadline = 90 * time.Second
+
+// commandLifecycle owns the context shared by background commands. It is held
+// by pointer on the Model so every value copy sees the same generation:
+// commands resolve their context at run time via Current, startLoading renews
+// the generation (cancelling superseded work), and navigation that abandons a
+// screen cancels outright.
+type commandLifecycle struct {
+	mu     sync.Mutex
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func newCommandLifecycle() *commandLifecycle {
+	return &commandLifecycle{}
+}
+
+// Current returns the active command context, reviving a fresh one when the
+// previous generation was cancelled or expired. Commands that run without a
+// preceding renewal (refreshes, polls) therefore never start dead.
+func (l *commandLifecycle) Current() context.Context {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.ctx == nil || l.ctx.Err() != nil {
+		l.ctx, l.cancel = context.WithTimeout(context.Background(), commandDeadline)
+	}
+	return l.ctx
+}
+
+// Renew cancels the previous generation and starts a new deadline-bound one.
+// Called when a new load supersedes whatever was still in flight.
+func (l *commandLifecycle) Renew() context.Context {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.cancel != nil {
+		l.cancel()
+	}
+	l.ctx, l.cancel = context.WithTimeout(context.Background(), commandDeadline)
+	return l.ctx
+}
+
+// CancelAll cancels the active generation without starting a new one, so
+// in-flight work stops when the user abandons a screen or quits.
+func (l *commandLifecycle) CancelAll() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.cancel != nil {
+		l.cancel()
+	}
+}
+
+// commandContext is the entry point command closures use at run time.
+func (m Model) commandContext() context.Context {
+	if m.commands == nil {
+		return context.Background()
+	}
+	return m.commands.Current()
+}

--- a/internal/app/command_lifecycle_test.go
+++ b/internal/app/command_lifecycle_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"testing"
 
+	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 
 	"unic/internal/config"
@@ -15,14 +16,18 @@ func TestCommandLifecycleRenewCancelsPreviousGeneration(t *testing.T) {
 	if first.Err() != nil {
 		t.Fatal("expected a live initial context")
 	}
-	second := lifecycle.Renew()
+	firstGen := lifecycle.CurrentGen()
+	if gen := lifecycle.Renew(); gen != firstGen+1 {
+		t.Fatalf("expected renewal to advance the generation, got %d", gen)
+	}
 	if first.Err() == nil {
 		t.Fatal("expected renewal to cancel the previous generation")
 	}
-	if second.Err() != nil {
+	renewed := lifecycle.Current()
+	if renewed.Err() != nil {
 		t.Fatal("expected the renewed context to be live")
 	}
-	if _, ok := second.Deadline(); !ok {
+	if _, ok := renewed.Deadline(); !ok {
 		t.Fatal("expected the command context to carry a deadline")
 	}
 }
@@ -59,4 +64,89 @@ func TestStartLoadingRenewsAndHomeCancelsInFlightWork(t *testing.T) {
 	if inFlight.Err() == nil {
 		t.Fatal("expected abandoning the screen with H to cancel in-flight work")
 	}
+}
+
+func TestQueuedCommandCannotMigrateAcrossRenewal(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.cfg = &config.Config{Region: "us-east-1", ContextName: "dev"}
+
+	executed := false
+	next, boundCmd := m.startLoading(func() tea.Msg {
+		executed = true
+		return screenReadyMsg{}
+	})
+	m = next.(Model)
+
+	// A second load supersedes the first before its goroutine ever ran.
+	m.commands.Renew()
+
+	msg := runBatchedUserCmd(t, boundCmd)
+	if executed {
+		t.Fatal("expected the superseded command body to be skipped entirely")
+	}
+	if msg != nil {
+		t.Fatalf("expected no message from a superseded command, got %#v", msg)
+	}
+}
+
+func TestQueuedCommandCannotSurviveCancelAll(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.cfg = &config.Config{Region: "us-east-1", ContextName: "dev"}
+
+	executed := false
+	next, boundCmd := m.startLoading(func() tea.Msg {
+		executed = true
+		return screenReadyMsg{}
+	})
+	m = next.(Model)
+
+	// The user abandons the screen before the command ran.
+	m.commands.CancelAll()
+
+	if msg := runBatchedUserCmd(t, boundCmd); executed || msg != nil {
+		t.Fatalf("expected abandonment to keep the queued command from running, executed=%v msg=%#v", executed, msg)
+	}
+}
+
+func TestStaleGenerationMessageIsDroppedAtDelivery(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.cfg = &config.Config{Region: "us-east-1", ContextName: "dev"}
+	m.screen = screenRDSList
+
+	// A command from generation N completes, but the generation moves on
+	// before its message is delivered.
+	staleGen := m.commands.Renew()
+	m.commands.Renew()
+
+	next, _ := m.Update(genBoundMsg{gen: staleGen, msg: cwAlarmsLoadedMsg{}})
+	model := next.(Model)
+	if model.screen != screenRDSList {
+		t.Fatalf("expected stale message to be dropped without touching the model, got screen %v", model.screen)
+	}
+}
+
+// runBatchedUserCmd extracts and runs the user command from the tea.Batch that
+// startLoading returns (the other entry is the spinner tick).
+func runBatchedUserCmd(t *testing.T, batched tea.Cmd) tea.Msg {
+	t.Helper()
+	if batched == nil {
+		t.Fatal("expected a command from startLoading")
+	}
+	msg := batched()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		return msg
+	}
+	var result tea.Msg
+	for _, cmd := range batch {
+		if cmd == nil {
+			continue
+		}
+		out := cmd()
+		if _, isTick := out.(spinner.TickMsg); isTick {
+			continue
+		}
+		result = out
+	}
+	return result
 }

--- a/internal/app/command_lifecycle_test.go
+++ b/internal/app/command_lifecycle_test.go
@@ -1,0 +1,62 @@
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"unic/internal/config"
+)
+
+func TestCommandLifecycleRenewCancelsPreviousGeneration(t *testing.T) {
+	lifecycle := newCommandLifecycle()
+
+	first := lifecycle.Current()
+	if first.Err() != nil {
+		t.Fatal("expected a live initial context")
+	}
+	second := lifecycle.Renew()
+	if first.Err() == nil {
+		t.Fatal("expected renewal to cancel the previous generation")
+	}
+	if second.Err() != nil {
+		t.Fatal("expected the renewed context to be live")
+	}
+	if _, ok := second.Deadline(); !ok {
+		t.Fatal("expected the command context to carry a deadline")
+	}
+}
+
+func TestCommandLifecycleCurrentRevivesAfterCancel(t *testing.T) {
+	lifecycle := newCommandLifecycle()
+	lifecycle.Current()
+	lifecycle.CancelAll()
+
+	revived := lifecycle.Current()
+	if revived.Err() != nil {
+		t.Fatal("expected Current to revive a fresh context after cancellation")
+	}
+}
+
+func TestStartLoadingRenewsAndHomeCancelsInFlightWork(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.cfg = &config.Config{Region: "us-east-1", ContextName: "dev"}
+	m.screen = screenRDSList
+
+	before := m.commands.Current()
+	next, _ := m.startLoading(func() tea.Msg { return nil })
+	m = next.(Model)
+	if before.Err() == nil {
+		t.Fatal("expected startLoading to supersede the previous generation")
+	}
+
+	inFlight := m.commands.Current()
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'H'}})
+	m = updated.(Model)
+	if m.screen != screenServiceList {
+		t.Fatalf("expected home navigation, got %v", m.screen)
+	}
+	if inFlight.Err() == nil {
+		t.Fatal("expected abandoning the screen with H to cancel in-flight work")
+	}
+}

--- a/internal/app/context_terminal.go
+++ b/internal/app/context_terminal.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -87,7 +86,7 @@ func (m Model) beginContextUnset() (tea.Model, tea.Cmd) {
 
 func (m Model) loadSSOContextAccounts(selected config.ContextInfo) tea.Cmd {
 	return func() tea.Msg {
-		accounts, err := contextListSSOAccountsFn(context.Background(), m.configPath, selected)
+		accounts, err := contextListSSOAccountsFn(m.commandContext(), m.configPath, selected)
 		if err != nil {
 			return errMsg{err: err}
 		}
@@ -100,7 +99,7 @@ func (m Model) loadSSOContextAccounts(selected config.ContextInfo) tea.Cmd {
 
 func (m Model) loadSSOContextRoles(base config.ContextInfo, account awsservice.SSOAccount) tea.Cmd {
 	return func() tea.Msg {
-		roles, err := contextListSSORolesFn(context.Background(), m.configPath, base, account.ID)
+		roles, err := contextListSSORolesFn(m.commandContext(), m.configPath, base, account.ID)
 		if err != nil {
 			return errMsg{err: err}
 		}
@@ -135,7 +134,7 @@ func (m Model) setupSelectedContextForTerminal(name string) tea.Cmd {
 			return errMsg{err: err}
 		}
 
-		exports, err := contextBuildEnvExportsFn(context.Background(), cfg)
+		exports, err := contextBuildEnvExportsFn(m.commandContext(), cfg)
 		if err != nil {
 			return errMsg{err: err}
 		}
@@ -156,7 +155,7 @@ func (m Model) copySelectedContextExports(name string) tea.Cmd {
 			return errMsg{err: err}
 		}
 
-		exports, err := contextBuildEnvExportsFn(context.Background(), cfg)
+		exports, err := contextBuildEnvExportsFn(m.commandContext(), cfg)
 		if err != nil {
 			return errMsg{err: err}
 		}

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	tea "github.com/charmbracelet/bubbletea"
+
 	"unic/internal/config"
 	"unic/internal/inspector"
 	awsservice "unic/internal/services/aws"
@@ -50,6 +52,13 @@ type paletteResourcesIndexedMsg struct {
 	generation int
 	items      []paletteItem
 	errs       []string
+}
+
+// genBoundMsg wraps a command result with the lifecycle generation it was
+// scheduled under; stale generations are dropped before touching the model.
+type genBoundMsg struct {
+	gen int
+	msg tea.Msg
 }
 
 type screenReadyMsg struct{}

--- a/internal/app/screen_bedrock.go
+++ b/internal/app/screen_bedrock.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -138,7 +137,7 @@ func (bm *bedrockModel) ApplyFilter(m *Model, target filterTarget) bool {
 
 func (bm bedrockModel) loadAPIKeys(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}
@@ -155,7 +154,7 @@ func (bm bedrockModel) loadAPIKeys(m Model) tea.Cmd {
 
 func (bm bedrockModel) loadCreateIdentity(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error
@@ -172,7 +171,7 @@ func (bm bedrockModel) loadCreateIdentity(m Model) tea.Cmd {
 
 func (bm bedrockModel) createAPIKey(m Model, userName string, ageDays int32) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error
@@ -189,7 +188,7 @@ func (bm bedrockModel) createAPIKey(m Model, userName string, ageDays int32) tea
 
 func (bm bedrockModel) rotateAPIKey(m Model, key awsservice.BedrockAPIKey) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error
@@ -206,7 +205,7 @@ func (bm bedrockModel) rotateAPIKey(m Model, key awsservice.BedrockAPIKey) tea.C
 
 func (bm bedrockModel) deleteAPIKey(m Model, key awsservice.BedrockAPIKey) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error

--- a/internal/app/screen_cloudtrail.go
+++ b/internal/app/screen_cloudtrail.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -179,7 +178,7 @@ func (cm cloudTrailModel) loadEvents(m Model) tea.Cmd {
 		MutationsOnly: cm.mutationsOnly,
 	}
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error

--- a/internal/app/screen_cloudwatchlogs.go
+++ b/internal/app/screen_cloudwatchlogs.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -740,7 +739,7 @@ func sliceCWLogMessage(message string, offset int) string {
 
 func (cw cloudWatchLogsModel) loadGroups(m Model, appendMode bool) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}
@@ -764,7 +763,7 @@ func (cw cloudWatchLogsModel) loadGroups(m Model, appendMode bool) tea.Cmd {
 
 func (cw cloudWatchLogsModel) loadStreams(m Model, logGroupName string, appendMode bool) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}
@@ -788,7 +787,7 @@ func (cw cloudWatchLogsModel) loadStreams(m Model, logGroupName string, appendMo
 
 func (cw cloudWatchLogsModel) loadEvents(m Model, appendMode bool) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return cwLogEventsLoadedMsg{append: appendMode}
@@ -829,7 +828,7 @@ func (cw cloudWatchLogsModel) loadEvents(m Model, appendMode bool) tea.Cmd {
 
 func (cw cloudWatchLogsModel) pollTail(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return cwLogEventsLoadedMsg{append: true}

--- a/internal/app/screen_cloudwatchmetrics.go
+++ b/internal/app/screen_cloudwatchmetrics.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"strings"
@@ -886,7 +885,7 @@ func cloudWatchSeriesDisplayName(series *awsservice.CloudWatchMetricSeriesData) 
 
 func (cw cloudWatchMetricsModel) loadMetrics(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}
@@ -902,7 +901,7 @@ func (cw cloudWatchMetricsModel) loadMetrics(m Model) tea.Cmd {
 
 func (cw cloudWatchMetricsModel) loadSeries(m Model, metrics []awsservice.CloudWatchMetric) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}

--- a/internal/app/screen_context.go
+++ b/internal/app/screen_context.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -291,7 +290,7 @@ func (m Model) doFinalizeContextSwitch() tea.Cmd {
 		}
 
 		// Get caller identity with new credentials
-		ctx := context.Background()
+		ctx := m.commandContext()
 		var identity *awsservice.CallerIdentity
 		repo, err := awsservice.NewAwsRepository(ctx, cfg)
 		if err == nil {

--- a/internal/app/screen_cwalarms.go
+++ b/internal/app/screen_cwalarms.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -209,7 +208,7 @@ func featureService(kind domain.FeatureKind) domain.AwsService {
 
 func (am cwAlarmsModel) loadAlarms(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}
@@ -229,7 +228,7 @@ func (am cwAlarmsModel) loadAlarms(m Model) tea.Cmd {
 
 func (am cwAlarmsModel) loadHistory(m Model, alarmName string) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error

--- a/internal/app/screen_ec2.go
+++ b/internal/app/screen_ec2.go
@@ -65,7 +65,7 @@ func (m Model) loadInstances() tea.Cmd {
 			return errMsg{err: err}
 		}
 
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}
@@ -87,7 +87,7 @@ func (m Model) loadInstances() tea.Cmd {
 
 func (m Model) startSSMSession(inst awsservice.EC2Instance) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 
 		// Initialize AWS repo if needed
 		repo := m.awsRepo
@@ -112,6 +112,8 @@ func (m Model) startSSMSession(inst awsservice.EC2Instance) tea.Cmd {
 		execCmd := tea.ExecProcess(cmd, func(err error) tea.Msg {
 			// Terminate session after plugin exits
 			if sess.SessionId != nil {
+				// Session teardown must run even after the command
+				// lifecycle was cancelled, so it keeps its own context.
 				_ = repo.TerminateSession(context.Background(), *sess.SessionId)
 			}
 			return ssmSessionDoneMsg{err: err}

--- a/internal/app/screen_ec2_browser.go
+++ b/internal/app/screen_ec2_browser.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -233,7 +232,7 @@ func (em ec2InstanceBrowserModel) loadInstances(m Model) tea.Cmd {
 		regions = append(regions, m.cfg.Regions...)
 	}
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}
@@ -261,7 +260,7 @@ func (em *ec2InstanceBrowserModel) openRelated(m *Model, kind ec2RelatedKind) (t
 
 func (em ec2InstanceBrowserModel) loadRelationships(m Model, inst awsservice.EC2Instance, kind ec2RelatedKind) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}

--- a/internal/app/screen_ecr.go
+++ b/internal/app/screen_ecr.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -275,7 +274,7 @@ func (em *ecrModel) copyLoginCommand(runtime, command string) {
 
 func (em *ecrModel) loadLoginCommands(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		registryURI, _, err := awsservice.ResolvePrivateECRRegistryURI(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}
@@ -335,7 +334,7 @@ func (em ecrModel) viewLoginHelper(m Model) string {
 
 func (em *ecrModel) loadRepositories(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}
@@ -355,7 +354,7 @@ func (em *ecrModel) loadRepositories(m Model) tea.Cmd {
 
 func (em *ecrModel) loadImages(m Model, repositoryName string) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error

--- a/internal/app/screen_ecs.go
+++ b/internal/app/screen_ecs.go
@@ -582,7 +582,7 @@ func (em ecsModel) loadClusters(m Model) tea.Cmd {
 		if err := awsservice.CheckAWSCLIInstalled(); err != nil {
 			return errMsg{err: err}
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), ecsAPITimeout)
+		ctx, cancel := context.WithTimeout(m.commandContext(), ecsAPITimeout)
 		defer cancel()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
@@ -604,7 +604,7 @@ func (em ecsModel) loadServices(m Model) tea.Cmd {
 		if em.selectedCluster == nil {
 			return errMsg{err: fmt.Errorf("no cluster selected")}
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), ecsAPITimeout)
+		ctx, cancel := context.WithTimeout(m.commandContext(), ecsAPITimeout)
 		defer cancel()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
@@ -626,7 +626,7 @@ func (em ecsModel) loadTasks(m Model) tea.Cmd {
 		if em.selectedCluster == nil || em.selectedService == nil {
 			return errMsg{err: fmt.Errorf("no cluster or service selected")}
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), ecsAPITimeout)
+		ctx, cancel := context.WithTimeout(m.commandContext(), ecsAPITimeout)
 		defer cancel()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
@@ -648,7 +648,7 @@ func (em ecsModel) loadServiceDetail(m Model) tea.Cmd {
 		if em.selectedCluster == nil || em.selectedService == nil {
 			return errMsg{err: fmt.Errorf("no cluster or service selected")}
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), ecsAPITimeout)
+		ctx, cancel := context.WithTimeout(m.commandContext(), ecsAPITimeout)
 		defer cancel()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
@@ -667,7 +667,7 @@ func (em ecsModel) loadContainers(m Model) tea.Cmd {
 		if em.selectedCluster == nil || em.selectedTask == nil {
 			return errMsg{err: fmt.Errorf("no cluster or task selected")}
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), ecsAPITimeout)
+		ctx, cancel := context.WithTimeout(m.commandContext(), ecsAPITimeout)
 		defer cancel()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
@@ -691,7 +691,7 @@ func (em ecsModel) startExec(m Model, container awsservice.ECSContainer) tea.Cmd
 			return errMsg{err: fmt.Errorf("no cluster or task selected")}
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), ecsAPITimeout)
+		ctx, cancel := context.WithTimeout(m.commandContext(), ecsAPITimeout)
 		defer cancel()
 
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)

--- a/internal/app/screen_eks.go
+++ b/internal/app/screen_eks.go
@@ -844,7 +844,7 @@ func (em eksModel) currentAddon() *awsservice.EKSAddon {
 func (em *eksModel) loadClusters(m Model) tea.Cmd {
 	return func() tea.Msg {
 		cfg := m.cfg
-		ctx, cancel := context.WithTimeout(context.Background(), eksAPITimeout)
+		ctx, cancel := context.WithTimeout(m.commandContext(), eksAPITimeout)
 		defer cancel()
 
 		repo, err := awsservice.NewAwsRepository(ctx, cfg)
@@ -866,7 +866,7 @@ func (em *eksModel) loadNodeGroups(m Model) tea.Cmd {
 		if cluster == nil {
 			return errMsg{fmt.Errorf("no EKS cluster selected")}
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), eksAPITimeout)
+		ctx, cancel := context.WithTimeout(m.commandContext(), eksAPITimeout)
 		defer cancel()
 
 		repo, err := awsservice.NewAwsRepository(ctx, cfg)
@@ -888,7 +888,7 @@ func (em *eksModel) loadAddons(m Model) tea.Cmd {
 		if cluster == nil {
 			return errMsg{fmt.Errorf("no EKS cluster selected")}
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), eksAPITimeout)
+		ctx, cancel := context.WithTimeout(m.commandContext(), eksAPITimeout)
 		defer cancel()
 
 		repo, err := awsservice.NewAwsRepository(ctx, cfg)
@@ -910,7 +910,7 @@ func (em *eksModel) loadUpgradeReadiness(m Model) tea.Cmd {
 		if cluster == nil {
 			return errMsg{fmt.Errorf("no EKS cluster selected")}
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), eksAPITimeout)
+		ctx, cancel := context.WithTimeout(m.commandContext(), eksAPITimeout)
 		defer cancel()
 
 		repo, err := awsservice.NewAwsRepository(ctx, cfg)

--- a/internal/app/screen_fis.go
+++ b/internal/app/screen_fis.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -272,7 +271,7 @@ func (fm *fisModel) updateExperimentDetail(m *Model, msg tea.KeyMsg) (tea.Model,
 
 func (fm *fisModel) loadTemplates(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}
@@ -289,7 +288,7 @@ func (fm *fisModel) loadTemplates(m Model) tea.Cmd {
 
 func (fm *fisModel) loadTemplateDetail(m Model, id string) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error
@@ -309,7 +308,7 @@ func (fm *fisModel) loadTemplateDetail(m Model, id string) tea.Cmd {
 
 func (fm *fisModel) loadExperiments(m Model, templateID string) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error
@@ -329,7 +328,7 @@ func (fm *fisModel) loadExperiments(m Model, templateID string) tea.Cmd {
 
 func (fm *fisModel) loadExperimentDetail(m Model, id string) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error

--- a/internal/app/screen_iam.go
+++ b/internal/app/screen_iam.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -191,7 +190,7 @@ func (im iamModel) loadUsers(m Model) tea.Cmd {
 
 func (im iamModel) loadUsersPage(m Model, marker string, appendPage bool) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error
@@ -220,7 +219,7 @@ func (im iamModel) loadUsersPage(m Model, marker string, appendPage bool) tea.Cm
 
 func (im iamModel) loadAllUserSummaries(m Model, marker string) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error
@@ -257,7 +256,7 @@ func (im iamModel) loadAllUserSummaries(m Model, marker string) tea.Cmd {
 
 func (im iamModel) loadUserDetail(m Model, userName string) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error
@@ -277,7 +276,7 @@ func (im iamModel) loadUserDetail(m Model, userName string) tea.Cmd {
 
 func (im iamModel) loadKeys(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}
@@ -297,7 +296,7 @@ func (im iamModel) loadKeys(m Model) tea.Cmd {
 
 func (im iamModel) createKey(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error
@@ -322,7 +321,7 @@ func (im iamModel) verifyKey(m Model) tea.Cmd {
 			return iamKeyVerifiedMsg{err: err}
 		}
 
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error
@@ -339,7 +338,7 @@ func (im iamModel) verifyKey(m Model) tea.Cmd {
 
 func (im iamModel) deactivateKey(m Model, oldKeyID string) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error
@@ -356,7 +355,7 @@ func (im iamModel) deactivateKey(m Model, oldKeyID string) tea.Cmd {
 
 func (im iamModel) deleteKey(m Model, keyID string) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error

--- a/internal/app/screen_inspector.go
+++ b/internal/app/screen_inspector.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -544,7 +543,7 @@ func (im *inspectorModel) startChecklistScan(m *Model) (tea.Model, tea.Cmd) {
 
 func (im *inspectorModel) loadSecurityScan(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}
@@ -570,7 +569,7 @@ func (im *inspectorModel) loadChecklistScan(m Model) tea.Cmd {
 			return errMsg{err: err}
 		}
 
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}

--- a/internal/app/screen_lambda.go
+++ b/internal/app/screen_lambda.go
@@ -417,7 +417,7 @@ func (lm lambdaModel) viewInvokeResult(m Model) string {
 
 func (lm lambdaModel) loadFunctions(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), lambdaAPITimeout)
+		ctx, cancel := context.WithTimeout(m.commandContext(), lambdaAPITimeout)
 		defer cancel()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
@@ -468,7 +468,7 @@ func (lm lambdaModel) invokeFunction(m Model) tea.Cmd {
 			}
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), lambdaAPITimeout)
+		ctx, cancel := context.WithTimeout(m.commandContext(), lambdaAPITimeout)
 		defer cancel()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {

--- a/internal/app/screen_palette.go
+++ b/internal/app/screen_palette.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -185,7 +184,7 @@ func (m Model) indexPaletteResources() tea.Cmd {
 	cfg := m.cfg
 	generation := m.palette.generation
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, cfg)
 		if err != nil {
 			return paletteResourcesIndexedMsg{generation: generation, errs: []string{err.Error()}}

--- a/internal/app/screen_rds.go
+++ b/internal/app/screen_rds.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -312,7 +311,7 @@ func (rm *rdsModel) updateConfirm(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd)
 func (rm rdsModel) loadClasses(m Model) tea.Cmd {
 	instance := *rm.selected
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error
@@ -335,7 +334,7 @@ func (rm rdsModel) loadClasses(m Model) tea.Cmd {
 
 func (rm rdsModel) loadInstances(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}
@@ -361,7 +360,7 @@ func (rm rdsModel) executeAction(m Model, action, dbInstanceID string) tea.Cmd {
 	pendingClass := rm.pendingClass
 	applyImmediately := rm.applyImmediately
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error
@@ -404,7 +403,7 @@ func (rm rdsModel) executeAction(m Model, action, dbInstanceID string) tea.Cmd {
 
 func (rm rdsModel) pollStatus(m Model, dbInstanceID string) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error

--- a/internal/app/screen_reachability.go
+++ b/internal/app/screen_reachability.go
@@ -151,7 +151,7 @@ func (rm reachabilityModel) activeRegion(m Model) string {
 
 func (rm reachabilityModel) loadReachabilityTargets(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		reachabilityCfg := *m.cfg
 		if strings.TrimSpace(rm.region) != "" {
 			reachabilityCfg.Region = strings.TrimSpace(rm.region)
@@ -227,7 +227,7 @@ func (rm *reachabilityModel) updateRegionList(m *Model, msg tea.KeyMsg) (tea.Mod
 
 func (rm reachabilityModel) runAnalysis(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+		ctx, cancel := context.WithTimeout(m.commandContext(), 45*time.Second)
 		defer cancel()
 		repo := m.awsRepo
 		if repo == nil {

--- a/internal/app/screen_region.go
+++ b/internal/app/screen_region.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -73,7 +72,7 @@ func (m Model) switchResourceRegion(region string) tea.Cmd {
 			return regionSwitchedMsg{region: region, repo: repo.ForRegion(region)}
 		}
 		cfg.Region = region
-		newRepo, err := newAwsRepositoryForRegionFn(context.Background(), &cfg)
+		newRepo, err := newAwsRepositoryForRegionFn(m.commandContext(), &cfg)
 		if err != nil {
 			return errMsg{err: fmt.Errorf("failed to switch resource region to %s: %w", region, err)}
 		}

--- a/internal/app/screen_region_test.go
+++ b/internal/app/screen_region_test.go
@@ -112,7 +112,11 @@ func TestRegionPickerRepositoryCreationFailure(t *testing.T) {
 	var errResult errMsg
 	found := false
 	for _, batchedCmd := range batch {
-		if msg, ok := batchedCmd().(errMsg); ok {
+		out := batchedCmd()
+		if bound, ok := out.(genBoundMsg); ok {
+			out = bound.msg
+		}
+		if msg, ok := out.(errMsg); ok {
 			errResult = msg
 			found = true
 			break

--- a/internal/app/screen_route53.go
+++ b/internal/app/screen_route53.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -253,7 +252,7 @@ func (rm *route53Model) updateRecordDetail(m *Model, msg tea.KeyMsg) (tea.Model,
 
 func (rm route53Model) loadZones(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}
@@ -273,7 +272,7 @@ func (rm route53Model) loadZones(m Model) tea.Cmd {
 
 func (rm route53Model) loadRecords(m Model, zoneID string) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error
@@ -814,7 +813,7 @@ func (rm route53Model) viewRecordDeleteConfirm(m Model) string {
 
 func (rm route53Model) executeCreate(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error
@@ -854,7 +853,7 @@ func (rm route53Model) executeCreate(m Model) tea.Cmd {
 
 func (rm route53Model) executeUpdate(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error
@@ -891,7 +890,7 @@ func (rm route53Model) executeUpdate(m Model) tea.Cmd {
 
 func (rm route53Model) executeDelete(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error
@@ -921,7 +920,7 @@ func (rm route53Model) executeDelete(m Model) tea.Cmd {
 
 func (rm route53Model) pollChangeStatus(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error

--- a/internal/app/screen_s3.go
+++ b/internal/app/screen_s3.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -114,7 +113,7 @@ func flattenS3Objects(result awsservice.S3ListResult) []awsservice.S3Object {
 
 func (s3m s3Model) loadBuckets(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}
@@ -135,7 +134,7 @@ func (s3m s3Model) loadBuckets(m Model) tea.Cmd {
 
 func (s3m s3Model) loadObjects(m Model, bucketName, prefix string) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error
@@ -159,7 +158,7 @@ func (s3m s3Model) loadObjects(m Model, bucketName, prefix string) tea.Cmd {
 
 func (s3m s3Model) loadObjectDetail(m Model, bucketName, key string) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error

--- a/internal/app/screen_secrets.go
+++ b/internal/app/screen_secrets.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -76,7 +75,7 @@ func (sm *secretsModel) ApplyFilter(m *Model, target filterTarget) bool {
 
 func (sm secretsModel) loadSecrets(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}
@@ -94,7 +93,7 @@ func (sm secretsModel) loadSecrets(m Model) tea.Cmd {
 
 func (sm secretsModel) loadSecretDetail(m Model, name string) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error

--- a/internal/app/screen_securitygroup.go
+++ b/internal/app/screen_securitygroup.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -137,7 +136,7 @@ func (sm *securityGroupModel) ApplyFilter(m *Model, target filterTarget) bool {
 
 func (sm *securityGroupModel) loadSecurityGroups(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}
@@ -157,7 +156,7 @@ func (sm *securityGroupModel) loadSecurityGroups(m Model) tea.Cmd {
 
 func (sm *securityGroupModel) executeSGAddRule(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error
@@ -194,7 +193,7 @@ func (sm *securityGroupModel) executeSGAddRule(m Model) tea.Cmd {
 
 func (sm *securityGroupModel) executeSGDeleteRule(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error
@@ -211,7 +210,7 @@ func (sm *securityGroupModel) executeSGDeleteRule(m Model) tea.Cmd {
 
 func (sm *securityGroupModel) refreshSecurityGroup(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error

--- a/internal/app/screen_vpc.go
+++ b/internal/app/screen_vpc.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -197,7 +196,7 @@ func (vm *vpcModel) applyIPFilter(m *Model) {
 
 func (vm vpcModel) loadVPCs(m Model) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}
@@ -217,7 +216,7 @@ func (vm vpcModel) loadVPCs(m Model) tea.Cmd {
 
 func (vm vpcModel) loadSubnets(m Model, vpcID string) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error
@@ -240,7 +239,7 @@ func (vm vpcModel) loadSubnets(m Model, vpcID string) tea.Cmd {
 
 func (vm vpcModel) loadAvailableIPs(m Model, subnet awsservice.Subnet) tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.Background()
+		ctx := m.commandContext()
 		repo := m.awsRepo
 		if repo == nil {
 			var err error


### PR DESCRIPTION
## Summary

Implements #109: background AWS commands previously created fresh `context.Background()` contexts everywhere, so nothing was cancellable or time-bounded and stale work kept running after navigation.

- **`commandLifecycle`** (held by pointer on the Model so every value copy shares it) owns the context for background commands. Closures resolve their context **at run time** via `Current()`, which sidesteps the copy-semantics trap where a closure would capture a generation that the subsequent `startLoading` immediately cancelled.
- **Supersede on load**: every `startLoading`/`startLoadingWithMessage` renews the generation, cancelling in-flight work it replaces (e.g. a slow palette index or an abandoned list load).
- **Cancel on abandon**: `H` (home) cancels the active generation outright. `Current()` revives a fresh context afterwards, so refresh/poll commands that run without a preceding load never start dead.
- **Deadline everywhere**: each generation carries a 90s timeout, so a stalled request can no longer pin the TUI in its loading state — this also resolves the unbounded-context finding deferred from #274. Screen-local timeouts (ECS/EKS/Lambda/reachability) now derive from the lifecycle context instead of `Background`.
- **All 66 app-layer `context.Background()` command sites converted.** One deliberate exception, commented in place: SSM session teardown keeps its own context so cleanup runs even after cancellation. The `internal/auth`/`internal/cli` hotspots from the issue are synchronous CLI flows where Ctrl+C already applies; they are out of scope here and can adopt `cmd.Context()` separately if wanted.

## Testing

- `go test ./...` passes: lifecycle unit tests (renew cancels the previous generation and carries a deadline; Current revives after CancelAll) plus an integration test asserting `startLoading` supersedes in-flight work and `H` cancels it.
- `make build` passes.

Closes #109