### PR TITLE
docs: reconcile canonical service inventories

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Context ordering:
 | SNS | Topic Browser |
 | SQS | Queue Browser |
 | ELB | Load Balancer Browser |
-| SSM Parameter Store | Parameter Browser |
+| Parameter Store | Parameter Browser |
 | KMS | Key Browser |
 | ACM | Certificate Browser |
 | Step Functions | Execution Browser |
@@ -331,6 +331,7 @@ Context ordering:
 | Lambda | Lambda Browser |
 | DynamoDB | Table Browser & Key Lookup |
 | AWS Backup | Recovery Browser |
+| API Gateway | API Gateway v2 Browser |
 | WAF | WAFv2 Web ACL Browser |
 | Bedrock | API Key Manager |
 | IAM | IAM User Browser |
@@ -473,6 +474,7 @@ checks:
 | Lambda | `A` toggle all-regions scope (multi-region contexts), `Enter` invoke, `d` detail, `l` view CloudWatch Logs, `/` filter, `r` refresh |
 | DynamoDB | `/` filter, `r` refresh, `Enter` table detail, detail `l` prompts for the complete partition/sort key and performs one `GetItem`, `↑`/`↓` and `PgUp`/`PgDn` scroll details or item JSON |
 | AWS Backup | `/` filter vaults, `r` refresh, `Enter` recovery-readiness detail, detail `↑`/`↓` scroll and `PgUp`/`PgDn` page through recovery points, protected resources, and recent failed/expired jobs |
+| API Gateway v2 | `/` filter APIs/routes, `r` refresh, `Enter` detail/routes, route detail `y` copy integration target, `g` open linked Lambda function |
 | WAFv2 | `/` filter, `r` refresh regional and CloudFront scopes, `Enter` logging/association/rule detail, detail `↑`/`↓` scroll, `PgUp`/`PgDn` page |
 
 The command palette (`P`) fuzzy-searches three kinds of items from anywhere outside text-entry screens: service features (jump straight into a browser), contexts (switch without opening the picker), and resources indexed across services. Opening the palette starts an async index of EC2 instances, RDS instances, Lambda functions, S3 buckets, ECS clusters, and Route53 zones in the current context. Press `Tab` to opt into searching the active context plus sync-managed contexts; context fan-out is bounded, rows show context and region tags, and per-context/service failures are shown inline. Matching covers names, IDs, ARNs, contexts, and regions where available. Selecting a resource in another context switches context and then jumps to the owning browser with the shared filter prefilled to that resource.

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -90,28 +90,37 @@ Current repository clients include:
 
 - EC2
 - SSM
+- KMS
+- SNS
+- SQS
 - RDS
-- CloudFormation
 - Route53
 - Secrets Manager
 - IAM
-- CloudWatch Metrics
-- EventBridge
 - STS
+- CloudWatch Metrics / Alarms
 - CloudWatch Logs
+- CloudTrail
+- CloudFormation
+- GuardDuty
+- AWS Config
 - ECS
 - ECR
+- EKS
 - Auto Scaling
 - FIS
 - ElastiCache
+- EventBridge
+- ELBv2
+- S3
+- Lambda
 - ACM
 - Step Functions
-- API Gateway v2
-- S3
-- KMS
 - DynamoDB
-- WAFv2 (regional and `us-east-1` CloudFront-scope clients, plus distribution and distribution-tenant association lookups)
 - AWS Backup
+- API Gateway v2
+- WAFv2 (regional and `us-east-1` CloudFront-scope clients)
+- CloudFront (distribution and distribution-tenant association lookups for WAFv2)
 
 Pattern:
 
@@ -159,23 +168,35 @@ Screen-specific rendering still lives in dedicated files such as:
 - `screen_ec2_browser.go`
 - `screen_autoscaling.go`
 - `screen_vpc.go`
+- `screen_reachability.go`
 - `screen_rds.go`
 - `screen_cloudformation.go`
 - `screen_route53.go`
 - `screen_securitygroup.go`
 - `screen_iam.go`
+- `screen_cloudtrail.go`
+- `screen_eventbridge.go`
+- `screen_cwalarms.go`
 - `screen_cloudwatchmetrics.go`
 - `screen_cloudwatchlogs.go`
 - `screen_ecs.go`
 - `screen_eks.go`
 - `screen_ecr.go`
+- `screen_fis.go`
 - `screen_elasticache.go`
+- `screen_sns.go`
+- `screen_sqs.go`
+- `screen_elb.go`
+- `screen_ssmparams.go`
 - `screen_acm.go`
 - `screen_stepfunctions.go`
+- `screen_apigatewayv2.go`
 - `screen_s3.go`
 - `screen_lambda.go`
 - `screen_dynamodb.go`
 - `screen_bedrock.go`
+- `screen_backup.go`
+- `screen_wafv2.go`
 - `screen_secrets.go`
 - `screen_kms.go`
 - `screen_inspector.go`
@@ -253,6 +274,8 @@ Current screen families include:
 - Secrets Manager list/detail
 - Security Group list/detail/edit flows
 - IAM user, key, and key-rotation flows
+- CloudTrail event list/detail and time-window, mutation, and resource-name filtering flows
+- CloudWatch alarm list/detail, state filtering, watch, and related-resource/log handoff flows
 - CloudWatch metric list/detail flows
 - CloudWatch Logs group/stream/viewer flows
 - ECS cluster/service/rollout detail/task/container flows
@@ -266,7 +289,12 @@ Current screen families include:
 - S3 bucket/object/detail flows
 - KMS key list/detail and rotation-posture flows
 - SNS topic list/detail and per-topic subscription list flows
+- SQS queue list/detail, DLQ navigation, watch, and typed-confirmation redrive/purge flows
+- ELB load balancer/target group/target-health and watch flows
+- Parameter Store list/detail, reveal-gated value, and no-print copy flows
 - EventBridge rule list/detail, scrollable complete event patterns, and type-to-confirm state changes for eligible rule modes
+- Lambda function list/detail, invoke, and CloudWatch Logs handoff flows
+- Bedrock IAM user/API key list and typed-confirmation create, rotate, and delete flows
 - DynamoDB table list/detail and complete-primary-key `GetItem` flows
 - WAFv2 regional/CloudFront Web ACL list and scrollable posture/rule detail flows
 - AWS Backup vault list and scrollable recovery-point/protected-resource/failed-job detail flows

--- a/docs/architecture.ko.md
+++ b/docs/architecture.ko.md
@@ -90,28 +90,37 @@ repository와 서비스별 AWS 연동 계층이다.
 
 - EC2
 - SSM
+- KMS
+- SNS
+- SQS
 - RDS
-- CloudFormation
 - Route53
 - Secrets Manager
 - IAM
-- CloudWatch Metrics
-- EventBridge
 - STS
+- CloudWatch Metrics / Alarms
 - CloudWatch Logs
+- CloudTrail
+- CloudFormation
+- GuardDuty
+- AWS Config
 - ECS
 - ECR
+- EKS
 - Auto Scaling
 - FIS
 - ElastiCache
+- EventBridge
+- ELBv2
+- S3
+- Lambda
 - ACM
 - Step Functions
-- API Gateway v2
-- S3
-- KMS
 - DynamoDB
-- WAFv2 (regional 및 `us-east-1` CloudFront scope client와 distribution 및 distribution tenant association lookup)
 - AWS Backup
+- API Gateway v2
+- WAFv2 (regional 및 `us-east-1` CloudFront scope client)
+- CloudFront (WAFv2의 distribution 및 distribution tenant association lookup)
 
 패턴:
 
@@ -159,23 +168,35 @@ Bubble Tea 앱의 상태, 화면 전환, 렌더링을 담당한다.
 - `screen_ec2_browser.go`
 - `screen_autoscaling.go`
 - `screen_vpc.go`
+- `screen_reachability.go`
 - `screen_rds.go`
 - `screen_cloudformation.go`
 - `screen_route53.go`
 - `screen_securitygroup.go`
 - `screen_iam.go`
+- `screen_cloudtrail.go`
+- `screen_eventbridge.go`
+- `screen_cwalarms.go`
 - `screen_cloudwatchmetrics.go`
 - `screen_cloudwatchlogs.go`
 - `screen_ecs.go`
 - `screen_eks.go`
 - `screen_ecr.go`
+- `screen_fis.go`
 - `screen_elasticache.go`
+- `screen_sns.go`
+- `screen_sqs.go`
+- `screen_elb.go`
+- `screen_ssmparams.go`
 - `screen_acm.go`
 - `screen_stepfunctions.go`
+- `screen_apigatewayv2.go`
 - `screen_s3.go`
 - `screen_lambda.go`
 - `screen_dynamodb.go`
 - `screen_bedrock.go`
+- `screen_backup.go`
+- `screen_wafv2.go`
 - `screen_secrets.go`
 - `screen_kms.go`
 - `screen_inspector.go`
@@ -253,6 +274,8 @@ UNIC은 현재 다섯 가지 인증 모드를 지원한다.
 - Secrets Manager list/detail
 - Security Group list/detail/edit
 - IAM user, key, key rotation
+- CloudTrail event list/detail, time window, mutation, resource-name filtering
+- CloudWatch alarm list/detail, 상태 filtering, watch, 관련 resource/log handoff
 - CloudWatch metric list/detail
 - CloudWatch Logs group/stream/viewer
 - ECS cluster/service/rollout detail/task/container
@@ -266,7 +289,12 @@ UNIC은 현재 다섯 가지 인증 모드를 지원한다.
 - S3 bucket/object/detail
 - KMS key list/detail, rotation 상태
 - SNS topic list/detail, topic별 subscription list flow
+- SQS queue list/detail, DLQ navigation, watch, type-to-confirm redrive/purge
+- ELB load balancer/target group/target health, watch flow
+- Parameter Store list/detail, reveal-gated value, no-print copy flow
 - EventBridge rule list/detail, 스크롤 가능한 전체 event pattern, 변경 가능한 rule mode의 type-to-confirm 상태 변경 flow
+- Lambda function list/detail, invoke, CloudWatch Logs handoff flow
+- Bedrock IAM user/API key list, type-to-confirm create/rotate/delete flow
 - DynamoDB table list/detail, 전체 primary key 기반 `GetItem`
 - WAFv2 regional/CloudFront Web ACL list, 스크롤 가능한 posture/rule detail
 - AWS Backup vault list, recovery point/protected resource/failed job 스크롤 상세 화면

--- a/docs/project-overview.en.md
+++ b/docs/project-overview.en.md
@@ -10,27 +10,36 @@ UNIC is a Go-based AWS terminal console that combines:
 
 Implemented service areas currently include:
 
-- EC2 / SSM
+- EC2 (including SSM Session Manager)
 - VPC
 - RDS
-- CloudFormation
 - Route53
 - Secrets Manager
 - IAM
 - CloudWatch Metrics
-- EventBridge
-- SNS
+- CloudWatch Alarms
 - CloudWatch Logs
+- CloudTrail
+- EventBridge
 - ECS
 - ECR
+- EKS
 - FIS
 - ElastiCache
+- S3
+- SNS
+- SQS
+- ELB
+- Parameter Store
+- KMS
 - ACM
 - Step Functions
-- S3
 - Lambda
+- Bedrock
+- CloudFormation
 - DynamoDB
-- KMS
+- AWS Backup
+- API Gateway v2
 - WAF
 - Inspector mode
 

--- a/docs/project-overview.ko.md
+++ b/docs/project-overview.ko.md
@@ -10,27 +10,36 @@ UNIC은 다음 세 가지를 결합한 Go 기반 AWS 터미널 콘솔이다.
 
 현재 구현된 서비스 영역은 다음과 같다.
 
-- EC2 / SSM
+- EC2 (SSM Session Manager 포함)
 - VPC
 - RDS
-- CloudFormation
 - Route53
 - Secrets Manager
 - IAM
 - CloudWatch Metrics
-- EventBridge
-- SNS
+- CloudWatch Alarms
 - CloudWatch Logs
+- CloudTrail
+- EventBridge
 - ECS
 - ECR
+- EKS
 - FIS
 - ElastiCache
+- S3
+- SNS
+- SQS
+- ELB
+- Parameter Store
+- KMS
 - ACM
 - Step Functions
-- S3
 - Lambda
+- Bedrock
+- CloudFormation
 - DynamoDB
-- KMS
+- AWS Backup
+- API Gateway v2
 - WAF
 - Inspector mode
 


### PR DESCRIPTION
### Summary

- reconcile the English and Korean supported-service inventories with the domain catalog
- include every active repository client and the missing user-facing screen families
- align the README service and keybinding tables for Parameter Store and API Gateway v2

### Related Issues

Closes #330

### Validation

- `make test`
- `make build`
- `git diff --check`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated for the confirmed catalog and keybinding drift
- [x] Relevant `docs/` pages updated
- [x] Tests/validation included
- [x] Breaking changes documented (none)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated supported-service lists to include CloudWatch Alarms, CloudTrail, EKS, Bedrock, AWS Backup, API Gateway v2, ELB, Parameter Store, and other newly documented areas.
  * Added API Gateway v2 navigation, filtering, refresh, detail, and action key references.
  * Refreshed architecture documentation to reflect current service integrations, screens, and workflows, including queues, alarms, load balancers, Lambda, and Parameter Store.
  * Clarified WAF and CloudFront coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->