### PR TITLE
feat: expose CLI discovery contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ unic context sync dev-sso --dry-run
 unic context sync dev-sso --prune
 ```
 
+### Agent discovery
+
+AI agents and scripts can inspect supported AWS features and executable CLI commands without starting the TUI:
+
+```bash
+unic capabilities --json
+unic schema context sync --json
+```
+
+The deterministic v1 JSON includes command arguments, flags, read-only and destructive classifications, and each command's output contract version. Service data comes from the same catalog used by the TUI.
+
 `unic context setup` writes its prompts to `stderr` and copies the generated shell commands to the clipboard.
 `unic env` prints shell commands to `stdout` so it can be used with `eval`.
 `unic ecr login` prints a machine-usable container registry login command to `stdout` and can optionally copy it to the clipboard with `--copy`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,6 +8,17 @@ go test ./...
 make build
 ```
 
+## Machine-readable command discovery
+
+Use the registered Cobra command tree and domain catalog as the source of truth for automation contracts:
+
+```bash
+unic capabilities --json
+unic schema context sync --json
+```
+
+Discovery output is deterministic, versioned JSON. New executable commands should set the `unic.dev/read-only`, `unic.dev/destructive`, and `unic.dev/output-version` annotations when their defaults do not describe the command accurately.
+
 ## Branch Naming
 
 Use [`branch-naming-harness.md`](branch-naming-harness.md) for branch names.

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -51,7 +51,8 @@ func newContextSyncCmd() *cobra.Command {
 		Short: "Generate contexts from the accounts and roles visible to an SSO base context",
 		Long: "List the AWS accounts and roles visible to an SSO base context and add a sync-managed context for each pair. " +
 			"Existing contexts are never rewritten; sync-managed contexts whose account/role disappeared are reported and removed only with --prune.",
-		Args: cobra.MaximumNArgs(1),
+		Args:        cobra.MaximumNArgs(1),
+		Annotations: map[string]string{annotationDestructive: "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configPath, err := defaultPathFn()
 			if err != nil {
@@ -142,9 +143,10 @@ func printSyncPlan(out io.Writer, plan auth.ContextSyncPlan, prune, dryRun bool)
 
 func newContextOrderCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "order [context-name] [number]",
-		Short: "Set the display order for a context",
-		Args:  cobra.MaximumNArgs(2),
+		Use:         "order [context-name] [number]",
+		Short:       "Set the display order for a context",
+		Args:        cobra.MaximumNArgs(2),
+		Annotations: map[string]string{annotationReadOnly: "false"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configPath, err := defaultPathFn()
 			if err != nil {
@@ -203,9 +205,10 @@ func parseContextOrder(raw string) (int, error) {
 
 func newContextSetupCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "setup",
-		Short: "Interactively select a context and copy shell exports to the clipboard",
-		Long:  "Select a context, resolve any required SSO account/role and resource region, set it as current, and copy shell export commands to the clipboard.",
+		Use:         "setup",
+		Short:       "Interactively select a context and copy shell exports to the clipboard",
+		Long:        "Select a context, resolve any required SSO account/role and resource region, set it as current, and copy shell export commands to the clipboard.",
+		Annotations: map[string]string{annotationReadOnly: "false"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configPath, err := defaultPathFn()
 			if err != nil {
@@ -231,9 +234,10 @@ func newContextSetupCmd() *cobra.Command {
 
 func newContextUnsetCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "unset",
-		Short: "Clear the current context and copy shell cleanup commands to the clipboard",
-		Long:  "Remove the current context selection from config and copy AWS environment cleanup commands to the clipboard.",
+		Use:         "unset",
+		Short:       "Clear the current context and copy shell cleanup commands to the clipboard",
+		Long:        "Remove the current context selection from config and copy AWS environment cleanup commands to the clipboard.",
+		Annotations: map[string]string{annotationDestructive: "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configPath, err := defaultPathFn()
 			if err != nil {
@@ -261,9 +265,10 @@ func newContextUnsetCmd() *cobra.Command {
 
 func newEnvCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "env [context-name]",
-		Short: "Print shell exports for the current or named context",
-		Args:  cobra.MaximumNArgs(1),
+		Use:         "env [context-name]",
+		Short:       "Print shell exports for the current or named context",
+		Args:        cobra.MaximumNArgs(1),
+		Annotations: map[string]string{annotationReadOnly: "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configPath, err := defaultPathFn()
 			if err != nil {

--- a/internal/cli/discovery.go
+++ b/internal/cli/discovery.go
@@ -1,0 +1,208 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"unic/internal/domain"
+)
+
+const (
+	discoverySchemaVersion  = "v1"
+	annotationReadOnly      = "unic.dev/read-only"
+	annotationDestructive   = "unic.dev/destructive"
+	annotationOutputVersion = "unic.dev/output-version"
+)
+
+type capabilityDocument struct {
+	SchemaVersion string              `json:"schema_version"`
+	Services      []capabilityService `json:"services"`
+	Commands      []commandContract   `json:"commands"`
+}
+
+type capabilityService struct {
+	Name     string              `json:"name"`
+	Features []capabilityFeature `json:"features"`
+}
+
+type capabilityFeature struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type commandContract struct {
+	SchemaVersion string            `json:"schema_version"`
+	Path          string            `json:"path"`
+	Description   string            `json:"description"`
+	Arguments     []commandArgument `json:"arguments"`
+	Flags         []commandFlag     `json:"flags"`
+	ReadOnly      bool              `json:"read_only"`
+	Destructive   bool              `json:"destructive"`
+	OutputVersion string            `json:"output_version"`
+}
+
+type commandArgument struct {
+	Name     string `json:"name"`
+	Required bool   `json:"required"`
+}
+
+type commandFlag struct {
+	Name      string `json:"name"`
+	Shorthand string `json:"shorthand,omitempty"`
+	Type      string `json:"type"`
+	Default   string `json:"default"`
+	Required  bool   `json:"required"`
+}
+
+func newCapabilitiesCmd(root *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:         "capabilities",
+		Short:       "Describe supported AWS features and automation commands",
+		Args:        cobra.NoArgs,
+		Annotations: discoveryAnnotations(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return writeJSON(cmd, buildCapabilityDocument(root))
+		},
+	}
+	cmd.Flags().Bool("json", false, "Print the v1 machine-readable contract")
+	_ = cmd.MarkFlagRequired("json")
+	return cmd
+}
+
+func newSchemaCmd(root *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:         "schema <command> [subcommand...]",
+		Short:       "Describe one automation command contract",
+		Args:        cobra.MinimumNArgs(1),
+		Annotations: discoveryAnnotations(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target := findCommand(root, args)
+			if target == nil || target.Run == nil && target.RunE == nil {
+				return fmt.Errorf("command %q not found or is not executable", strings.Join(args, " "))
+			}
+			return writeJSON(cmd, contractFor(target))
+		},
+	}
+	cmd.Flags().Bool("json", false, "Print the v1 machine-readable contract")
+	_ = cmd.MarkFlagRequired("json")
+	return cmd
+}
+
+func discoveryAnnotations() map[string]string {
+	return map[string]string{
+		annotationReadOnly:      "true",
+		annotationDestructive:   "false",
+		annotationOutputVersion: discoverySchemaVersion,
+	}
+}
+
+func buildCapabilityDocument(root *cobra.Command) capabilityDocument {
+	services := make([]capabilityService, 0, len(domain.Catalog()))
+	for _, service := range domain.Catalog() {
+		features := make([]capabilityFeature, 0, len(service.Features))
+		for _, feature := range service.Features {
+			features = append(features, capabilityFeature{Name: string(feature.Kind), Description: feature.Description})
+		}
+		sort.Slice(features, func(i, j int) bool { return features[i].Name < features[j].Name })
+		services = append(services, capabilityService{Name: string(service.Name), Features: features})
+	}
+	sort.Slice(services, func(i, j int) bool { return services[i].Name < services[j].Name })
+
+	var commands []commandContract
+	var walk func(*cobra.Command)
+	walk = func(parent *cobra.Command) {
+		for _, cmd := range parent.Commands() {
+			if cmd.Hidden {
+				continue
+			}
+			if cmd.Run != nil || cmd.RunE != nil {
+				commands = append(commands, contractFor(cmd))
+			}
+			walk(cmd)
+		}
+	}
+	walk(root)
+	sort.Slice(commands, func(i, j int) bool { return commands[i].Path < commands[j].Path })
+
+	return capabilityDocument{SchemaVersion: discoverySchemaVersion, Services: services, Commands: commands}
+}
+
+func contractFor(cmd *cobra.Command) commandContract {
+	outputVersion := cmd.Annotations[annotationOutputVersion]
+	if outputVersion == "" {
+		outputVersion = "unversioned"
+	}
+	return commandContract{
+		SchemaVersion: discoverySchemaVersion,
+		Path:          cmd.CommandPath(),
+		Description:   cmd.Short,
+		Arguments:     commandArguments(cmd.Use),
+		Flags:         commandFlags(cmd),
+		ReadOnly:      cmd.Annotations[annotationReadOnly] == "true",
+		Destructive:   cmd.Annotations[annotationDestructive] == "true",
+		OutputVersion: outputVersion,
+	}
+}
+
+func commandArguments(use string) []commandArgument {
+	fields := strings.Fields(use)
+	arguments := make([]commandArgument, 0, max(len(fields)-1, 0))
+	for _, field := range fields[1:] {
+		optional := strings.HasPrefix(field, "[")
+		name := strings.Trim(field, "[]<>")
+		name = strings.TrimSuffix(name, "...")
+		arguments = append(arguments, commandArgument{Name: name, Required: !optional})
+	}
+	return arguments
+}
+
+func commandFlags(cmd *cobra.Command) []commandFlag {
+	byName := make(map[string]commandFlag)
+	collect := func(flag *pflag.Flag) {
+		if flag.Name == "help" {
+			return
+		}
+		byName[flag.Name] = commandFlag{
+			Name: flag.Name, Shorthand: flag.Shorthand, Type: flag.Value.Type(), Default: flag.DefValue,
+			Required: len(flag.Annotations[cobra.BashCompOneRequiredFlag]) > 0,
+		}
+	}
+	cmd.Flags().VisitAll(collect)
+	cmd.InheritedFlags().VisitAll(collect)
+	flags := make([]commandFlag, 0, len(byName))
+	for _, flag := range byName {
+		flags = append(flags, flag)
+	}
+	sort.Slice(flags, func(i, j int) bool { return flags[i].Name < flags[j].Name })
+	return flags
+}
+
+func findCommand(root *cobra.Command, names []string) *cobra.Command {
+	current := root
+	for _, name := range names {
+		var next *cobra.Command
+		for _, candidate := range current.Commands() {
+			if candidate.Name() == name {
+				next = candidate
+				break
+			}
+		}
+		if next == nil {
+			return nil
+		}
+		current = next
+	}
+	return current
+}
+
+func writeJSON(cmd *cobra.Command, value any) error {
+	encoder := json.NewEncoder(cmd.OutOrStdout())
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(value)
+}

--- a/internal/cli/discovery_test.go
+++ b/internal/cli/discovery_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestCapabilitiesJSONIsDeterministicAndUsesCatalog(t *testing.T) {
+	first := executeDiscovery(t, "capabilities", "--json")
+	second := executeDiscovery(t, "capabilities", "--json")
+	if first != second {
+		t.Fatal("capabilities output should be deterministic")
+	}
+
+	var document capabilityDocument
+	if err := json.Unmarshal([]byte(first), &document); err != nil {
+		t.Fatalf("decode capabilities: %v", err)
+	}
+	if document.SchemaVersion != discoverySchemaVersion {
+		t.Fatalf("schema version = %q, want %q", document.SchemaVersion, discoverySchemaVersion)
+	}
+	if len(document.Services) == 0 || len(document.Commands) == 0 {
+		t.Fatalf("expected services and commands, got %#v", document)
+	}
+	for i := 1; i < len(document.Services); i++ {
+		if document.Services[i-1].Name > document.Services[i].Name {
+			t.Fatalf("services are not sorted: %q before %q", document.Services[i-1].Name, document.Services[i].Name)
+		}
+	}
+}
+
+func TestSchemaDescribesRegisteredCommand(t *testing.T) {
+	output := executeDiscovery(t, "schema", "context", "sync", "--json")
+	var contract commandContract
+	if err := json.Unmarshal([]byte(output), &contract); err != nil {
+		t.Fatalf("decode schema: %v", err)
+	}
+
+	wantArgs := []commandArgument{{Name: "base-context", Required: false}}
+	if contract.Path != "unic context sync" || !reflect.DeepEqual(contract.Arguments, wantArgs) {
+		t.Fatalf("unexpected contract: %#v", contract)
+	}
+	if contract.ReadOnly || !contract.Destructive {
+		t.Fatalf("context sync safety classification = read_only:%t destructive:%t", contract.ReadOnly, contract.Destructive)
+	}
+	if !hasFlag(contract.Flags, "dry-run") || !hasFlag(contract.Flags, "profile") {
+		t.Fatalf("expected local and inherited flags, got %#v", contract.Flags)
+	}
+}
+
+func TestSchemaRejectsUnknownOrNonExecutableCommand(t *testing.T) {
+	for _, args := range [][]string{{"schema", "missing", "--json"}, {"schema", "context", "--json"}} {
+		cmd := NewRootCmd()
+		cmd.SetArgs(args)
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		if err := cmd.Execute(); err == nil {
+			t.Fatalf("Execute(%v) succeeded, want error", args)
+		}
+	}
+}
+
+func executeDiscovery(t *testing.T, args ...string) string {
+	t.Helper()
+	cmd := NewRootCmd()
+	var output bytes.Buffer
+	cmd.SetArgs(args)
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute(%v): %v\n%s", args, err, output.String())
+	}
+	return output.String()
+}
+
+func hasFlag(flags []commandFlag, name string) bool {
+	for _, flag := range flags {
+		if flag.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/ecr.go
+++ b/internal/cli/ecr.go
@@ -35,8 +35,9 @@ func newECRLoginCmd() *cobra.Command {
 	var copyToClipboard bool
 
 	cmd := &cobra.Command{
-		Use:   "login",
-		Short: "Print an ECR login command for the current AWS context",
+		Use:         "login",
+		Short:       "Print an ECR login command for the current AWS context",
+		Annotations: map[string]string{annotationReadOnly: "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configPath, err := ecrDefaultPathFn()
 			if err != nil {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -12,9 +12,10 @@ func newInitCmd() *cobra.Command {
 	var force bool
 
 	cmd := &cobra.Command{
-		Use:   "init",
-		Short: "Initialize unic config file",
-		Long:  "Create the default config file at ~/.config/unic/config.yaml (or $XDG_CONFIG_HOME/unic/config.yaml).",
+		Use:         "init",
+		Short:       "Initialize unic config file",
+		Long:        "Create the default config file at ~/.config/unic/config.yaml (or $XDG_CONFIG_HOME/unic/config.yaml).",
+		Annotations: map[string]string{annotationDestructive: "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configPath, err := config.DefaultPath()
 			if err != nil {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -32,6 +32,8 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newECRCmd())
 	cmd.AddCommand(newEnvCmd())
 	cmd.AddCommand(newUpdateCmd())
+	cmd.AddCommand(newCapabilitiesCmd(cmd))
+	cmd.AddCommand(newSchemaCmd(cmd))
 
 	return cmd
 }

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -10,9 +10,10 @@ import (
 
 func newUpdateCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update",
-		Short: "Update unic to the latest version",
-		Long:  "Check for the latest release on GitHub and replace the current binary in-place.",
+		Use:         "update",
+		Short:       "Update unic to the latest version",
+		Long:        "Check for the latest release on GitHub and replace the current binary in-place.",
+		Annotations: map[string]string{annotationDestructive: "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Printf("Current version: %s\n", Version)
 			fmt.Println("Checking for updates...")


### PR DESCRIPTION
### Summary

- add deterministic `unic capabilities --json` output backed by the domain catalog and registered Cobra commands
- add `unic schema <command> --json` with arguments, flags, safety classification, and output version
- document the v1 agent discovery contract

### Related Issues

Closes #333

### Validation

- `make test`
- `make build`
- `go vet ./...`
- `go run ./cmd/unic capabilities --json`
- `go run ./cmd/unic schema context sync --json`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed
- [x] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented