### PR TITLE
fix: preserve interrupted DynamoDB loads

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -690,11 +690,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.stopWatch()
 			m.deactivateFilter()
 			m.ssmParams.clearValue()
-			if m.screen != screenSettings || m.settingsPrevScreen != screenContextPicker {
+			returnsToContextPicker :=
+				(m.screen == screenSettings && m.settingsPrevScreen == screenContextPicker) ||
+					(m.screen == screenViewList && m.views.prevScreen == screenContextPicker)
+			if !returnsToContextPicker {
 				m.ctxPrevScreen = m.screen
+				m.ctxPrevWasLoading = false
 			}
 			m.ctxPickerPending = true
-			m.ctxPrevWasLoading = false
 			if m.screen == screenLoading && isDynamoDBScreen(m.loadingReturnScreen) {
 				m.ctxPrevScreen = m.loadingReturnScreen
 				m.ctxPrevWasLoading = true

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -693,7 +693,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			returnsToContextPicker :=
 				(m.screen == screenSettings && m.settingsPrevScreen == screenContextPicker) ||
 					(m.screen == screenViewList && m.views.prevScreen == screenContextPicker)
-			if !returnsToContextPicker {
+			if !m.ctxPrevWasLoading && !returnsToContextPicker {
 				m.ctxPrevScreen = m.screen
 				m.ctxPrevWasLoading = false
 			}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -750,7 +750,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.stopWatch()
 			m.deactivateFilter()
 			m.ssmParams.clearValue()
-			m.settingsPrevScreen = m.screen
+			if !overlayChainMatches(m, m.screen, func(current screen) bool {
+				return current == screenSettings
+			}) {
+				m.settingsPrevScreen = m.screen
+			}
 			m.cancelDynamoDBLoadForOverlay()
 			m.screen = screenSettings
 			return m, nil

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -562,6 +562,8 @@ func overlayChainMatches(m Model, current screen, match func(screen) bool) bool 
 			current = m.views.prevScreen
 		case screenContextPicker:
 			current = m.ctxPrevScreen
+		case screenRegionPicker:
+			current = m.regionPrevScreen
 		default:
 			return false
 		}
@@ -738,7 +740,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.stopWatch()
 			m.deactivateFilter()
 			m.ssmParams.clearValue()
-			m.regionPrevScreen = m.screen
+			if !overlayChainMatches(m, m.screen, func(current screen) bool {
+				return current == screenRegionPicker
+			}) {
+				m.regionPrevScreen = m.screen
+			}
 			m.regionIdx = m.activeRegionIndex()
 			m.screen = screenRegionPicker
 			return m, nil

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -543,6 +543,31 @@ func (m Model) isTextEntryScreen() bool {
 	}
 }
 
+func overlayChainMatches(m Model, current screen, match func(screen) bool) bool {
+	visited := make(map[screen]struct{}, 4)
+	for {
+		if match(current) {
+			return true
+		}
+		if _, ok := visited[current]; ok {
+			return false
+		}
+		visited[current] = struct{}{}
+		switch current {
+		case screenSettings:
+			current = m.settingsPrevScreen
+		case screenCommandPalette:
+			current = m.palette.prevScreen
+		case screenViewList:
+			current = m.views.prevScreen
+		case screenContextPicker:
+			current = m.ctxPrevScreen
+		default:
+			return false
+		}
+	}
+}
+
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Global messages
 	switch msg := msg.(type) {
@@ -690,9 +715,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.stopWatch()
 			m.deactivateFilter()
 			m.ssmParams.clearValue()
-			returnsToContextPicker :=
-				(m.screen == screenSettings && m.settingsPrevScreen == screenContextPicker) ||
-					(m.screen == screenViewList && m.views.prevScreen == screenContextPicker)
+			returnsToContextPicker := overlayChainMatches(m, m.screen, func(current screen) bool {
+				return current == screenContextPicker
+			})
 			if !m.ctxPrevWasLoading && !returnsToContextPicker {
 				m.ctxPrevScreen = m.screen
 				m.ctxPrevWasLoading = false

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -376,9 +376,12 @@ func TestContextPickerStackedOverlaysPreserveReturnScreen(t *testing.T) {
 		{name: "views settings views", keys: "VSV"},
 		{name: "palette settings palette", keys: "PSP"},
 		{name: "palette views palette", keys: "PVP"},
+		{name: "settings then region", keys: "SR"},
+		{name: "views region settings region", keys: "VRSR"},
+		{name: "settings region views region", keys: "SRVR"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			m := New(testConfig(), t.TempDir()+"/config.yaml", "dev")
+			m := multiRegionTestModel()
 			m.cfg.ContextName = "dev"
 
 			opened, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'C'}})

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -365,6 +365,41 @@ func TestGlobalSettingsShortcutOpensSettings(t *testing.T) {
 	}
 }
 
+func TestContextPickerStackedOverlaysPreserveReturnScreen(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		keys string
+	}{
+		{name: "settings then views", keys: "SV"},
+		{name: "views then settings", keys: "VS"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := New(testConfig(), t.TempDir()+"/config.yaml", "dev")
+			m.cfg.ContextName = "dev"
+
+			opened, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'C'}})
+			m = opened.(Model)
+			loaded, _ := m.Update(contextsLoadedMsg{contexts: testContexts()})
+			m = loaded.(Model)
+
+			for _, key := range tc.keys {
+				overlay, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{key}})
+				m = overlay.(Model)
+			}
+
+			reopened, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'C'}})
+			m = reopened.(Model)
+			reloaded, _ := m.Update(contextsLoadedMsg{contexts: testContexts()})
+			m = reloaded.(Model)
+			canceled, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+			m = canceled.(Model)
+			if m.screen != screenServiceList || cmd != nil {
+				t.Fatalf("expected cancel to return to the service list, screen=%v cmd=%v", m.screen, cmd)
+			}
+		})
+	}
+}
+
 func TestSettingsViewShowsBootSplashSetting(t *testing.T) {
 	m := New(testConfig(), "", "dev")
 	m.screen = screenSettings

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -374,6 +374,8 @@ func TestContextPickerStackedOverlaysPreserveReturnScreen(t *testing.T) {
 		{name: "views then settings", keys: "VS"},
 		{name: "settings views settings", keys: "SVS"},
 		{name: "views settings views", keys: "VSV"},
+		{name: "palette settings palette", keys: "PSP"},
+		{name: "palette views palette", keys: "PVP"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			m := New(testConfig(), t.TempDir()+"/config.yaml", "dev")

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -372,6 +372,8 @@ func TestContextPickerStackedOverlaysPreserveReturnScreen(t *testing.T) {
 	}{
 		{name: "settings then views", keys: "SV"},
 		{name: "views then settings", keys: "VS"},
+		{name: "settings views settings", keys: "SVS"},
+		{name: "views settings views", keys: "VSV"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			m := New(testConfig(), t.TempDir()+"/config.yaml", "dev")

--- a/internal/app/screen_cloudformation.go
+++ b/internal/app/screen_cloudformation.go
@@ -122,44 +122,19 @@ func (cm *cloudFormationModel) HandleMessage(m *Model, msg tea.Msg) (tea.Model, 
 }
 
 func cloudFormationLoadActive(m Model) bool {
-	return cloudFormationOverlayChainMatches(m, m.screen, func(current screen) bool {
+	return overlayChainMatches(m, m.screen, func(current screen) bool {
 		return current == screenLoading
 	})
 }
 
 func cloudFormationContextReturnActive(m Model) bool {
-	return cloudFormationOverlayChainMatches(m, m.ctxPrevScreen, func(current screen) bool {
+	return overlayChainMatches(m, m.ctxPrevScreen, func(current screen) bool {
 		if current == screenCloudFormationStackList || current == screenCloudFormationStackDetail {
 			return true
 		}
 		return current == screenLoading &&
 			(m.loadingReturnScreen == screenCloudFormationStackList || m.loadingReturnScreen == screenCloudFormationStackDetail)
 	})
-}
-
-func cloudFormationOverlayChainMatches(m Model, current screen, match func(screen) bool) bool {
-	visited := make(map[screen]struct{}, 4)
-	for {
-		if match(current) {
-			return true
-		}
-		if _, ok := visited[current]; ok {
-			return false
-		}
-		visited[current] = struct{}{}
-		switch current {
-		case screenSettings:
-			current = m.settingsPrevScreen
-		case screenCommandPalette:
-			current = m.palette.prevScreen
-		case screenViewList:
-			current = m.views.prevScreen
-		case screenContextPicker:
-			current = m.ctxPrevScreen
-		default:
-			return false
-		}
-	}
 }
 
 func finishCloudFormationLoad(m *Model, next screen) {

--- a/internal/app/screen_context.go
+++ b/internal/app/screen_context.go
@@ -113,6 +113,7 @@ func (m Model) handleContextMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		m.cfg.Region = msg.region
 		m.awsRepo = msg.repo
 		resetStepFunctionsContextState(&m)
+		m.ctxPrevWasLoading = false
 		// Region-scoped feature state may contain resources from the previous
 		// region, so return to the service catalog after switching.
 		m.screen = screenServiceList

--- a/internal/app/screen_dynamodb_test.go
+++ b/internal/app/screen_dynamodb_test.go
@@ -926,11 +926,13 @@ func TestDynamoDBContextPickerCommittedOverlaysClearInterruptedLoad(t *testing.T
 func TestDynamoDBContextPickerOverlaysPreserveInterruptedLoad(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
-		key    rune
+		keys   string
 		screen screen
 	}{
-		{name: "settings", key: 'S', screen: screenSettings},
-		{name: "views", key: 'V', screen: screenViewList},
+		{name: "settings", keys: "S", screen: screenSettings},
+		{name: "views", keys: "V", screen: screenViewList},
+		{name: "settings then views", keys: "SV", screen: screenViewList},
+		{name: "views then settings", keys: "VS", screen: screenSettings},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			m := New(testConfig(), t.TempDir()+"/config.yaml", "dev")
@@ -943,8 +945,10 @@ func TestDynamoDBContextPickerOverlaysPreserveInterruptedLoad(t *testing.T) {
 			loaded, _ := m.Update(contextsLoadedMsg{contexts: testContexts()})
 			m = loaded.(Model)
 
-			overlay, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{tc.key}})
-			m = overlay.(Model)
+			for _, key := range tc.keys {
+				overlay, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{key}})
+				m = overlay.(Model)
+			}
 			if m.screen != tc.screen || !m.ctxPrevWasLoading {
 				t.Fatalf("expected %s over the interrupted context picker, screen=%v loading=%v", tc.name, m.screen, m.ctxPrevWasLoading)
 			}

--- a/internal/app/screen_dynamodb_test.go
+++ b/internal/app/screen_dynamodb_test.go
@@ -983,6 +983,55 @@ func TestDynamoDBContextPickerOverlaysPreserveInterruptedLoad(t *testing.T) {
 	}
 }
 
+func TestDynamoDBRegionSwitchClearsInterruptedOverlayReturn(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		key  rune
+	}{
+		{name: "settings", key: 'S'},
+		{name: "views", key: 'V'},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := multiRegionTestModel()
+			loading, _ := m.dynamodb.Start(&m)
+			m = loading.(Model)
+
+			opened, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'C'}})
+			m = opened.(Model)
+			loaded, _ := m.Update(contextsLoadedMsg{contexts: testContexts()})
+			m = loaded.(Model)
+			overlay, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{tc.key}})
+			m = overlay.(Model)
+
+			regionPicker, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'R'}})
+			m = regionPicker.(Model)
+			moved, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+			m = moved.(Model)
+			switching, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			m = switching.(Model)
+			if m.screen != screenLoading || cmd == nil {
+				t.Fatalf("expected %s region switch to start loading, screen=%v cmd=%v", tc.name, m.screen, cmd)
+			}
+
+			switched, _ := m.Update(regionSwitchedMsg{region: "us-east-1"})
+			m = switched.(Model)
+			if m.screen != screenServiceList || m.ctxPrevWasLoading {
+				t.Fatalf("expected %s region switch to clear interrupted return, screen=%v loading=%v", tc.name, m.screen, m.ctxPrevWasLoading)
+			}
+
+			reopened, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'C'}})
+			m = reopened.(Model)
+			reloaded, _ := m.Update(contextsLoadedMsg{contexts: testContexts()})
+			m = reloaded.(Model)
+			canceled, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+			m = canceled.(Model)
+			if m.screen != screenServiceList || cmd != nil {
+				t.Fatalf("expected later picker cancel to stay on the service list, screen=%v cmd=%v", m.screen, cmd)
+			}
+		})
+	}
+}
+
 func TestDynamoDBGlobalOverlaysDropInterruptedResultAndRestartOnCancel(t *testing.T) {
 	for _, tc := range []struct {
 		name   string

--- a/internal/app/screen_dynamodb_test.go
+++ b/internal/app/screen_dynamodb_test.go
@@ -923,6 +923,62 @@ func TestDynamoDBContextPickerCommittedOverlaysClearInterruptedLoad(t *testing.T
 	}
 }
 
+func TestDynamoDBContextPickerOverlaysPreserveInterruptedLoad(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		key    rune
+		screen screen
+	}{
+		{name: "settings", key: 'S', screen: screenSettings},
+		{name: "views", key: 'V', screen: screenViewList},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := New(testConfig(), t.TempDir()+"/config.yaml", "dev")
+			m.cfg.ContextName = "dev"
+			loading, _ := m.dynamodb.Start(&m)
+			m = loading.(Model)
+
+			opened, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'C'}})
+			m = opened.(Model)
+			loaded, _ := m.Update(contextsLoadedMsg{contexts: testContexts()})
+			m = loaded.(Model)
+
+			overlay, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{tc.key}})
+			m = overlay.(Model)
+			if m.screen != tc.screen || !m.ctxPrevWasLoading {
+				t.Fatalf("expected %s over the interrupted context picker, screen=%v loading=%v", tc.name, m.screen, m.ctxPrevWasLoading)
+			}
+
+			reopened, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'C'}})
+			m = reopened.(Model)
+			if cmd == nil {
+				t.Fatal("expected context reload command")
+			}
+			reloaded, _ := m.Update(contextsLoadedMsg{contexts: testContexts()})
+			m = reloaded.(Model)
+			if m.screen != screenContextPicker || m.ctxPrevScreen != screenDynamoDBTableList || !m.ctxPrevWasLoading {
+				t.Fatalf("expected %s to preserve the interrupted load owner, screen=%v return=%v loading=%v", tc.name, m.screen, m.ctxPrevScreen, m.ctxPrevWasLoading)
+			}
+
+			generation := m.commands.CurrentGen()
+			resumed, resumeCmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+			m = resumed.(Model)
+			if m.screen != screenLoading || m.loadingReturnScreen != screenDynamoDBTableList || resumeCmd == nil {
+				t.Fatalf("expected %s cancel to restart the list load, screen=%v return=%v cmd=%v", tc.name, m.screen, m.loadingReturnScreen, resumeCmd)
+			}
+			if got := m.commands.CurrentGen(); got != generation+1 {
+				t.Fatalf("expected exactly one resumed command generation, got %d after %d", got, generation)
+			}
+
+			stillLoading, duplicateCmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+			m = stillLoading.(Model)
+			if duplicateCmd != nil || m.screen != screenLoading || m.commands.CurrentGen() != generation+1 {
+				t.Fatalf("expected repeated cancel to leave the single resumed load unchanged, screen=%v cmd=%v generation=%d", m.screen, duplicateCmd, m.commands.CurrentGen())
+			}
+		})
+	}
+}
+
 func TestDynamoDBGlobalOverlaysDropInterruptedResultAndRestartOnCancel(t *testing.T) {
 	for _, tc := range []struct {
 		name   string

--- a/internal/app/screen_palette.go
+++ b/internal/app/screen_palette.go
@@ -87,7 +87,11 @@ var (
 // openPalette builds the instantly-available items (features, contexts) and
 // starts the async resource index for the current context.
 func (m Model) openPalette() (tea.Model, tea.Cmd) {
-	m.palette.prevScreen = m.screen
+	if !overlayChainMatches(m, m.screen, func(current screen) bool {
+		return current == screenCommandPalette
+	}) {
+		m.palette.prevScreen = m.screen
+	}
 	m.palette.query = ""
 	m.palette.idx = 0
 	m.palette.resources = nil

--- a/internal/app/screen_views.go
+++ b/internal/app/screen_views.go
@@ -70,7 +70,11 @@ func (m Model) openViews() (tea.Model, tea.Cmd) {
 	m.views.naming = false
 	m.views.nameInput = ""
 	m.views.notice = ""
-	m.views.prevScreen = m.screen
+	if !overlayChainMatches(m, m.screen, func(current screen) bool {
+		return current == screenViewList
+	}) {
+		m.views.prevScreen = m.screen
+	}
 	m.screen = screenViewList
 	return m, nil
 }


### PR DESCRIPTION
### Summary

- preserve the paused DynamoDB load owner when Settings or Saved Views reopens the context picker
- prevent overlay return cycles and restart the interrupted load exactly once
- add table-driven regressions for both nested overlay paths
- leave README and docs unchanged because keybindings, visible workflow, and architecture remain as already documented

### Related Issues

Closes #310

### Validation

- `go test ./internal/app -run "TestDynamoDB(ContextPickerOverlaysPreserveInterruptedLoad|ContextPickerCommittedOverlaysClearInterruptedLoad|GlobalOverlaysDropInterruptedResultAndRestartOnCancel|OverlayContextSwitchInvalidatesLoadingReturn)" -count=1`
- `make test`
- `make build`
- `git diff --check`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed (no documentation change required)
- [x] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed (not applicable)
- [x] Tests/validation included
- [x] Breaking changes documented (none)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed context picker navigation when returning from stacked settings, command palette, saved views, or other overlays.
  * Canceling a reopened context picker now correctly returns to the service list without triggering unintended commands.
  * Improved recovery from interrupted DynamoDB loading when navigating between overlays or switching regions.
  * Fixed loading indicators and return behavior after changing regions.
  * Improved consistency when returning from CloudFormation-related overlays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->