### PR TITLE
feat: extend all-regions browsing to RDS and Lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ contexts:
 | `sso` | Use AWS IAM Identity Center / SSO, reusing a valid AWS CLI SSO cache and prompting for login only when needed | `sso_start_url`, and for concrete contexts `sso_account_id`, `sso_role_name`; `profile` is optional |
 | `okta_saml` | Okta SAML federation: `unic env` signs in to Okta (prompt on stderr, password without echo; `UNIC_OKTA_USERNAME`/`UNIC_OKTA_PASSWORD` for automation), exchanges the SAML assertion via `sts:AssumeRoleWithSAML`, and caches the session under `~/.config/unic/cache/okta-saml/`. The TUI reuses a valid cached session passively. Okta MFA challenges support TOTP codes and Okta Verify push in v1 | `okta_org_url`, `okta_app_id`; `role_arn` required when the assertion carries multiple roles. Passwords and MFA secrets are never stored |
 
-The preferred context format separates `auth` from `resources`. `auth.sso_region` controls IAM Identity Center login and role-credential retrieval. `resources.default_region` is selected at startup, and `resources.regions` lists additional regions available from the global `R` region picker. Switching regions reuses the current credentials and recreates only the regional AWS clients. The EC2 Instance Browser can additionally aggregate all configured regions into a single list with `A`.
+The preferred context format separates `auth` from `resources`. `auth.sso_region` controls IAM Identity Center login and role-credential retrieval. `resources.default_region` is selected at startup, and `resources.regions` lists additional regions available from the global `R` region picker. Switching regions reuses the current credentials and recreates only the regional AWS clients. The EC2 Instance Browser, RDS Browser, and Lambda Browser can additionally aggregate all configured regions into a single list with `A`; rows gain a region tag, per-region failures render inline, and actions (RDS start/stop/modify, Lambda invoke) run against the row's own region.
 
 Legacy flat fields (`auth_type`, `profile`, `region`, `regions`, `sso_region`, and related auth fields) remain supported. A context without a region list behaves as a single-region context, and an omitted SSO region still falls back to its default resource region.
 
@@ -418,7 +418,7 @@ checks:
 | EC2 Instance Browser | `r` refresh, `/` filter, `A` toggle all-regions scope (multi-region contexts), `Enter` detail, detail `g/a/t/b/n` opens related security groups/ASG/target groups/load balancers/listeners |
 | Security Groups | `a` add rule, `d` delete rule, `Tab` switch ingress/egress |
 | Reachability Analyzer | Region select first, `←`/`→` or `Tab` change type, `/` filter, `Enter` advance, `Tab`/`↑`/`↓` move config fields, `←`/`→` protocol, `r` rerun |
-| RDS | `s` start, `x` stop, `f` failover, `m` modify instance class (filterable class picker, `Tab` apply-immediately toggle, type-to-confirm), `r` refresh |
+| RDS | `A` toggle all-regions scope (multi-region contexts), `s` start, `x` stop, `f` failover, `m` modify instance class (filterable class picker, `Tab` apply-immediately toggle, type-to-confirm), `r` refresh |
 | Route53 | `c` create, `e` edit, `d` delete |
 | IAM Key Rotation | `r` rotate, `c` copy exports, `a` apply and verify, `d` deactivate old key, `x` delete old key |
 | Bedrock API Keys | `c` create, choose current IAM user or another user, `r` rotate secret, `d` delete, type the IAM user/key ID to confirm, `c` copy one-time key without printing it, `e` copy `AWS_BEARER_TOKEN_BEDROCK` export |
@@ -437,7 +437,7 @@ checks:
 | Settings | `Enter`/`Space` toggle selected setting, `Esc`/`q` back |
 | Context Picker | `a` add context, `f` favorite/unfavorite selected context, type or `/` filter, `s` setup selected context and quit, `y` copy selected exports and quit, filter-mode `Ctrl+S` setup selected filtered context, filter-mode `Ctrl+Y` copy selected filtered exports, `u` clear shell context and quit with a final confirmation message |
 | ECR | `Enter` images, `d` repository detail, `/` filter, `r` refresh, image detail `c` copy digest, `t` copy tag |
-| Lambda | `Enter` invoke, `d` detail, `l` view CloudWatch Logs, `/` filter, `r` refresh |
+| Lambda | `A` toggle all-regions scope (multi-region contexts), `Enter` invoke, `d` detail, `l` view CloudWatch Logs, `/` filter, `r` refresh |
 
 The command palette (`P`) fuzzy-searches three kinds of items from anywhere outside text-entry screens: service features (jump straight into a browser), contexts (switch without opening the picker), and resources indexed across services. Opening the palette starts an async index of EC2 instances, RDS instances, Lambda functions, S3 buckets, ECS clusters, and Route53 zones in the current context; results stream in as they load, per-service failures are shown inline, and matching covers names, IDs, and ARNs where available. Selecting a resource jumps to the owning browser with the shared filter prefilled to that resource.
 

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -237,7 +237,11 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 			{"q", "Go back to the feature list"},
 		}
 	case screenRDSList:
-		return listScreenShortcuts("open the selected instance", "go back to the feature list", true, false)
+		shortcuts := listScreenShortcuts("open the selected instance", "go back to the feature list", true, false)
+		if m.hasMultipleRegions() {
+			shortcuts = append(shortcuts, helpShortcut{"A", "Toggle all-regions instance scope"})
+		}
+		return shortcuts
 	case screenRDSDetail:
 		shortcuts := []helpShortcut{
 			{"m", "Modify the instance class"},
@@ -518,7 +522,7 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 			{"q", "Go back to the feature list"},
 		}
 	case screenLambdaFunctionList:
-		return []helpShortcut{
+		shortcuts := []helpShortcut{
 			{"↑/↓, j/k", "Move between functions"},
 			{"/", "Start filtering functions"},
 			{"r", "Refresh the function list"},
@@ -527,6 +531,10 @@ func (m Model) currentScreenShortcuts() []helpShortcut {
 			{"l", "View CloudWatch Logs for the selected function"},
 			{"q / esc", "Go back to the feature list"},
 		}
+		if m.hasMultipleRegions() {
+			shortcuts = append(shortcuts, helpShortcut{"A", "Toggle all-regions function scope"})
+		}
+		return shortcuts
 	case screenLambdaFunctionDetail:
 		return []helpShortcut{
 			{"i", "Invoke the selected function"},

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -15,7 +15,7 @@ type instancesLoadedMsg struct {
 
 type ec2BrowserInstancesLoadedMsg struct {
 	instances    []awsservice.EC2Instance
-	regionErrors []awsservice.EC2RegionError
+	regionErrors []awsservice.RegionError
 }
 
 type ec2RelationshipsLoadedMsg struct {
@@ -99,7 +99,8 @@ type ssmSessionDoneMsg struct {
 }
 
 type rdsInstancesLoadedMsg struct {
-	instances []awsservice.RDSInstance
+	instances    []awsservice.RDSInstance
+	regionErrors []awsservice.RegionError
 }
 
 type rdsClassesLoadedMsg struct {
@@ -349,7 +350,8 @@ type inspectorChecklistLoadedMsg struct {
 }
 
 type lambdaFunctionsLoadedMsg struct {
-	functions []awsservice.LambdaFunction
+	functions    []awsservice.LambdaFunction
+	regionErrors []awsservice.RegionError
 }
 
 type lambdaInvokeResultMsg struct {

--- a/internal/app/screen_all_regions_test.go
+++ b/internal/app/screen_all_regions_test.go
@@ -1,0 +1,87 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"unic/internal/config"
+	awsservice "unic/internal/services/aws"
+)
+
+func multiRegionCfg() *config.Config {
+	return &config.Config{Region: "us-east-1", Regions: []string{"us-east-1", "eu-west-1"}, ContextName: "dev"}
+}
+
+func TestRDSAllRegionsToggleAndRendering(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.cfg = multiRegionCfg()
+	m.screen = screenRDSList
+
+	next, cmd := m.rds.updateList(&m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
+	model := next.(Model)
+	if !model.rds.allRegions || cmd == nil || model.screen != screenLoading {
+		t.Fatalf("expected all-regions reload, allRegions=%v screen=%v", model.rds.allRegions, model.screen)
+	}
+
+	m = model
+	m.rds.HandleMessage(&m, rdsInstancesLoadedMsg{
+		instances: []awsservice.RDSInstance{
+			{DBInstanceID: "prod-db", Region: "eu-west-1"},
+		},
+		regionErrors: []awsservice.RegionError{{Region: "us-east-1", Err: errRegionTest}},
+	})
+	view, _ := m.rds.View(m)
+	for _, want := range []string{"(all regions)", "[eu-west-1]", "us-east-1: access denied"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected %q in RDS all-regions view, got:\n%s", want, view)
+		}
+	}
+}
+
+func TestRDSAllRegionsToggleIgnoredForSingleRegion(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.cfg = &config.Config{Region: "us-east-1", Regions: []string{"us-east-1"}, ContextName: "dev"}
+	m.screen = screenRDSList
+
+	next, cmd := m.rds.updateList(&m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
+	model := next.(Model)
+	if model.rds.allRegions || cmd != nil {
+		t.Fatal("expected no-op for single-region contexts")
+	}
+}
+
+func TestLambdaAllRegionsToggleAndRendering(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.cfg = multiRegionCfg()
+	m.screen = screenLambdaFunctionList
+
+	next, cmd := m.lambda.updateFunctionList(&m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
+	model := next.(Model)
+	if !model.lambda.allRegions || cmd == nil {
+		t.Fatal("expected all-regions reload for lambda")
+	}
+
+	m = model
+	m.screen = screenLambdaFunctionList
+	m.lambda.HandleMessage(&m, lambdaFunctionsLoadedMsg{
+		functions: []awsservice.LambdaFunction{
+			{Name: "checkout", Region: "eu-west-1"},
+		},
+		regionErrors: []awsservice.RegionError{{Region: "us-east-1", Err: errRegionTest}},
+	})
+	m.screen = screenLambdaFunctionList
+	view, _ := m.lambda.View(m)
+	for _, want := range []string{"(all regions)", "[eu-west-1]", "us-east-1: access denied"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected %q in Lambda all-regions view, got:\n%s", want, view)
+		}
+	}
+}
+
+var errRegionTest = errTest{}
+
+type errTest struct{}
+
+func (errTest) Error() string { return "access denied" }

--- a/internal/app/screen_all_regions_test.go
+++ b/internal/app/screen_all_regions_test.go
@@ -85,3 +85,50 @@ var errRegionTest = errTest{}
 type errTest struct{}
 
 func (errTest) Error() string { return "access denied" }
+
+func TestLambdaLogsCarryTheRowRegion(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.cfg = multiRegionCfg()
+	m.screen = screenLambdaFunctionList
+	m.lambda.HandleMessage(&m, lambdaFunctionsLoadedMsg{
+		functions: []awsservice.LambdaFunction{{Name: "checkout", Region: "eu-west-1"}},
+	})
+	m.screen = screenLambdaFunctionList
+
+	next, cmd := m.lambda.updateFunctionList(&m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	model := next.(Model)
+	if cmd == nil {
+		t.Fatal("expected the log flow to start")
+	}
+	if model.cwLogs.regionOverride != "eu-west-1" {
+		t.Fatalf("expected the log flow pinned to the row's region, got %q", model.cwLogs.regionOverride)
+	}
+
+	// Entering CloudWatch Logs from the catalog clears the override.
+	cleared, _ := model.cwLogs.Start(&model)
+	if cleared.(Model).cwLogs.regionOverride != "" {
+		t.Fatal("expected a catalog entry to clear the region override")
+	}
+}
+
+func TestRDSRefreshMatchesRegionQualifiedIdentity(t *testing.T) {
+	m := New(testConfig(), "", "dev")
+	m.cfg = multiRegionCfg()
+	m.screen = screenRDSDetail
+	m.rds.instances = []awsservice.RDSInstance{
+		{DBInstanceID: "orders-db", Region: "us-east-1", Status: "available"},
+		{DBInstanceID: "orders-db", Region: "eu-west-1", Status: "available"},
+	}
+	selected := m.rds.instances[1]
+	m.rds.selected = &selected
+
+	refreshed := awsservice.RDSInstance{DBInstanceID: "orders-db", Region: "eu-west-1", Status: "stopping"}
+	m.rds.HandleMessage(&m, rdsStatusRefreshedMsg{instance: &refreshed})
+
+	if m.rds.instances[0].Status != "available" {
+		t.Fatalf("expected the same-ID row in another region untouched, got %q", m.rds.instances[0].Status)
+	}
+	if m.rds.instances[1].Status != "stopping" {
+		t.Fatalf("expected the region-matched row updated, got %q", m.rds.instances[1].Status)
+	}
+}

--- a/internal/app/screen_cloudwatchlogs.go
+++ b/internal/app/screen_cloudwatchlogs.go
@@ -33,6 +33,10 @@ var (
 )
 
 type cloudWatchLogsModel struct {
+	// regionOverride pins all log requests to a specific region when the
+	// flow was entered from an all-regions row (e.g. a Lambda function in a
+	// non-active region). Empty means the active context region.
+	regionOverride string
 	groups           []awsservice.LogGroup
 	filteredGroups   []awsservice.LogGroup
 	groupIdx         int
@@ -62,6 +66,7 @@ func newCloudWatchLogsModel() cloudWatchLogsModel {
 }
 
 func (cw *cloudWatchLogsModel) Start(m *Model) (tea.Model, tea.Cmd) {
+	cw.regionOverride = ""
 	cw.selectedGroup = nil
 	cw.selectedStream = nil
 	cw.events = nil
@@ -75,7 +80,8 @@ func (cw *cloudWatchLogsModel) Start(m *Model) (tea.Model, tea.Cmd) {
 }
 
 // StartFromLambda enters the CW logs flow scoped to a Lambda function's log group.
-func (cw *cloudWatchLogsModel) StartFromLambda(m *Model, functionName string) (tea.Model, tea.Cmd) {
+func (cw *cloudWatchLogsModel) StartFromLambda(m *Model, functionName, region string) (tea.Model, tea.Cmd) {
+	cw.regionOverride = region
 	logGroupName := "/aws/lambda/" + functionName
 	cw.selectedGroup = &awsservice.LogGroup{Name: logGroupName}
 	cw.selectedStream = nil
@@ -744,6 +750,9 @@ func (cw cloudWatchLogsModel) loadGroups(m Model, appendMode bool) tea.Cmd {
 		if err != nil {
 			return errMsg{err: err}
 		}
+		if cw.regionOverride != "" && repo.Region != cw.regionOverride {
+			repo = repo.ForRegion(cw.regionOverride)
+		}
 
 		var nextToken *string
 		if appendMode {
@@ -768,6 +777,9 @@ func (cw cloudWatchLogsModel) loadStreams(m Model, logGroupName string, appendMo
 		if err != nil {
 			return errMsg{err: err}
 		}
+		if cw.regionOverride != "" && repo.Region != cw.regionOverride {
+			repo = repo.ForRegion(cw.regionOverride)
+		}
 
 		var nextToken *string
 		if appendMode {
@@ -791,6 +803,9 @@ func (cw cloudWatchLogsModel) loadEvents(m Model, appendMode bool) tea.Cmd {
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return cwLogEventsLoadedMsg{append: appendMode}
+		}
+		if cw.regionOverride != "" && repo.Region != cw.regionOverride {
+			repo = repo.ForRegion(cw.regionOverride)
 		}
 
 		if cw.selectedGroup == nil {
@@ -832,6 +847,9 @@ func (cw cloudWatchLogsModel) pollTail(m Model) tea.Cmd {
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return cwLogEventsLoadedMsg{append: true}
+		}
+		if cw.regionOverride != "" && repo.Region != cw.regionOverride {
+			repo = repo.ForRegion(cw.regionOverride)
 		}
 
 		if cw.selectedGroup == nil {

--- a/internal/app/screen_ec2_browser.go
+++ b/internal/app/screen_ec2_browser.go
@@ -17,7 +17,7 @@ type ec2InstanceBrowserModel struct {
 	filtered        []awsservice.EC2Instance
 	idx             int
 	allRegions      bool
-	regionErrors    []awsservice.EC2RegionError
+	regionErrors    []awsservice.RegionError
 	selected        *awsservice.EC2Instance
 	relationships   *awsservice.EC2InstanceRelationships
 	relatedKind     ec2RelatedKind

--- a/internal/app/screen_ec2_browser_test.go
+++ b/internal/app/screen_ec2_browser_test.go
@@ -60,7 +60,7 @@ func TestEC2BrowserStoresRegionErrorsFromLoadedMsg(t *testing.T) {
 		instances: []awsservice.EC2Instance{
 			{InstanceID: "i-east", Region: "us-east-1"},
 		},
-		regionErrors: []awsservice.EC2RegionError{
+		regionErrors: []awsservice.RegionError{
 			{Region: "eu-west-1", Err: errors.New("access denied")},
 		},
 	}

--- a/internal/app/screen_lambda.go
+++ b/internal/app/screen_lambda.go
@@ -32,6 +32,8 @@ type lambdaModel struct {
 	invokeResult  *awsservice.LambdaInvokeResult
 	payloadSource lambdaPayloadSource
 	invokeStep    int // 0=source select, 1=text input
+	allRegions    bool
+	regionErrors  []awsservice.RegionError
 }
 
 func newLambdaModel() lambdaModel {
@@ -46,6 +48,7 @@ func (lm *lambdaModel) HandleMessage(m *Model, msg tea.Msg) (tea.Model, tea.Cmd,
 	switch msg := msg.(type) {
 	case lambdaFunctionsLoadedMsg:
 		lm.functions = msg.functions
+		lm.regionErrors = msg.regionErrors
 		lm.filtered = msg.functions
 		lm.functionIdx = 0
 		m.resetFilter(filterLambdaFunctions)
@@ -118,6 +121,12 @@ func (lm *lambdaModel) updateFunctionList(m *Model, msg tea.KeyMsg) (tea.Model, 
 		lm.functionIdx = nextListIndex(lm.functionIdx, len(lm.filtered))
 	case "/":
 		return *m, m.activateFilter(filterLambdaFunctions)
+	case "A":
+		if m.hasMultipleRegions() {
+			lm.allRegions = !lm.allRegions
+			m.resetFilter(filterLambdaFunctions)
+			return m.startLoading(lm.loadFunctions(*m))
+		}
 	case "r":
 		return m.startLoading(lm.loadFunctions(*m))
 	case "d":
@@ -149,11 +158,20 @@ func (lm lambdaModel) viewFunctionList(m Model) string {
 	var b strings.Builder
 	var panel strings.Builder
 	b.WriteString(m.renderStatusBar())
-	b.WriteString(titleStyle.Render("Lambda Functions"))
+	title := "Lambda Functions"
+	allRegions := lm.allRegions && m.hasMultipleRegions()
+	if allRegions {
+		title += " (all regions)"
+	}
+	b.WriteString(titleStyle.Render(title))
 	b.WriteString("\n")
 	b.WriteString(m.renderFilterValue(filterLambdaFunctions))
 	b.WriteString("\n\n")
 
+	for _, regionErr := range lm.regionErrors {
+		panel.WriteString(errorStyle.Render(fmt.Sprintf("  %s: %v", regionErr.Region, regionErr.Err)))
+		panel.WriteString("\n")
+	}
 	if len(lm.filtered) == 0 {
 		panel.WriteString(dimStyle.Render("  No functions found"))
 		panel.WriteString("\n")
@@ -173,7 +191,11 @@ func (lm lambdaModel) viewFunctionList(m Model) string {
 				cursor = "> "
 				style = selectedStyle
 			}
-			panel.WriteString(style.Render(cursor + m.renderHighlightedValue(filterLambdaFunctions, fn.DisplayTitle())))
+			row := fn.DisplayTitle()
+			if allRegions {
+				row = fmt.Sprintf("[%s] %s", fn.Region, row)
+			}
+			panel.WriteString(style.Render(cursor + m.renderHighlightedValue(filterLambdaFunctions, row)))
 			panel.WriteString("\n")
 		}
 		panel.WriteString("\n")
@@ -182,7 +204,11 @@ func (lm lambdaModel) viewFunctionList(m Model) string {
 
 	b.WriteString(m.renderListPanel(panel.String()))
 	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • r: refresh • enter: invoke • d: detail • l: logs • esc: back"))
+	helpText := "↑/↓: navigate • /: filter • r: refresh • enter: invoke • d: detail • l: logs • esc: back"
+	if m.hasMultipleRegions() {
+		helpText = "↑/↓: navigate • /: filter • r: refresh • A: all regions • enter: invoke • d: detail • l: logs • esc: back"
+	}
+	b.WriteString(m.renderHelpBar(helpText))
 	return b.String()
 }
 
@@ -414,12 +440,21 @@ func (lm lambdaModel) viewInvokeResult(m Model) string {
 // --- Load Commands ---
 
 func (lm lambdaModel) loadFunctions(m Model) tea.Cmd {
+	allRegions := lm.allRegions && m.hasMultipleRegions()
+	var regions []string
+	if m.cfg != nil {
+		regions = append(regions, m.cfg.Regions...)
+	}
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(m.commandContext(), lambdaAPITimeout)
 		defer cancel()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}
+		}
+		if allRegions {
+			functions, regionErrors := repo.ListFunctionsAcrossRegions(ctx, regions)
+			return lambdaFunctionsLoadedMsg{functions: functions, regionErrors: regionErrors}
 		}
 		functions, err := repo.ListFunctions(ctx)
 		if err != nil {
@@ -471,6 +506,11 @@ func (lm lambdaModel) invokeFunction(m Model) tea.Cmd {
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
 		if err != nil {
 			return errMsg{err: err}
+		}
+		if sel := lm.selected; sel != nil && sel.Region != "" && repo.Region != sel.Region {
+			// Functions loaded through the all-regions scope invoke against
+			// their own region.
+			repo = repo.ForRegion(sel.Region)
 		}
 		result, err := repo.InvokeFunction(ctx, fnName, payload, false)
 		if err != nil {

--- a/internal/app/screen_lambda.go
+++ b/internal/app/screen_lambda.go
@@ -139,7 +139,7 @@ func (lm *lambdaModel) updateFunctionList(m *Model, msg tea.KeyMsg) (tea.Model, 
 		if len(lm.filtered) > 0 && lm.functionIdx < len(lm.filtered) {
 			fn := lm.filtered[lm.functionIdx]
 			lm.selected = &fn
-			return m.cwLogs.StartFromLambda(m, fn.Name)
+			return m.cwLogs.StartFromLambda(m, fn.Name, fn.Region)
 		}
 	case "enter":
 		if len(lm.filtered) > 0 && lm.functionIdx < len(lm.filtered) {
@@ -225,7 +225,7 @@ func (lm *lambdaModel) updateFunctionDetail(m *Model, msg tea.KeyMsg) (tea.Model
 		m.screen = screenLambdaInvokeInput
 	case "l":
 		if lm.selected != nil {
-			return m.cwLogs.StartFromLambda(m, lm.selected.Name)
+			return m.cwLogs.StartFromLambda(m, lm.selected.Name, lm.selected.Region)
 		}
 	}
 	return *m, nil
@@ -382,7 +382,7 @@ func (lm *lambdaModel) updateInvokeResult(m *Model, msg tea.KeyMsg) (tea.Model, 
 		m.screen = screenLambdaInvokeInput
 	case "l":
 		if lm.selected != nil {
-			return m.cwLogs.StartFromLambda(m, lm.selected.Name)
+			return m.cwLogs.StartFromLambda(m, lm.selected.Name, lm.selected.Region)
 		}
 	}
 	return *m, nil

--- a/internal/app/screen_rds.go
+++ b/internal/app/screen_rds.go
@@ -78,7 +78,9 @@ func (rm *rdsModel) HandleMessage(m *Model, msg tea.Msg) (tea.Model, tea.Cmd, bo
 		}
 		rm.selected = msg.instance
 		for i, inst := range rm.instances {
-			if inst.DBInstanceID == msg.instance.DBInstanceID {
+			// Identifiers are only unique per region; an all-regions list can
+			// hold the same ID twice, so match the region as well.
+			if inst.DBInstanceID == msg.instance.DBInstanceID && inst.Region == msg.instance.Region {
 				rm.instances[i] = *msg.instance
 				break
 			}

--- a/internal/app/screen_rds.go
+++ b/internal/app/screen_rds.go
@@ -18,6 +18,8 @@ type rdsModel struct {
 	action       string // "start", "stop", "failover", "modify"
 	confirmInput string // typed input for destructive action confirmation
 	polling      bool
+	allRegions   bool
+	regionErrors []awsservice.RegionError
 
 	// Instance class modification
 	classes          []string
@@ -41,6 +43,7 @@ func (rm *rdsModel) HandleMessage(m *Model, msg tea.Msg) (tea.Model, tea.Cmd, bo
 	switch msg := msg.(type) {
 	case rdsInstancesLoadedMsg:
 		rm.instances = msg.instances
+		rm.regionErrors = msg.regionErrors
 		rm.filtered = applyFilter(rm.instances, m.filterValue(filterRDS))
 		rm.idx = 0
 		m.screen = screenRDSList
@@ -160,6 +163,12 @@ func (rm *rdsModel) updateList(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		rm.idx = nextListIndex(rm.idx, len(rm.filtered))
 	case "/":
 		return *m, m.activateFilter(filterRDS)
+	case "A":
+		if m.hasMultipleRegions() {
+			rm.allRegions = !rm.allRegions
+			m.resetFilter(filterRDS)
+			return m.startLoading(rm.loadInstances(*m))
+		}
 	case "enter":
 		if len(rm.filtered) > 0 && rm.idx < len(rm.filtered) {
 			selected := rm.filtered[rm.idx]
@@ -317,6 +326,9 @@ func (rm rdsModel) loadClasses(m Model) tea.Cmd {
 			}
 		}
 
+		if instance.Region != "" && repo.Region != instance.Region {
+			repo = repo.ForRegion(instance.Region)
+		}
 		classes, err := repo.ListOrderableDBInstanceClasses(ctx, instance.Engine, instance.EngineVersion)
 		if err != nil {
 			return errMsg{err: err}
@@ -329,6 +341,11 @@ func (rm rdsModel) loadClasses(m Model) tea.Cmd {
 }
 
 func (rm rdsModel) loadInstances(m Model) tea.Cmd {
+	allRegions := rm.allRegions && m.hasMultipleRegions()
+	var regions []string
+	if m.cfg != nil {
+		regions = append(regions, m.cfg.Regions...)
+	}
 	return func() tea.Msg {
 		ctx := m.commandContext()
 		repo, err := awsservice.NewAwsRepository(ctx, m.cfg)
@@ -336,6 +353,11 @@ func (rm rdsModel) loadInstances(m Model) tea.Cmd {
 			return errMsg{err: err}
 		}
 		m.awsRepo = repo
+
+		if allRegions {
+			instances, regionErrors := repo.ListDBInstancesAcrossRegions(ctx, regions)
+			return rdsInstancesLoadedMsg{instances: instances, regionErrors: regionErrors}
+		}
 
 		instances, err := repo.ListDBInstances(ctx)
 		if err != nil {
@@ -364,6 +386,12 @@ func (rm rdsModel) executeAction(m Model, action, dbInstanceID string) tea.Cmd {
 			if err != nil {
 				return rdsActionDoneMsg{action: action, instanceID: dbInstanceID, err: err}
 			}
+		}
+
+		if inst := rm.selected; inst != nil && inst.Region != "" && repo.Region != inst.Region {
+			// Rows loaded through the all-regions scope act against their
+			// own region, not the globally active one.
+			repo = repo.ForRegion(inst.Region)
 		}
 
 		var err error
@@ -409,6 +437,9 @@ func (rm rdsModel) pollStatus(m Model, dbInstanceID string) tea.Cmd {
 			}
 		}
 
+		if sel := rm.selected; sel != nil && sel.Region != "" && repo.Region != sel.Region {
+			repo = repo.ForRegion(sel.Region)
+		}
 		inst, err := repo.DescribeDBInstance(ctx, dbInstanceID)
 		return rdsStatusRefreshedMsg{instance: inst, err: err}
 	}
@@ -420,16 +451,28 @@ func (rm rdsModel) tickPoll(dbInstanceID string) tea.Cmd {
 	})
 }
 
+func (rm rdsModel) allRegionsActive(m Model) bool {
+	return rm.allRegions && m.hasMultipleRegions()
+}
+
 func (rm rdsModel) viewList(m Model) string {
 	var b strings.Builder
 	var panel strings.Builder
 	b.WriteString(m.renderStatusBar())
-	b.WriteString(titleStyle.Render("RDS Instances"))
+	title := "RDS Instances"
+	if rm.allRegionsActive(m) {
+		title += " (all regions)"
+	}
+	b.WriteString(titleStyle.Render(title))
 	b.WriteString("\n")
 
 	b.WriteString(m.renderFilterValue(filterRDS))
 	b.WriteString("\n\n")
 
+	for _, regionErr := range rm.regionErrors {
+		panel.WriteString(errorStyle.Render(fmt.Sprintf("  %s: %v", regionErr.Region, regionErr.Err)))
+		panel.WriteString("\n")
+	}
 	if len(rm.filtered) == 0 {
 		panel.WriteString(dimStyle.Render("  No matching instances"))
 		panel.WriteString("\n")
@@ -449,7 +492,11 @@ func (rm rdsModel) viewList(m Model) string {
 				cursor = "> "
 				style = selectedStyle
 			}
-			panel.WriteString(style.Render(cursor + m.renderHighlightedValue(filterRDS, inst.DisplayTitle())))
+			row := inst.DisplayTitle()
+			if rm.allRegionsActive(m) {
+				row = fmt.Sprintf("[%s] %s", inst.Region, row)
+			}
+			panel.WriteString(style.Render(cursor + m.renderHighlightedValue(filterRDS, row)))
 			panel.WriteString("\n")
 		}
 
@@ -459,7 +506,11 @@ func (rm rdsModel) viewList(m Model) string {
 
 	b.WriteString(m.renderListPanel(panel.String()))
 	b.WriteString("\n\n")
-	b.WriteString(m.renderHelpBar("↑/↓: navigate • /: filter • enter: detail • esc: back • H: home"))
+	helpText := "↑/↓: navigate • /: filter • enter: detail • esc: back • H: home"
+	if m.hasMultipleRegions() {
+		helpText = "↑/↓: navigate • /: filter • A: all regions • enter: detail • esc: back • H: home"
+	}
+	b.WriteString(m.renderHelpBar(helpText))
 	return b.String()
 }
 
@@ -475,6 +526,10 @@ func (rm rdsModel) viewDetail(m Model) string {
 
 	b.WriteString(renderDetailLine("Identifier", normalStyle.Render(r.DBInstanceID)))
 	b.WriteString("\n")
+	if r.Region != "" {
+		b.WriteString(renderDetailLine("Region", normalStyle.Render(r.Region)))
+		b.WriteString("\n")
+	}
 	b.WriteString(renderDetailLine("Engine", normalStyle.Render(fmt.Sprintf("%s %s", r.Engine, r.EngineVersion))))
 	b.WriteString("\n")
 

--- a/internal/services/aws/ec2.go
+++ b/internal/services/aws/ec2.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"sort"
 	"strings"
-	"sync"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -87,53 +86,13 @@ func (r *AwsRepository) ListEC2Instances(ctx context.Context) ([]EC2Instance, er
 	return instances, nil
 }
 
-// EC2RegionError reports a per-region listing failure during an all-regions scan.
-type EC2RegionError struct {
-	Region string
-	Err    error
-}
-
-// ec2RepoForRegion is a test seam: ForRegion builds real SDK clients, so tests
-// substitute regional repositories with mocked clients here.
-var ec2RepoForRegion = func(r *AwsRepository, region string) *AwsRepository {
-	return r.ForRegion(region)
-}
-
-// ListEC2InstancesAcrossRegions fans ListEC2Instances out over the given regions
-// concurrently, reusing the repository credentials. Per-region failures are
-// returned alongside the successful rows instead of failing the whole scan.
-func (r *AwsRepository) ListEC2InstancesAcrossRegions(ctx context.Context, regions []string) ([]EC2Instance, []EC2RegionError) {
+// ListEC2InstancesAcrossRegions fans ListEC2Instances out over the given
+// regions through the shared all-regions helper.
+func (r *AwsRepository) ListEC2InstancesAcrossRegions(ctx context.Context, regions []string) ([]EC2Instance, []RegionError) {
 	uniclog.Debug("aws", "ListEC2InstancesAcrossRegions called", "regions", regions)
-
-	type regionResult struct {
-		instances []EC2Instance
-		err       error
-	}
-	results := make([]regionResult, len(regions))
-	var wg sync.WaitGroup
-	for i, region := range regions {
-		wg.Add(1)
-		go func(i int, region string) {
-			defer wg.Done()
-			repo := r
-			if region != r.Region {
-				repo = ec2RepoForRegion(r, region)
-			}
-			instances, err := repo.ListEC2Instances(ctx)
-			results[i] = regionResult{instances: instances, err: err}
-		}(i, region)
-	}
-	wg.Wait()
-
-	var instances []EC2Instance
-	var regionErrors []EC2RegionError
-	for i, result := range results {
-		if result.err != nil {
-			regionErrors = append(regionErrors, EC2RegionError{Region: regions[i], Err: result.err})
-			continue
-		}
-		instances = append(instances, result.instances...)
-	}
+	instances, regionErrors := listAcrossRegions(ctx, r, regions, func(ctx context.Context, repo *AwsRepository) ([]EC2Instance, error) {
+		return repo.ListEC2Instances(ctx)
+	})
 	sortEC2Instances(instances)
 	return instances, regionErrors
 }

--- a/internal/services/aws/ec2_test.go
+++ b/internal/services/aws/ec2_test.go
@@ -326,9 +326,9 @@ func TestListEC2InstancesAcrossRegions_MergesAndTagsRegions(t *testing.T) {
 	base := &AwsRepository{Region: "us-east-1", EC2Client: regionEC2Mock("us-east-1", "i-east")}
 	west := &AwsRepository{Region: "eu-west-1", EC2Client: regionEC2Mock("eu-west-1", "i-west")}
 
-	original := ec2RepoForRegion
-	defer func() { ec2RepoForRegion = original }()
-	ec2RepoForRegion = func(r *AwsRepository, region string) *AwsRepository {
+	original := repoForRegionFn
+	defer func() { repoForRegionFn = original }()
+	repoForRegionFn = func(r *AwsRepository, region string) *AwsRepository {
 		if region != "eu-west-1" {
 			t.Fatalf("unexpected region requested: %s", region)
 		}
@@ -359,9 +359,9 @@ func TestListEC2InstancesAcrossRegions_KeepsPartialResultsOnFailure(t *testing.T
 		},
 	}}
 
-	original := ec2RepoForRegion
-	defer func() { ec2RepoForRegion = original }()
-	ec2RepoForRegion = func(_ *AwsRepository, _ string) *AwsRepository { return broken }
+	original := repoForRegionFn
+	defer func() { repoForRegionFn = original }()
+	repoForRegionFn = func(_ *AwsRepository, _ string) *AwsRepository { return broken }
 
 	instances, regionErrors := base.ListEC2InstancesAcrossRegions(context.Background(), []string{"us-east-1", "eu-west-1"})
 	if len(instances) != 1 || instances[0].InstanceID != "i-east" {

--- a/internal/services/aws/lambda.go
+++ b/internal/services/aws/lambda.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"sort"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
@@ -29,6 +30,7 @@ func (r *AwsRepository) ListFunctions(ctx context.Context) ([]LambdaFunction, er
 		for _, f := range out.Functions {
 			fn := LambdaFunction{
 				Name:         awssdk.ToString(f.FunctionName),
+				Region:       r.Region,
 				ARN:          awssdk.ToString(f.FunctionArn),
 				Runtime:      string(f.Runtime),
 				Handler:      awssdk.ToString(f.Handler),
@@ -93,4 +95,22 @@ func (r *AwsRepository) InvokeFunction(ctx context.Context, functionName, payloa
 		}
 	}
 	return result, nil
+}
+
+// ListFunctionsAcrossRegions fans ListFunctions out over the given regions
+// through the shared all-regions helper.
+func (r *AwsRepository) ListFunctionsAcrossRegions(ctx context.Context, regions []string) ([]LambdaFunction, []RegionError) {
+	uniclog.Debug("aws", "ListFunctionsAcrossRegions called", "regions", regions)
+	functions, regionErrors := listAcrossRegions(ctx, r, regions, func(ctx context.Context, repo *AwsRepository) ([]LambdaFunction, error) {
+		return repo.ListFunctions(ctx)
+	})
+	sort.Slice(functions, func(i, j int) bool {
+		left := normalizedSortKey(functions[i].Name)
+		right := normalizedSortKey(functions[j].Name)
+		if left == right {
+			return functions[i].Region < functions[j].Region
+		}
+		return left < right
+	})
+	return functions, regionErrors
 }

--- a/internal/services/aws/lambda_model.go
+++ b/internal/services/aws/lambda_model.go
@@ -8,6 +8,7 @@ import (
 // LambdaFunction represents an AWS Lambda function.
 type LambdaFunction struct {
 	Name         string
+	Region       string
 	ARN          string
 	Runtime      string
 	Handler      string
@@ -27,7 +28,7 @@ func (f LambdaFunction) DisplayTitle() string {
 }
 
 func (f LambdaFunction) FilterText() string {
-	return f.Name + " " + f.Runtime
+	return f.Name + " " + f.Runtime + " " + f.Region
 }
 
 func (f LambdaFunction) shortLastModified() string {

--- a/internal/services/aws/rds.go
+++ b/internal/services/aws/rds.go
@@ -37,6 +37,7 @@ func (r *AwsRepository) ListDBInstances(ctx context.Context) ([]RDSInstance, err
 		if db.PendingModifiedValues != nil {
 			inst.PendingInstanceClass = awssdk.ToString(db.PendingModifiedValues.DBInstanceClass)
 		}
+		inst.Region = r.Region
 
 		// Endpoint may be nil for stopped instances
 		if db.Endpoint != nil {
@@ -86,6 +87,7 @@ func (r *AwsRepository) DescribeDBInstance(ctx context.Context, dbInstanceID str
 	if db.PendingModifiedValues != nil {
 		inst.PendingInstanceClass = awssdk.ToString(db.PendingModifiedValues.DBInstanceClass)
 	}
+	inst.Region = r.Region
 	if db.Endpoint != nil {
 		inst.Endpoint = fmt.Sprintf("%s:%d", awssdk.ToString(db.Endpoint.Address), awssdk.ToInt32(db.Endpoint.Port))
 	}
@@ -213,4 +215,22 @@ func (r *AwsRepository) ModifyDBInstanceClass(ctx context.Context, dbInstanceID,
 		return fmt.Errorf("failed to modify DB instance class for %s: %w", dbInstanceID, err)
 	}
 	return nil
+}
+
+// ListDBInstancesAcrossRegions fans ListDBInstances out over the given
+// regions through the shared all-regions helper.
+func (r *AwsRepository) ListDBInstancesAcrossRegions(ctx context.Context, regions []string) ([]RDSInstance, []RegionError) {
+	uniclog.Debug("aws", "ListDBInstancesAcrossRegions called", "regions", regions)
+	instances, regionErrors := listAcrossRegions(ctx, r, regions, func(ctx context.Context, repo *AwsRepository) ([]RDSInstance, error) {
+		return repo.ListDBInstances(ctx)
+	})
+	sort.Slice(instances, func(i, j int) bool {
+		left := normalizedSortKey(instances[i].DBInstanceID)
+		right := normalizedSortKey(instances[j].DBInstanceID)
+		if left == right {
+			return instances[i].Region < instances[j].Region
+		}
+		return left < right
+	})
+	return instances, regionErrors
 }

--- a/internal/services/aws/rds_model.go
+++ b/internal/services/aws/rds_model.go
@@ -13,6 +13,7 @@ type RDSInstance struct {
 	Status                string
 	InstanceClass         string
 	PendingInstanceClass  string
+	Region                string
 	MultiAZ               bool
 	StorageGB             int32
 	StorageEncrypted      bool
@@ -30,8 +31,8 @@ func (r RDSInstance) DisplayTitle() string {
 
 // FilterText returns a lowercase string for keyword matching.
 func (r RDSInstance) FilterText() string {
-	return strings.ToLower(fmt.Sprintf("%s %s %s %s %s %s",
-		r.DBInstanceID, r.Engine, r.EngineVersion, r.Status, r.InstanceClass, r.ClusterID))
+	return strings.ToLower(fmt.Sprintf("%s %s %s %s %s %s %s",
+		r.DBInstanceID, r.Engine, r.EngineVersion, r.Status, r.InstanceClass, r.ClusterID, r.Region))
 }
 
 // IsClusterMember returns true if this instance belongs to an Aurora cluster.

--- a/internal/services/aws/regions.go
+++ b/internal/services/aws/regions.go
@@ -1,0 +1,54 @@
+package aws
+
+import (
+	"context"
+	"sync"
+)
+
+// RegionError reports a per-region listing failure during an all-regions scan.
+type RegionError struct {
+	Region string
+	Err    error
+}
+
+// repoForRegionFn is a test seam: ForRegion builds real SDK clients, so tests
+// substitute regional repositories with mocked clients here.
+var repoForRegionFn = func(r *AwsRepository, region string) *AwsRepository {
+	return r.ForRegion(region)
+}
+
+// listAcrossRegions fans a per-region list call out concurrently, reusing the
+// repository credentials via ForRegion. Per-region failures are returned
+// alongside the successful rows instead of failing the whole scan.
+func listAcrossRegions[T any](ctx context.Context, r *AwsRepository, regions []string, list func(context.Context, *AwsRepository) ([]T, error)) ([]T, []RegionError) {
+	type regionResult struct {
+		items []T
+		err   error
+	}
+	results := make([]regionResult, len(regions))
+	var wg sync.WaitGroup
+	for i, region := range regions {
+		wg.Add(1)
+		go func(i int, region string) {
+			defer wg.Done()
+			repo := r
+			if region != r.Region {
+				repo = repoForRegionFn(r, region)
+			}
+			items, err := list(ctx, repo)
+			results[i] = regionResult{items: items, err: err}
+		}(i, region)
+	}
+	wg.Wait()
+
+	var items []T
+	var regionErrors []RegionError
+	for i, result := range results {
+		if result.err != nil {
+			regionErrors = append(regionErrors, RegionError{Region: regions[i], Err: result.err})
+			continue
+		}
+		items = append(items, result.items...)
+	}
+	return items, regionErrors
+}

--- a/internal/services/aws/regions_test.go
+++ b/internal/services/aws/regions_test.go
@@ -1,0 +1,38 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestListAcrossRegionsMergesAndReportsFailures(t *testing.T) {
+	base := &AwsRepository{Region: "us-east-1"}
+	west := &AwsRepository{Region: "eu-west-1"}
+
+	orig := repoForRegionFn
+	t.Cleanup(func() { repoForRegionFn = orig })
+	repoForRegionFn = func(_ *AwsRepository, region string) *AwsRepository {
+		if region != "eu-west-1" {
+			t.Fatalf("unexpected region %s", region)
+		}
+		return west
+	}
+
+	wantErr := errors.New("region down")
+	items, regionErrors := listAcrossRegions(context.Background(), base,
+		[]string{"us-east-1", "eu-west-1"},
+		func(_ context.Context, repo *AwsRepository) ([]string, error) {
+			if repo.Region == "eu-west-1" {
+				return nil, wantErr
+			}
+			return []string{"a-" + repo.Region, "b-" + repo.Region}, nil
+		})
+
+	if len(items) != 2 || items[0] != "a-us-east-1" {
+		t.Fatalf("expected the healthy region's items, got %+v", items)
+	}
+	if len(regionErrors) != 1 || regionErrors[0].Region != "eu-west-1" || !errors.Is(regionErrors[0].Err, wantErr) {
+		t.Fatalf("expected one eu-west-1 failure, got %+v", regionErrors)
+	}
+}


### PR DESCRIPTION
## Summary

Implements #268: the all-regions scope from #237 now covers the RDS and Lambda browsers, and — with a third consumer arriving — the fan-out is extracted into a shared helper.

- **Shared helper**: `listAcrossRegions` (generic, concurrent per-region listing via `ForRegion`, partial-failure tolerant) plus a unified `RegionError` type and a single `repoForRegionFn` test seam. The EC2 implementation now delegates to it; the duplicated goroutine/fan-out code is gone.
- **RDS Browser**: `A` toggles all-regions for multi-region contexts — region-tagged rows, inline per-region errors, region in the filter text, and a Region line in instance detail. **Actions follow the row's region**: start/stop/failover/modify-class, status polling, and orderable-class listing all switch to `ForRegion(row.Region)` when it differs from the active region, so an all-regions row can be operated on safely.
- **Lambda Browser**: same `A` toggle and rendering; invoking a function from an all-regions row runs against the function's own region.
- Overlay help entries and help bars gain the conditional `A` binding on both screens (hidden for single-region contexts), matching the EC2 pattern.

## Testing

- `go test ./...` passes: shared-helper merge/partial-failure with the seam, RDS toggle + all-regions rendering (title/region tags/inline errors) + single-region no-op, and the Lambda toggle + rendering equivalents. Existing EC2 across-regions tests now exercise the shared helper.
- `make build` passes.

## Docs

- README: RDS/Lambda key-binding rows and the multi-region configuration paragraph now cover all three browsers and the region-aware action behavior.

Closes #268