### PR TITLE
feat: add JSON resource query CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ In the CLI `unic context setup` flow, the picker filters contexts, SSO accounts,
 Use `unic context order` to open reorder mode, choose a context with `↑/↓` or `j/k`, press `Enter` to start moving it, then press `Enter` again to save. `unic context order <name> <number>` still works for direct updates.
 `unic context sync [base-context]` lists the AWS accounts and roles visible to an SSO base context and adds a sync-managed concrete context for each new account/role pair, inheriting the base context's regions. When only one SSO base context exists the argument can be omitted. Existing contexts are never rewritten: pairs that already have a context (manual or synced) are kept as-is. Synced contexts carry a `sync_source: <base-context>` marker in `config.yaml`; when their account/role disappears from SSO they are reported as orphans and removed only with `--prune`. Use `--dry-run` to preview the plan without writing config.
 
+For automation, `unic resources backup-vaults --json` lists AWS Backup vaults using the active context (or `--profile` / `--region`) without starting the TUI. The versioned JSON envelope contains `data`, partial-result `warnings`, and pagination metadata; stdout contains only JSON. Without `--json`, the command prints a compact table and sends warnings to stderr. This CLI is a secondary scripting surface; interactive workflows remain TUI-first.
+
 ## Configuration
 
 Primary config path:

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,6 +8,8 @@ go test ./...
 make build
 ```
 
+Read-only automation commands live under `internal/cli/`; keep their `--json` output versioned and deterministic, write only JSON to stdout, and cover human and JSON output paths with CLI tests.
+
 ## Branch Naming
 
 Use [`branch-naming-harness.md`](branch-naming-harness.md) for branch names.

--- a/internal/cli/resources.go
+++ b/internal/cli/resources.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"unic/internal/config"
+	awsservice "unic/internal/services/aws"
+)
+
+type jsonEnvelope[T any] struct {
+	SchemaVersion string         `json:"schema_version"`
+	Data          T              `json:"data"`
+	Warnings      []string       `json:"warnings"`
+	Pagination    jsonPagination `json:"pagination"`
+}
+
+type jsonPagination struct {
+	Complete  bool    `json:"complete"`
+	NextToken *string `json:"next_token"`
+}
+
+type backupVaultJSON struct {
+	ARN                string `json:"arn"`
+	Name               string `json:"name"`
+	Region             string `json:"region"`
+	State              string `json:"state"`
+	Type               string `json:"type"`
+	EncryptionKeyARN   string `json:"encryption_key_arn,omitempty"`
+	RecoveryPointCount int64  `json:"recovery_point_count"`
+	Locked             bool   `json:"locked"`
+}
+
+var loadBackupVaults = func(ctx context.Context) ([]awsservice.BackupVault, []error, error) {
+	configPath, err := config.DefaultPath()
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := config.EnsureConfigExists(configPath); err != nil {
+		return nil, nil, err
+	}
+	cfg, err := config.Load(Profile(), Region(), configPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	repo, err := awsservice.NewAwsRepository(ctx, cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+	return repo.ListBackupVaults(ctx)
+}
+
+func newResourcesCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "resources", Short: "Read-only resource queries for automation"}
+	cmd.AddCommand(newBackupVaultsCmd())
+	return cmd
+}
+
+func newBackupVaultsCmd() *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:   "backup-vaults",
+		Short: "List AWS Backup vaults",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			vaults, warningErrors, err := loadBackupVaults(cmd.Context())
+			if err != nil {
+				return err
+			}
+			warnings := make([]string, 0, len(warningErrors))
+			for _, warning := range warningErrors {
+				warnings = append(warnings, warning.Error())
+			}
+			if jsonOutput {
+				data := make([]backupVaultJSON, 0, len(vaults))
+				for _, vault := range vaults {
+					data = append(data, backupVaultJSON{
+						ARN: vault.ARN, Name: vault.Name, Region: vault.Region, State: vault.State,
+						Type: vault.Type, EncryptionKeyARN: vault.EncryptionKeyARN,
+						RecoveryPointCount: vault.RecoveryPointCount, Locked: vault.Locked,
+					})
+				}
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(jsonEnvelope[[]backupVaultJSON]{
+					SchemaVersion: "v1", Data: data, Warnings: warnings,
+					Pagination: jsonPagination{Complete: len(warnings) == 0},
+				})
+			}
+
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+			if _, err := fmt.Fprintln(w, "NAME\tSTATE\tTYPE\tRECOVERY POINTS\tREGION"); err != nil {
+				return err
+			}
+			for _, vault := range vaults {
+				if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\n", vault.Name, vault.State, vault.Type, vault.RecoveryPointCount, vault.Region); err != nil {
+					return err
+				}
+			}
+			if err := w.Flush(); err != nil {
+				return err
+			}
+			for _, warning := range warnings {
+				if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s\n", warning); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Emit stable machine-readable JSON")
+	return cmd
+}

--- a/internal/cli/resources_test.go
+++ b/internal/cli/resources_test.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	awsservice "unic/internal/services/aws"
+)
+
+func TestBackupVaultsJSONIncludesDataWarningsAndPagination(t *testing.T) {
+	original := loadBackupVaults
+	defer func() { loadBackupVaults = original }()
+	loadBackupVaults = func(context.Context) ([]awsservice.BackupVault, []error, error) {
+		return []awsservice.BackupVault{{
+			ARN: "arn:aws:backup:us-east-1:123456789012:backup-vault:prod", Name: "prod",
+			Region: "us-east-1", State: "AVAILABLE", Type: "BACKUP_VAULT",
+			RecoveryPointCount: 7, Locked: true,
+		}}, []error{errors.New("second page unavailable")}, nil
+	}
+
+	cmd := NewRootCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"resources", "backup-vaults", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var result struct {
+		SchemaVersion string `json:"schema_version"`
+		Data          []struct {
+			Name string `json:"name"`
+		} `json:"data"`
+		Warnings   []string `json:"warnings"`
+		Pagination struct {
+			Complete  bool    `json:"complete"`
+			NextToken *string `json:"next_token"`
+		} `json:"pagination"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, stdout.String())
+	}
+	if result.SchemaVersion != "v1" || len(result.Data) != 1 || result.Data[0].Name != "prod" {
+		t.Fatalf("unexpected data envelope: %+v", result)
+	}
+	if len(result.Warnings) != 1 || result.Warnings[0] != "second page unavailable" {
+		t.Fatalf("unexpected warnings: %v", result.Warnings)
+	}
+	if result.Pagination.Complete || result.Pagination.NextToken != nil {
+		t.Fatalf("unexpected pagination: %+v", result.Pagination)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("JSON mode must keep diagnostics in the envelope, got stderr %q", stderr.String())
+	}
+}
+
+func TestBackupVaultsHumanOutputSendsWarningsToStderr(t *testing.T) {
+	original := loadBackupVaults
+	defer func() { loadBackupVaults = original }()
+	loadBackupVaults = func(context.Context) ([]awsservice.BackupVault, []error, error) {
+		return []awsservice.BackupVault{{Name: "prod", State: "AVAILABLE", Region: "us-east-1"}}, []error{errors.New("partial result")}, nil
+	}
+
+	cmd := NewRootCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"resources", "backup-vaults"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), "prod") || !strings.Contains(stderr.String(), "warning: partial result") {
+		t.Fatalf("unexpected output: stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -30,6 +30,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newInitCmd())
 	cmd.AddCommand(newContextCmd())
 	cmd.AddCommand(newECRCmd())
+	cmd.AddCommand(newResourcesCmd())
 	cmd.AddCommand(newEnvCmd())
 	cmd.AddCommand(newUpdateCmd())
 


### PR DESCRIPTION
### Summary

- add `unic resources backup-vaults` as the first read-only automation query
- provide a stable `--json` v1 envelope with data, warnings, and pagination status
- keep human output tabular and route partial-result warnings to stderr

### Related Issues

Closes #332

### Validation

- `make test`
- `make build`
- `go vet ./...`
- `go run ./cmd/unic resources backup-vaults --help`
- `git diff --check`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed
- [x] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented (none)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `resources backup-vaults` command to list AWS Backup vaults.
  * Added human-readable table output with warnings sent to stderr.
  * Added versioned JSON output with vault data, warnings, and pagination metadata.
  * Added support for selecting configuration context, profile, and region.
* **Documentation**
  * Documented the command, JSON format, output behavior, and automation usage.
  * Added development guidance for deterministic, versioned CLI JSON output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->