### PR TITLE
refactor: introduce declarative per-screen keymaps for help rendering

### DIFF
--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -134,6 +134,11 @@ func (m Model) helpModeShortcuts() []helpShortcut {
 }
 
 func (m Model) currentScreenShortcuts() []helpShortcut {
+	// Screens migrated to declarative keymaps render from one definition;
+	// the switch below is the legacy catalog for the rest.
+	if shortcuts, ok := m.keymapShortcuts(); ok {
+		return shortcuts
+	}
 	switch m.screen {
 	case screenServiceList:
 		return []helpShortcut{
@@ -276,44 +281,6 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 			{"enter", "Confirm when the typed identifier matches"},
 			{"esc", "Cancel and return to the detail screen"},
 		}
-	case screenRoute53ZoneList:
-		return listScreenShortcuts("open the selected hosted zone", "go back to the feature list", true, false)
-	case screenRoute53RecordList:
-		shortcuts := listScreenShortcuts("open the selected record", "go back to the hosted zone list", true, false)
-		return append(shortcuts[:3], append([]helpShortcut{{"c", "Create a new DNS record"}}, shortcuts[3:]...)...)
-	case screenRoute53RecordDetail:
-		shortcuts := []helpShortcut{
-			{"c", "Create a new DNS record"},
-			{"q / esc", "Go back to the record list"},
-		}
-		if m.route53.selectedRecord != nil {
-			canEdit := m.route53.selectedRecord.AliasTarget == "" &&
-				(m.route53.selectedRecord.Type == "A" || m.route53.selectedRecord.Type == "CNAME")
-			canDelete := m.route53.selectedRecord.Type != "NS" && m.route53.selectedRecord.Type != "SOA"
-			if canEdit {
-				shortcuts = append([]helpShortcut{{"e", "Edit the selected DNS record"}}, shortcuts...)
-			}
-			if canDelete {
-				shortcuts = append(shortcuts[:len(shortcuts)-1], append([]helpShortcut{{"d", "Delete the selected DNS record"}}, shortcuts[len(shortcuts)-1:]...)...)
-			}
-		}
-		return shortcuts
-	case screenRoute53RecordCreate:
-		return route53FormShortcuts(m.route53.editField == 1)
-	case screenRoute53RecordEdit:
-		return []helpShortcut{
-			{"type", "Edit the current record field"},
-			{"backspace", "Delete the previous character"},
-			{"enter", "Advance to the next field or save the update"},
-			{"esc", "Cancel and return to the record detail"},
-		}
-	case screenRoute53RecordDeleteConfirm:
-		return []helpShortcut{
-			{"type", "Enter the record name to confirm deletion"},
-			{"backspace", "Delete the previous character"},
-			{"enter", "Delete the record when the typed name matches"},
-			{"esc", "Cancel and return to the record detail"},
-		}
 	case screenSecretList:
 		return listScreenShortcuts("open the selected secret", "go back to the feature list", true, false)
 	case screenSecretDetail:
@@ -350,42 +317,6 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 			{"backspace", "Delete the previous character"},
 			{"enter", "Delete the rule when the typed ID matches"},
 			{"esc", "Cancel and return to the security group detail"},
-		}
-	case screenIAMUserList:
-		shortcuts := listScreenShortcuts("open the selected IAM user", "go back to the feature list", true, false)
-		return append(shortcuts[:3], append([]helpShortcut{{"n", "Load the next page of IAM users"}}, shortcuts[3:]...)...)
-	case screenIAMUserDetail:
-		return []helpShortcut{
-			{"q / esc", "Go back to the IAM user list"},
-		}
-	case screenIAMKeyList:
-		return []helpShortcut{
-			{"↑/↓, j/k", "Move between access keys"},
-			{"enter", "Open the selected access key detail"},
-			{"q / esc", "Go back to the feature list"},
-		}
-	case screenIAMKeyDetail:
-		shortcuts := []helpShortcut{
-			{"q / esc", "Go back to the access key list"},
-		}
-		if m.iam.rotationEnabled && m.iam.selectedKey != nil && m.iam.selectedKey.Status == "Active" {
-			shortcuts = append([]helpShortcut{{"r", "Start rotating the selected access key"}}, shortcuts...)
-		}
-		return shortcuts
-	case screenIAMKeyRotateConfirm:
-		return []helpShortcut{
-			{"type", "Enter the access key ID to confirm rotation"},
-			{"backspace", "Delete the previous character"},
-			{"enter", "Create the new key when the typed ID matches"},
-			{"esc", "Cancel and return to the access key detail"},
-		}
-	case screenIAMKeyRotateResult:
-		return []helpShortcut{
-			{"c", "Copy export commands for the new credentials"},
-			{"a", "Apply and verify the new credentials when supported"},
-			{"d", "Deactivate the old access key when allowed"},
-			{"x", "Delete the old access key after deactivation"},
-			{"q / esc", "Return to the access key list"},
 		}
 	case screenCWMetricList:
 		shortcuts := listScreenShortcuts("open the selected metric series", "go back to the feature list", true, true)
@@ -438,10 +369,6 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 			{"r", "Reload the transition history"},
 			{"q / esc", "Go back to the alarm list"},
 		}
-	case screenCWLogGroupList:
-		return listScreenShortcuts("open log streams for the selected group", "go back to the feature list", true, false)
-	case screenCWLogStreamList:
-		return listScreenShortcuts("open the log viewer for the selected stream", "go back to the log group list", true, false)
 	case screenCWLogViewer:
 		shortcuts := []helpShortcut{
 			{"↑/↓, j/k", "Scroll the log viewer"},
@@ -868,20 +795,6 @@ func reachabilityTargetShortcuts(label string, includeQuitBack bool) []helpShort
 		shortcuts = append(shortcuts, helpShortcut{"q / esc", "Go back to the previous step"})
 	}
 	return shortcuts
-}
-
-func route53FormShortcuts(typeSelection bool) []helpShortcut {
-	shortcuts := []helpShortcut{
-		{"enter", "Advance to the next field or save the record"},
-		{"esc", "Cancel and return to the record list"},
-	}
-	if typeSelection {
-		return append([]helpShortcut{{"↑/↓, j/k", "Move between record types"}}, shortcuts...)
-	}
-	return append([]helpShortcut{
-		{"type", "Edit the current field"},
-		{"backspace", "Delete the previous character"},
-	}, shortcuts...)
 }
 
 func capitalizeFirst(value string) string {

--- a/internal/app/keymap.go
+++ b/internal/app/keymap.go
@@ -1,0 +1,177 @@
+package app
+
+import "strings"
+
+// keyBinding declares one shortcut in a single place: the overlay key label,
+// the compact bottom-bar form, the overlay description, and an optional
+// visibility condition. Both the `?` overlay and the bottom help bar render
+// from the same binding, so the two surfaces can no longer drift apart.
+//
+// A binding with an empty help is bar-only (globals like `H: home` that the
+// overlay lists in its Global section); an empty bar is overlay-only.
+type keyBinding struct {
+	keys string
+	bar  string
+	help string
+	when func(Model) bool
+}
+
+// screenKeymaps holds the screens migrated to declarative keymaps. Screens not
+// listed here still use the legacy switch in currentScreenShortcuts and their
+// hand-written help-bar strings; they migrate incrementally. The CloudWatch
+// log viewer intentionally stays legacy: its bar labels embed live state
+// (wrap on/off, horizontal offset) that a static declaration cannot express.
+var screenKeymaps = map[screen][]keyBinding{
+	screenRoute53ZoneList: {
+		{keys: "↑/↓, j/k", bar: "↑/↓: navigate", help: "Move between rows"},
+		{keys: "/", bar: "/: filter", help: "Start filtering the list"},
+		{keys: "enter", bar: "enter: records", help: "Open the selected hosted zone"},
+		{keys: "q / esc", bar: "esc: back", help: "Go back to the feature list"},
+		{bar: "H: home"},
+	},
+	screenRoute53RecordList: {
+		{keys: "↑/↓, j/k", bar: "↑/↓: navigate", help: "Move between rows"},
+		{keys: "/", bar: "/: filter", help: "Start filtering the list"},
+		{keys: "c", bar: "c: create", help: "Create a new DNS record"},
+		{keys: "enter", bar: "enter: detail", help: "Open the selected record"},
+		{keys: "q / esc", bar: "esc: back", help: "Go back to the hosted zone list"},
+		{bar: "H: home"},
+	},
+	screenRoute53RecordDetail: {
+		{keys: "c", bar: "c: create", help: "Create a new DNS record",
+			when: func(m Model) bool { return m.route53.selectedRecord != nil }},
+		{keys: "e", bar: "e: edit", help: "Edit the selected DNS record",
+			when: func(m Model) bool { return m.route53.canEditSelectedRecord() }},
+		{keys: "d", bar: "d: delete", help: "Delete the selected DNS record",
+			when: func(m Model) bool { return m.route53.canDeleteSelectedRecord() }},
+		{keys: "q / esc", bar: "esc: back", help: "Go back to the record list"},
+		{bar: "H: home"},
+	},
+	screenRoute53RecordCreate: {
+		{keys: "↑/↓, j/k", help: "Move between record types",
+			when: func(m Model) bool { return m.route53.editField == 1 }},
+		{keys: "type", help: "Edit the current field",
+			when: func(m Model) bool { return m.route53.editField != 1 }},
+		{keys: "backspace", help: "Delete the previous character",
+			when: func(m Model) bool { return m.route53.editField != 1 }},
+		{keys: "enter", bar: "enter: next", help: "Advance to the next field or save the record"},
+		{keys: "esc", bar: "esc: cancel", help: "Cancel and return to the record list"},
+	},
+	screenRoute53RecordEdit: {
+		{keys: "type", help: "Edit the current record field"},
+		{keys: "backspace", help: "Delete the previous character"},
+		{keys: "enter", bar: "enter: next", help: "Advance to the next field or save the update"},
+		{keys: "esc", bar: "esc: cancel", help: "Cancel and return to the record detail"},
+	},
+	screenRoute53RecordDeleteConfirm: {
+		{keys: "type", help: "Enter the record name to confirm deletion"},
+		{keys: "backspace", help: "Delete the previous character"},
+		{keys: "enter", bar: "enter: confirm", help: "Delete the record when the typed name matches"},
+		{keys: "esc", bar: "esc: cancel", help: "Cancel and return to the record detail"},
+	},
+
+	screenIAMUserList: {
+		{keys: "↑/↓, j/k", bar: "↑/↓: navigate", help: "Move between rows"},
+		{keys: "/", bar: "/: filter", help: "Start filtering the list"},
+		{keys: "n", bar: "n: next page", help: "Load the next page of IAM users"},
+		{keys: "enter", bar: "enter: detail", help: "Open the selected IAM user"},
+		{keys: "q / esc", bar: "esc: back", help: "Go back to the feature list"},
+		{bar: "H: home"},
+	},
+	screenIAMUserDetail: {
+		{keys: "q / esc", bar: "esc: back", help: "Go back to the IAM user list"},
+		{bar: "H: home"},
+	},
+	screenIAMKeyList: {
+		{keys: "↑/↓, j/k", bar: "↑/↓: navigate", help: "Move between access keys"},
+		{keys: "enter", bar: "enter: detail", help: "Open the selected access key detail"},
+		{keys: "q / esc", bar: "esc: back", help: "Go back to the feature list"},
+		{bar: "H: home"},
+	},
+	screenIAMKeyDetail: {
+		{keys: "r", bar: "r: rotate", help: "Start rotating the selected access key",
+			when: func(m Model) bool {
+				return m.iam.rotationEnabled && m.iam.selectedKey != nil && m.iam.selectedKey.Status == "Active"
+			}},
+		{keys: "q / esc", bar: "esc: back", help: "Go back to the access key list"},
+		{bar: "H: home"},
+	},
+	screenIAMKeyRotateConfirm: {
+		{keys: "type", help: "Enter the access key ID to confirm rotation"},
+		{keys: "backspace", help: "Delete the previous character"},
+		{keys: "enter", bar: "enter: confirm", help: "Create the new key when the typed ID matches"},
+		{keys: "esc", bar: "esc: cancel", help: "Cancel and return to the access key detail"},
+	},
+	screenIAMKeyRotateResult: {
+		{keys: "c", bar: "c: copy exports", help: "Copy export commands for the new credentials"},
+		{keys: "a", bar: "a: apply+verify", help: "Apply and verify the new credentials when supported"},
+		{keys: "d", bar: "d: deactivate old", help: "Deactivate the old access key when allowed"},
+		{keys: "x", bar: "x: delete old", help: "Delete the old access key after deactivation"},
+		{keys: "q / esc", bar: "esc: back to key list", help: "Return to the access key list"},
+	},
+
+	screenCWLogGroupList: {
+		{keys: "↑/↓, j/k", bar: "↑/↓: navigate", help: "Move between rows"},
+		{keys: "/", bar: "/: filter", help: "Start filtering the list"},
+		{keys: "n", bar: "n: load more", help: "Load more log groups"},
+		{keys: "enter", bar: "enter: streams", help: "Open log streams for the selected group"},
+		{keys: "q / esc", bar: "esc: back", help: "Go back to the feature list"},
+		{bar: "H: home"},
+	},
+	screenCWLogStreamList: {
+		{keys: "↑/↓, j/k", bar: "↑/↓: navigate", help: "Move between rows"},
+		{keys: "/", bar: "/: filter", help: "Start filtering the list"},
+		{keys: "n", bar: "n: load more", help: "Load more log streams"},
+		{keys: "enter", bar: "enter: view logs", help: "Open the log viewer for the selected stream"},
+		{keys: "q / esc", bar: "esc: back", help: "Go back to the log group list"},
+		{bar: "H: home"},
+	},
+}
+
+// visibleBindings returns the declared bindings whose conditions hold.
+func (m Model) visibleBindings(s screen) ([]keyBinding, bool) {
+	bindings, ok := screenKeymaps[s]
+	if !ok {
+		return nil, false
+	}
+	visible := make([]keyBinding, 0, len(bindings))
+	for _, binding := range bindings {
+		if binding.when != nil && !binding.when(m) {
+			continue
+		}
+		visible = append(visible, binding)
+	}
+	return visible, true
+}
+
+// keymapHelpBar renders the bottom help bar for the current screen from its
+// declared keymap.
+func (m Model) keymapHelpBar() string {
+	bindings, ok := m.visibleBindings(m.screen)
+	if !ok {
+		return ""
+	}
+	parts := make([]string, 0, len(bindings))
+	for _, binding := range bindings {
+		if binding.bar != "" {
+			parts = append(parts, binding.bar)
+		}
+	}
+	return strings.Join(parts, " • ")
+}
+
+// keymapShortcuts renders the `?` overlay entries for the current screen from
+// its declared keymap.
+func (m Model) keymapShortcuts() ([]helpShortcut, bool) {
+	bindings, ok := m.visibleBindings(m.screen)
+	if !ok {
+		return nil, false
+	}
+	shortcuts := make([]helpShortcut, 0, len(bindings))
+	for _, binding := range bindings {
+		if binding.help != "" {
+			shortcuts = append(shortcuts, helpShortcut{binding.keys, binding.help})
+		}
+	}
+	return shortcuts, true
+}

--- a/internal/app/keymap_test.go
+++ b/internal/app/keymap_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"unic/internal/config"
 	awsservice "unic/internal/services/aws"
 )
@@ -93,5 +95,62 @@ func TestLegacyScreensStillUseTheSwitch(t *testing.T) {
 	}
 	if len(m.currentScreenShortcuts()) == 0 {
 		t.Fatal("expected legacy shortcuts to keep working")
+	}
+}
+
+func TestKeymapEligibilityBoundariesMatchBehavior(t *testing.T) {
+	cases := []struct {
+		name      string
+		record    awsservice.DNSRecord
+		canEdit   bool
+		canDelete bool
+	}{
+		{"plain A", awsservice.DNSRecord{Type: "A"}, true, true},
+		{"alias A", awsservice.DNSRecord{Type: "A", AliasTarget: "elb.amazonaws.com"}, false, true},
+		{"plain CNAME", awsservice.DNSRecord{Type: "CNAME"}, true, true},
+		{"SOA", awsservice.DNSRecord{Type: "SOA"}, false, false},
+		{"NS", awsservice.DNSRecord{Type: "NS"}, false, false},
+	}
+	for _, tc := range cases {
+		m := keymapTestModel()
+		m.screen = screenRoute53RecordDetail
+		record := tc.record
+		m.route53.selectedRecord = &record
+
+		bar := m.keymapHelpBar()
+		if strings.Contains(bar, "e: edit") != tc.canEdit {
+			t.Fatalf("%s: help edit visibility mismatch, bar=%q", tc.name, bar)
+		}
+		if strings.Contains(bar, "d: delete") != tc.canDelete {
+			t.Fatalf("%s: help delete visibility mismatch, bar=%q", tc.name, bar)
+		}
+
+		// Behavior follows the same predicates: keys act exactly when shown.
+		next, _ := m.route53.updateRecordDetail(&m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+		if entered := next.(Model).screen == screenRoute53RecordEdit; entered != tc.canEdit {
+			t.Fatalf("%s: edit key behavior mismatch, entered=%v", tc.name, entered)
+		}
+		m.screen = screenRoute53RecordDetail
+		next, _ = m.route53.updateRecordDetail(&m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+		if entered := next.(Model).screen == screenRoute53RecordDeleteConfirm; entered != tc.canDelete {
+			t.Fatalf("%s: delete key behavior mismatch, entered=%v", tc.name, entered)
+		}
+	}
+}
+
+func TestKeymapIAMRotationHiddenWhenIneligible(t *testing.T) {
+	m := keymapTestModel()
+	m.screen = screenIAMKeyDetail
+
+	m.iam.rotationEnabled = false
+	m.iam.selectedKey = &awsservice.AccessKey{Status: "Active"}
+	if strings.Contains(m.keymapHelpBar(), "r: rotate") {
+		t.Fatal("expected rotation hidden when the workflow is disabled")
+	}
+
+	m.iam.rotationEnabled = true
+	m.iam.selectedKey = &awsservice.AccessKey{Status: "Inactive"}
+	if strings.Contains(m.keymapHelpBar(), "r: rotate") {
+		t.Fatal("expected rotation hidden for inactive keys")
 	}
 }

--- a/internal/app/keymap_test.go
+++ b/internal/app/keymap_test.go
@@ -1,0 +1,97 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"unic/internal/config"
+	awsservice "unic/internal/services/aws"
+)
+
+func keymapTestModel() Model {
+	m := New(testConfig(), "", "dev")
+	m.cfg = &config.Config{Region: "us-east-1", ContextName: "dev"}
+	return m
+}
+
+func TestKeymapRendersBarAndOverlayFromOneDefinition(t *testing.T) {
+	m := keymapTestModel()
+	m.screen = screenRoute53ZoneList
+
+	bar := m.keymapHelpBar()
+	for _, want := range []string{"↑/↓: navigate", "/: filter", "enter: records", "esc: back", "H: home"} {
+		if !strings.Contains(bar, want) {
+			t.Fatalf("expected bar to contain %q, got %q", want, bar)
+		}
+	}
+
+	shortcuts, ok := m.keymapShortcuts()
+	if !ok || len(shortcuts) != 4 {
+		t.Fatalf("expected 4 overlay entries (H stays in the Global section), got %d", len(shortcuts))
+	}
+	if shortcuts[2].keys != "enter" || shortcuts[2].description != "Open the selected hosted zone" {
+		t.Fatalf("expected overlay entry from the same definition, got %+v", shortcuts[2])
+	}
+}
+
+func TestKeymapConditionalBindingsFollowModelState(t *testing.T) {
+	m := keymapTestModel()
+	m.screen = screenRoute53RecordDetail
+
+	// NS records: no edit, no delete.
+	m.route53.selectedRecord = &awsservice.DNSRecord{Type: "NS"}
+	bar := m.keymapHelpBar()
+	if strings.Contains(bar, "e: edit") || strings.Contains(bar, "d: delete") {
+		t.Fatalf("expected protected record to hide edit/delete, got %q", bar)
+	}
+
+	// Plain A records: both appear, in bar and overlay alike.
+	m.route53.selectedRecord = &awsservice.DNSRecord{Type: "A"}
+	bar = m.keymapHelpBar()
+	if !strings.Contains(bar, "e: edit") || !strings.Contains(bar, "d: delete") {
+		t.Fatalf("expected editable record to offer edit/delete, got %q", bar)
+	}
+	shortcuts, _ := m.keymapShortcuts()
+	joined := ""
+	for _, shortcut := range shortcuts {
+		joined += shortcut.keys + ";"
+	}
+	if !strings.Contains(joined, "e;") || !strings.Contains(joined, "d;") {
+		t.Fatalf("expected overlay to match the bar's conditional bindings, got %q", joined)
+	}
+}
+
+func TestKeymapOverlayEntriesDriveCurrentScreenShortcuts(t *testing.T) {
+	m := keymapTestModel()
+	m.screen = screenIAMKeyDetail
+	m.iam.rotationEnabled = true
+	m.iam.selectedKey = &awsservice.AccessKey{Status: "Active"}
+
+	shortcuts := m.currentScreenShortcuts()
+	found := false
+	for _, shortcut := range shortcuts {
+		if shortcut.keys == "r" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected the rotation binding to reach the overlay through the keymap")
+	}
+	// The bar previously omitted r: rotate while the overlay showed it — with
+	// one definition both surfaces agree.
+	if !strings.Contains(m.keymapHelpBar(), "r: rotate") {
+		t.Fatal("expected the bar to agree with the overlay on the rotation binding")
+	}
+}
+
+func TestLegacyScreensStillUseTheSwitch(t *testing.T) {
+	m := keymapTestModel()
+	m.screen = screenCWLogViewer
+
+	if _, ok := m.keymapShortcuts(); ok {
+		t.Fatal("expected the log viewer to stay on the legacy catalog (stateful bar labels)")
+	}
+	if len(m.currentScreenShortcuts()) == 0 {
+		t.Fatal("expected legacy shortcuts to keep working")
+	}
+}

--- a/internal/app/screen_cloudwatchlogs.go
+++ b/internal/app/screen_cloudwatchlogs.go
@@ -345,7 +345,7 @@ func (cw cloudWatchLogsModel) viewGroupList(m Model) string {
 
 	b.WriteString(m.renderListPanel(panel.String()))
 	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • n: load more • enter: streams • esc: back • H: home"))
+	b.WriteString(m.renderHelpBar(m.keymapHelpBar()))
 	return b.String()
 }
 
@@ -464,7 +464,7 @@ func (cw cloudWatchLogsModel) viewStreamList(m Model) string {
 
 	b.WriteString(m.renderListPanel(panel.String()))
 	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • n: load more • enter: view logs • esc: back • H: home"))
+	b.WriteString(m.renderHelpBar(m.keymapHelpBar()))
 	return b.String()
 }
 

--- a/internal/app/screen_iam.go
+++ b/internal/app/screen_iam.go
@@ -665,7 +665,7 @@ func (im iamModel) viewUserList(m Model) string {
 
 	b.WriteString(m.renderListPanel(panel.String()))
 	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • n: next page • enter: detail • esc: back • H: home"))
+	b.WriteString(m.renderHelpBar(m.keymapHelpBar()))
 	return b.String()
 }
 
@@ -719,7 +719,7 @@ func (im iamModel) viewUserDetail(m Model) string {
 	b.WriteString(renderIAMAccessKeyList(u.AccessKeys))
 	b.WriteString("\n\n")
 
-	b.WriteString(m.renderHelpBar("esc: back • H: home"))
+	b.WriteString(m.renderHelpBar(m.keymapHelpBar()))
 	return b.String()
 }
 
@@ -780,7 +780,7 @@ func (im iamModel) viewKeyList(m Model) string {
 
 	b.WriteString(m.renderListPanel(panel.String()))
 	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("↑/↓: navigate • enter: detail • esc: back • H: home"))
+	b.WriteString(m.renderHelpBar(m.keymapHelpBar()))
 	return b.String()
 }
 
@@ -843,7 +843,7 @@ func (im iamModel) viewKeyDetail(m Model) string {
 	}
 
 	b.WriteString("\n")
-	b.WriteString(m.renderHelpBar("esc: back • H: home"))
+	b.WriteString(m.renderHelpBar(m.keymapHelpBar()))
 	return b.String()
 }
 
@@ -874,7 +874,7 @@ func (im iamModel) viewKeyRotateConfirm(m Model) string {
 	b.WriteString("\n")
 	b.WriteString(filterStyle.Render(fmt.Sprintf("  %s▏", im.rotateConfirm)))
 	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("enter: confirm • esc: cancel"))
+	b.WriteString(m.renderHelpBar(m.keymapHelpBar()))
 	return b.String()
 }
 
@@ -943,7 +943,7 @@ func (im iamModel) viewKeyRotateResult(m Model) string {
 		b.WriteString(dimStyle.Render("  [x] Delete old key (available after deactivation)"))
 	}
 	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("esc: back to key list"))
+	b.WriteString(m.renderHelpBar(m.keymapHelpBar()))
 	return b.String()
 }
 

--- a/internal/app/screen_route53.go
+++ b/internal/app/screen_route53.go
@@ -219,9 +219,7 @@ func (rm *route53Model) updateRecordDetail(m *Model, msg tea.KeyMsg) (tea.Model,
 	case "q", "esc":
 		m.screen = screenRoute53RecordList
 	case "e":
-		// Edit only for A/CNAME non-alias records
-		if rm.selectedRecord != nil && rm.selectedRecord.AliasTarget == "" &&
-			(rm.selectedRecord.Type == "A" || rm.selectedRecord.Type == "CNAME") {
+		if rm.canEditSelectedRecord() {
 			rm.action = "edit"
 			rm.editField = 0
 			rm.editValues = map[string]string{
@@ -232,9 +230,7 @@ func (rm *route53Model) updateRecordDetail(m *Model, msg tea.KeyMsg) (tea.Model,
 			m.screen = screenRoute53RecordEdit
 		}
 	case "d":
-		// Delete allowed for non-NS/SOA records
-		if rm.selectedRecord != nil &&
-			rm.selectedRecord.Type != "NS" && rm.selectedRecord.Type != "SOA" {
+		if rm.canDeleteSelectedRecord() {
 			rm.action = "delete"
 			rm.confirmInput = ""
 			m.screen = screenRoute53RecordDeleteConfirm

--- a/internal/app/screen_route53.go
+++ b/internal/app/screen_route53.go
@@ -359,7 +359,7 @@ func (rm route53Model) viewZoneList(m Model) string {
 
 	b.WriteString(m.renderListPanel(panel.String()))
 	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • enter: records • esc: back • H: home"))
+	b.WriteString(m.renderHelpBar(m.keymapHelpBar()))
 	return b.String()
 }
 
@@ -448,7 +448,7 @@ func (rm route53Model) viewRecordList(m Model) string {
 
 	b.WriteString(m.renderListPanel(panel.String()))
 	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • c: create • enter: detail • esc: back • H: home"))
+	b.WriteString(m.renderHelpBar(m.keymapHelpBar()))
 	return b.String()
 }
 
@@ -485,20 +485,7 @@ func (rm route53Model) viewRecordDetail(m Model) string {
 	}
 
 	b.WriteString("\n")
-	hints := "esc: back • H: home"
-	if rm.selectedRecord != nil {
-		canEdit := rm.selectedRecord.AliasTarget == "" &&
-			(rm.selectedRecord.Type == "A" || rm.selectedRecord.Type == "CNAME")
-		canDelete := rm.selectedRecord.Type != "NS" && rm.selectedRecord.Type != "SOA"
-		if canEdit {
-			hints = "e: edit • " + hints
-		}
-		if canDelete {
-			hints = "d: delete • " + hints
-		}
-		hints = "c: create • " + hints
-	}
-	b.WriteString(m.renderHelpBar(hints))
+	b.WriteString(m.renderHelpBar(m.keymapHelpBar()))
 	return b.String()
 }
 
@@ -644,7 +631,7 @@ func (rm route53Model) viewRecordCreate(m Model) string {
 	}
 
 	b.WriteString("\n")
-	b.WriteString(m.renderHelpBar("enter: next • esc: cancel"))
+	b.WriteString(m.renderHelpBar(m.keymapHelpBar()))
 	return b.String()
 }
 
@@ -736,7 +723,7 @@ func (rm route53Model) viewRecordEdit(m Model) string {
 	}
 
 	b.WriteString("\n")
-	b.WriteString(m.renderHelpBar("enter: next • esc: cancel"))
+	b.WriteString(m.renderHelpBar(m.keymapHelpBar()))
 	return b.String()
 }
 
@@ -793,7 +780,7 @@ func (rm route53Model) viewRecordDeleteConfirm(m Model) string {
 	b.WriteString("\n")
 	b.WriteString(filterStyle.Render(fmt.Sprintf("  %s▏", rm.confirmInput)))
 	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("enter: confirm • esc: cancel"))
+	b.WriteString(m.renderHelpBar(m.keymapHelpBar()))
 	return b.String()
 }
 
@@ -939,4 +926,19 @@ func parseTTL(s string) int64 {
 		return defaultTTL
 	}
 	return ttl
+}
+
+// canEditSelectedRecord reports whether the selected record supports in-TUI
+// editing (plain A/CNAME records without an alias target).
+func (rm route53Model) canEditSelectedRecord() bool {
+	return rm.selectedRecord != nil &&
+		rm.selectedRecord.AliasTarget == "" &&
+		(rm.selectedRecord.Type == "A" || rm.selectedRecord.Type == "CNAME")
+}
+
+// canDeleteSelectedRecord reports whether the selected record may be deleted
+// (NS/SOA records are protected).
+func (rm route53Model) canDeleteSelectedRecord() bool {
+	return rm.selectedRecord != nil &&
+		rm.selectedRecord.Type != "NS" && rm.selectedRecord.Type != "SOA"
 }


### PR DESCRIPTION
## Summary

Implements #111: every screen maintained its shortcuts twice — a hand-written bottom-bar string in the view and a separate overlay case in `help.go` — and the two drifted (e.g. the IAM key detail bar omitted `r: rotate` while the overlay showed it).

- **`keyBinding` / `screenKeymaps`**: a screen declares each shortcut once — overlay key label, compact bar form, verbose description, and an optional `when(Model) bool` visibility condition. `keymapHelpBar()` and `keymapShortcuts()` render the bottom bar and the `?` overlay from that single definition; `currentScreenShortcuts` consults the keymap first and falls back to the legacy switch.
- **Hotspot screens migrated** (the three files the issue names): all six Route53 screens — with the record edit/delete eligibility rules factored into `canEditSelectedRecord`/`canDeleteSelectedRecord`, shared by keymap conditions instead of being duplicated between the view's hint builder and the overlay — all six IAM screens, and the CloudWatch Logs group/stream lists. Their hand-written bar strings and overlay cases (plus `route53FormShortcuts`) are deleted.
- **Drift fixed by unification**: the IAM key detail bar now shows `r: rotate` exactly when the overlay does.
- **Explicit boundaries**: bar-only bindings (globals like `H: home`, which the overlay lists in its Global section) and overlay-only bindings (typing hints too verbose for the bar) are both expressible. The CloudWatch log viewer deliberately stays legacy — its bar labels embed live state (wrap on/off, horizontal offset) that a static declaration cannot express — and the remaining screens migrate incrementally on the same structure.

## Testing

- `go test ./...` passes: bar+overlay rendering from one definition, conditional bindings following model state on both surfaces (NS vs. A records), keymap-driven overlay through `currentScreenShortcuts` incl. the rotation-drift fix, and legacy fallback for unmigrated screens.
- `make build` passes.

Closes #111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized keyboard shortcut help across Route 53, IAM, and CloudWatch screens.
  * The help bar and `?` overlay now stay synchronized and show only actions available for the current selection.
  * Added context-aware shortcuts for record editing, deletion, and IAM key rotation.
  * Existing screens without the new keymap continue to use their previous shortcut behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->