### PR TITLE
fix: restore SSM loads after global overlays

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -132,15 +132,16 @@ const (
 
 // Model is the root Bubbletea model.
 type Model struct {
-	cfg                *config.Config
-	awsRepo            *awsservice.AwsRepository
-	screen             screen
-	quitting           bool
-	exitMessage        string
-	exitTitle          string
-	bootFrame          int
-	settingsIdx        int
-	settingsPrevScreen screen
+	cfg                 *config.Config
+	awsRepo             *awsservice.AwsRepository
+	screen              screen
+	loadingReturnScreen screen
+	quitting            bool
+	exitMessage         string
+	exitTitle           string
+	bootFrame           int
+	settingsIdx         int
+	settingsPrevScreen  screen
 
 	// App-shell state stays root-owned because it coordinates global navigation,
 	// context/session setup, shared chrome, and cross-feature transitions.
@@ -434,6 +435,7 @@ func (m Model) startLoadingWithMessage(title string, details []string, cmd tea.C
 		cmd = m.commands.BindCmd(gen, cmd)
 	}
 	m.screen = screenLoading
+	m.loadingReturnScreen = 0
 	m.loadingSpinner = newLoadingSpinner()
 	m.loadingTitle = title
 	m.loadingDetails = append([]string(nil), details...)
@@ -441,6 +443,13 @@ func (m Model) startLoadingWithMessage(title string, details []string, cmd tea.C
 		return m, m.loadingSpinner.Tick
 	}
 	return m, tea.Batch(m.loadingSpinner.Tick, cmd)
+}
+
+func (m Model) startLoadingFor(returnScreen screen, title string, details []string, cmd tea.Cmd) (tea.Model, tea.Cmd) {
+	updated, next := m.startLoadingWithMessage(title, details, cmd)
+	model := updated.(Model)
+	model.loadingReturnScreen = returnScreen
+	return model, next
 }
 
 // isTextEntryScreen reports whether the current screen captures free-form text

--- a/internal/app/screen_palette.go
+++ b/internal/app/screen_palette.go
@@ -111,14 +111,7 @@ func (pm *paletteModel) refilter() {
 func (m Model) updatePalette(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "esc":
-		if m.palette.prevScreen == screenLoading && m.ssmParams.loading {
-			return m.ssmParams.Start(&m)
-		}
-		if m.palette.prevScreen == screenLoading && m.ssmParams.selected != nil {
-			m.screen = screenSSMParamDetail
-			return m, nil
-		}
-		m.screen = m.palette.prevScreen
+		return m.restoreScreenAfterOverlay(m.palette.prevScreen)
 	case "up":
 		m.palette.idx = previousListIndex(m.palette.idx, len(m.palette.filtered))
 	case "down":

--- a/internal/app/screen_settings.go
+++ b/internal/app/screen_settings.go
@@ -28,10 +28,9 @@ func (m Model) updateSettings(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "q", "esc":
 		if m.settingsPrevScreen == 0 || m.settingsPrevScreen == screenSettings {
-			m.screen = screenContextPicker
-		} else {
-			m.screen = m.settingsPrevScreen
+			return m.restoreScreenAfterOverlay(screenContextPicker)
 		}
+		return m.restoreScreenAfterOverlay(m.settingsPrevScreen)
 	case "up", "k":
 		m.settingsIdx = previousListIndex(m.settingsIdx, len(items))
 	case "down", "j":

--- a/internal/app/screen_ssmparams.go
+++ b/internal/app/screen_ssmparams.go
@@ -45,10 +45,10 @@ func (pm *ssmParamsModel) clearValue() {
 }
 
 func (m Model) restoreScreenAfterOverlay(previous screen) (tea.Model, tea.Cmd) {
-	if previous == screenLoading && m.ssmParams.loading {
+	if previous == screenLoading && m.loadingReturnScreen == screenSSMParamList {
 		return m.ssmParams.Start(&m)
 	}
-	if previous == screenLoading && m.ssmParams.selected != nil {
+	if previous == screenLoading && m.loadingReturnScreen == screenSSMParamDetail {
 		m.screen = screenSSMParamDetail
 		return m, nil
 	}
@@ -59,7 +59,7 @@ func (m Model) restoreScreenAfterOverlay(previous screen) (tea.Model, tea.Cmd) {
 func (pm *ssmParamsModel) Start(m *Model) (tea.Model, tea.Cmd) {
 	pm.request++
 	pm.loading = true
-	return m.startLoading(pm.loadParameters(*m, pm.request))
+	return m.startLoadingFor(screenSSMParamList, "Loading...", nil, pm.loadParameters(*m, pm.request))
 }
 
 func (pm *ssmParamsModel) HandleMessage(m *Model, msg tea.Msg) (tea.Model, tea.Cmd, bool) {
@@ -158,7 +158,7 @@ func (pm *ssmParamsModel) updateList(m *Model, msg tea.KeyMsg) (tea.Model, tea.C
 		m.resetFilter(filterSSMParameters)
 		pm.request++
 		pm.loading = true
-		return m.startLoading(pm.loadParameters(*m, pm.request))
+		return m.startLoadingFor(screenSSMParamList, "Loading...", nil, pm.loadParameters(*m, pm.request))
 	case "enter":
 		if len(pm.filtered) > 0 && pm.idx < len(pm.filtered) {
 			selected := pm.filtered[pm.idx]
@@ -181,12 +181,12 @@ func (pm *ssmParamsModel) updateDetail(m *Model, msg tea.KeyMsg) (tea.Model, tea
 	case "v":
 		if pm.selected != nil && !pm.revealed {
 			pm.request++
-			return m.startLoadingWithMessage("Fetching value...", []string{pm.selected.Name}, pm.loadValue(*m, pm.selected.Name, false, pm.request))
+			return m.startLoadingFor(screenSSMParamDetail, "Fetching value...", []string{pm.selected.Name}, pm.loadValue(*m, pm.selected.Name, false, pm.request))
 		}
 	case "y":
 		if pm.selected != nil {
 			pm.request++
-			return m.startLoadingWithMessage("Copying value...", []string{pm.selected.Name}, pm.loadValue(*m, pm.selected.Name, true, pm.request))
+			return m.startLoadingFor(screenSSMParamDetail, "Copying value...", []string{pm.selected.Name}, pm.loadValue(*m, pm.selected.Name, true, pm.request))
 		}
 	}
 	return *m, nil

--- a/internal/app/screen_ssmparams.go
+++ b/internal/app/screen_ssmparams.go
@@ -44,6 +44,18 @@ func (pm *ssmParamsModel) clearValue() {
 	pm.notice = ""
 }
 
+func (m Model) restoreScreenAfterOverlay(previous screen) (tea.Model, tea.Cmd) {
+	if previous == screenLoading && m.ssmParams.loading {
+		return m.ssmParams.Start(&m)
+	}
+	if previous == screenLoading && m.ssmParams.selected != nil {
+		m.screen = screenSSMParamDetail
+		return m, nil
+	}
+	m.screen = previous
+	return m, nil
+}
+
 func (pm *ssmParamsModel) Start(m *Model) (tea.Model, tea.Cmd) {
 	pm.request++
 	pm.loading = true

--- a/internal/app/screen_ssmparams_test.go
+++ b/internal/app/screen_ssmparams_test.go
@@ -336,6 +336,49 @@ func TestSSMParamPaletteCancelDuringValueLoadRestoresDetail(t *testing.T) {
 	}
 }
 
+func TestSSMParamGlobalOverlayCancelRestoresInterruptedLoad(t *testing.T) {
+	for _, overlay := range []rune{'S', 'V'} {
+		t.Run(string(overlay)+"/list", func(t *testing.T) {
+			m := ssmParamsTestModel()
+			m.ssmParams.request++
+			m.ssmParams.loading = true
+			m.screen = screenLoading
+
+			updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{overlay}})
+			m = updated.(Model)
+			updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+			m = updated.(Model)
+
+			if m.screen != screenLoading || cmd == nil || !m.ssmParams.loading {
+				t.Fatalf("expected %c cancel to restart the parameter load, screen=%v loading=%v", overlay, m.screen, m.ssmParams.loading)
+			}
+		})
+
+		for _, action := range []rune{'v', 'y'} {
+			t.Run(string(overlay)+"/"+string(action), func(t *testing.T) {
+				m := ssmParamsTestModel()
+				m.ssmParams.HandleMessage(&m, ssmParametersLoadedMsg{parameters: testParameters()})
+				m.ssmParams.idx = 1
+				m.ssmParams.updateList(&m, tea.KeyMsg{Type: tea.KeyEnter})
+
+				updated, _ := m.ssmParams.updateDetail(&m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{action}})
+				m = updated.(Model)
+				updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{overlay}})
+				m = updated.(Model)
+				updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+				m = updated.(Model)
+
+				if m.screen != screenSSMParamDetail || cmd != nil || m.ssmParams.selected == nil {
+					t.Fatalf("expected %c cancel during %c to restore parameter detail, screen=%v", overlay, action, m.screen)
+				}
+				if m.ssmParams.revealed || m.ssmParams.value != "" {
+					t.Fatalf("expected restored detail to keep the value hidden, got %+v", m.ssmParams)
+				}
+			})
+		}
+	}
+}
+
 func TestSSMParamLateListFailureDoesNotEscapePalette(t *testing.T) {
 	m := ssmParamsTestModel()
 	m.ssmParams.request++

--- a/internal/app/screen_ssmparams_test.go
+++ b/internal/app/screen_ssmparams_test.go
@@ -296,9 +296,8 @@ func TestSSMParamLateListDoesNotEscapePalette(t *testing.T) {
 
 func TestSSMParamPaletteCancelRestartsInitialLoad(t *testing.T) {
 	m := ssmParamsTestModel()
-	m.ssmParams.request++
-	m.ssmParams.loading = true
-	m.screen = screenLoading
+	started, _ := m.ssmParams.Start(&m)
+	m = started.(Model)
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'P'}})
 	m = updated.(Model)
@@ -340,9 +339,8 @@ func TestSSMParamGlobalOverlayCancelRestoresInterruptedLoad(t *testing.T) {
 	for _, overlay := range []rune{'S', 'V'} {
 		t.Run(string(overlay)+"/list", func(t *testing.T) {
 			m := ssmParamsTestModel()
-			m.ssmParams.request++
-			m.ssmParams.loading = true
-			m.screen = screenLoading
+			started, _ := m.ssmParams.Start(&m)
+			m = started.(Model)
 
 			updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{overlay}})
 			m = updated.(Model)
@@ -376,6 +374,28 @@ func TestSSMParamGlobalOverlayCancelRestoresInterruptedLoad(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestSSMParamGlobalOverlayCancelDoesNotRestoreAbandonedSSMLoad(t *testing.T) {
+	for _, overlay := range []rune{'P', 'S', 'V'} {
+		t.Run(string(overlay), func(t *testing.T) {
+			m := ssmParamsTestModel()
+			m.ssmParams.loading = true
+			selected := testParameters()[0]
+			m.ssmParams.selected = &selected
+			updated, _ := m.startLoading(nil)
+			m = updated.(Model)
+
+			updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{overlay}})
+			m = updated.(Model)
+			updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+			m = updated.(Model)
+
+			if m.screen != screenLoading || cmd != nil {
+				t.Fatalf("expected %c cancel to restore the unrelated load, screen=%v cmd=%v", overlay, m.screen, cmd)
+			}
+		})
 	}
 }
 

--- a/internal/app/screen_views.go
+++ b/internal/app/screen_views.go
@@ -131,7 +131,7 @@ func (m Model) updateViews(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	switch key {
 	case "q", "esc":
-		m.screen = m.views.prevScreen
+		return m.restoreScreenAfterOverlay(m.views.prevScreen)
 	case "up", "k":
 		m.views.idx = previousListIndex(m.views.idx, len(m.views.views))
 	case "down", "j":


### PR DESCRIPTION
## Summary

- share interrupted SSM loading restoration across Palette, Settings, and Saved Views
- restart interrupted list loads and restore interrupted reveal/copy loads to hidden detail
- cover Settings and Saved Views across list, reveal, and copy cases

## Related Issues

Closes #299

## Validation

- `make test`
- `make build`

## Checklist

- [x] Tests added for the regression
- [x] Full test suite passes
- [x] Build passes
- [x] No documentation change needed; this restores intended navigation behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overlay cancellation and closing behavior across command palette, settings, views, and parameter screens.
  * Preserved loading progress and restored the appropriate parameter detail or previous screen when overlays are dismissed.
  * Ensured sensitive parameter values remain hidden after canceling related actions.

* **Tests**
  * Added coverage for overlay cancellation during parameter loading and value actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->