### PR TITLE
feat: add safe mutation protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ unic context unset
 # Generate contexts from the accounts/roles visible to an SSO base context
 unic context sync
 unic context sync dev-sso --dry-run
-unic context sync dev-sso --prune
+unic context sync dev-sso --json
+unic context sync dev-sso --apply --confirm dev-sso
+unic context sync dev-sso --prune --apply --confirm dev-sso
 ```
 
 `unic context setup` writes its prompts to `stderr` and copies the generated shell commands to the clipboard.
@@ -125,7 +127,7 @@ Both flows now include a `UNIC_CONTEXT` marker in the generated exports so the T
 Contexts can be prioritized in the setup picker with an `order` field in config.
 In the CLI `unic context setup` flow, the picker filters contexts, SSO accounts, SSO roles, and configured resource regions as you type, with arrow-key navigation and Enter to confirm. Multi-region contexts prompt for the shell session region after account/role selection; single-region contexts skip that step. The selection changes `AWS_REGION` and `AWS_DEFAULT_REGION` in the generated exports without modifying the context's persisted default region.
 Use `unic context order` to open reorder mode, choose a context with `↑/↓` or `j/k`, press `Enter` to start moving it, then press `Enter` again to save. `unic context order <name> <number>` still works for direct updates.
-`unic context sync [base-context]` lists the AWS accounts and roles visible to an SSO base context and adds a sync-managed concrete context for each new account/role pair, inheriting the base context's regions. When only one SSO base context exists the argument can be omitted. Existing contexts are never rewritten: pairs that already have a context (manual or synced) are kept as-is. Synced contexts carry a `sync_source: <base-context>` marker in `config.yaml`; when their account/role disappears from SSO they are reported as orphans and removed only with `--prune`. Use `--dry-run` to preview the plan without writing config.
+`unic context sync [base-context]` lists the AWS accounts and roles visible to an SSO base context and previews a sync plan without writing config. Apply the plan explicitly with `--apply --confirm <base-context>`; add `--prune` to remove sync-managed contexts that disappeared from SSO. Existing contexts are never rewritten, and new contexts inherit the base context's regions. Use `--json` for a stable v1 plan/result contract containing `before`, `after`, `changed`, and an optional rollback hint. JSON failures include a stable error code, message, retryability, and the required AWS permission when known; machine-readable output stays on stdout while diagnostics use stderr.
 
 ## Configuration
 

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -46,7 +46,9 @@ Owns non-TUI commands:
   - generates a sync-managed context for every account/role pair visible to an SSO base context
   - generated contexts carry a `sync_source` marker to stay distinguishable from manual ones
   - sync-managed contexts whose account/role disappeared are reported as orphans and removed only with `--prune`
-  - `--dry-run` prints the plan without writing config
+  - previews the plan without writing config by default
+  - `--apply --confirm <base-context>` explicitly applies a plan; `--prune` includes orphan removal
+  - `--json` emits stable v1 plan/result/error contracts for automation
 - `unic context unset`
 
 ### `internal/config/`

--- a/docs/architecture.ko.md
+++ b/docs/architecture.ko.md
@@ -46,7 +46,9 @@ cmd/unic/main.go
   - SSO base context에 보이는 account/role 조합마다 sync-managed context를 생성
   - 생성된 context는 `sync_source` marker로 수동 context와 구분
   - 사라진 account/role의 sync-managed context는 orphan으로 보고하고 `--prune`일 때만 삭제
-  - `--dry-run`으로 config를 쓰지 않고 plan만 출력
+  - 기본 동작으로 config를 쓰지 않고 plan만 출력
+  - `--apply --confirm <base-context>`로 plan을 명시적으로 적용하며 `--prune`은 orphan 제거를 포함
+  - `--json`으로 자동화용 stable v1 plan/result/error contract 출력
 - `unic context unset`
 
 ### `internal/config/`

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -79,7 +79,11 @@ func newContextSyncCmd() *cobra.Command {
 				if jsonOutput {
 					return json.NewEncoder(cmd.OutOrStdout()).Encode(contract)
 				}
-				printSyncPlan(cmd.OutOrStdout(), plan, prune, true)
+				suffix := " (preview, nothing written)"
+				if dryRun {
+					suffix = " (dry run, nothing written)"
+				}
+				printSyncPlan(cmd.OutOrStdout(), plan, prune, suffix)
 				return nil
 			}
 			if confirmation != base.Name {
@@ -96,7 +100,7 @@ func newContextSyncCmd() *cobra.Command {
 					RollbackHint: "restore the previous config file from backup or version control",
 				})
 			}
-			printSyncPlan(cmd.OutOrStdout(), plan, prune, false)
+			printSyncPlan(cmd.OutOrStdout(), plan, prune, "")
 			return nil
 		},
 	}
@@ -177,7 +181,7 @@ func resolveSyncBase(configPath string, args []string) (config.ContextInfo, erro
 	}
 }
 
-func printSyncPlan(out io.Writer, plan auth.ContextSyncPlan, prune, dryRun bool) {
+func printSyncPlan(out io.Writer, plan auth.ContextSyncPlan, prune bool, suffix string) {
 	for _, entry := range plan.Add {
 		fmt.Fprintf(out, "add:    %s\n", entry.Name)
 	}
@@ -187,10 +191,6 @@ func printSyncPlan(out io.Writer, plan auth.ContextSyncPlan, prune, dryRun bool)
 			action = "remove"
 		}
 		fmt.Fprintf(out, "%s: %s\n", action, name)
-	}
-	suffix := ""
-	if dryRun {
-		suffix = " (dry run, nothing written)"
 	}
 	fmt.Fprintf(out, "sync %s: %d added, %d kept, %d orphaned%s\n", plan.Base, len(plan.Add), len(plan.Keep), len(plan.Orphans), suffix)
 	if !prune && len(plan.Orphans) > 0 {

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -92,7 +92,7 @@ func newContextSyncCmd() *cobra.Command {
 			if jsonOutput {
 				return json.NewEncoder(cmd.OutOrStdout()).Encode(MutationResult{
 					Version: "v1", Operation: contract.Operation, Resource: contract.Resource,
-					Changed: len(plan.Add) > 0 || prune && len(plan.Orphans) > 0, Before: contract.Before, After: contract.After,
+					Changed: len(plan.Add) > 0 || (prune && len(plan.Orphans) > 0), Before: contract.Before, After: contract.After,
 					RollbackHint: "restore the previous config file from backup or version control",
 				})
 			}

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -45,39 +47,95 @@ func newContextCmd() *cobra.Command {
 }
 
 func newContextSyncCmd() *cobra.Command {
-	var prune, dryRun bool
+	var prune, dryRun, apply, jsonOutput bool
+	var confirmation string
 	cmd := &cobra.Command{
 		Use:   "sync [base-context]",
-		Short: "Generate contexts from the accounts and roles visible to an SSO base context",
-		Long: "List the AWS accounts and roles visible to an SSO base context and add a sync-managed context for each pair. " +
-			"Existing contexts are never rewritten; sync-managed contexts whose account/role disappeared are reported and removed only with --prune.",
+		Short: "Plan or apply contexts from the accounts and roles visible to an SSO base context",
+		Long: "Build a plan for the accounts and roles visible to an SSO base context. Apply it only with --apply and --confirm. " +
+			"Existing contexts are never rewritten; sync-managed contexts whose account/role disappeared are removed only when applying with --prune.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if dryRun && apply {
+				return writeMutationError(cmd, fmt.Errorf("--dry-run and --apply cannot be used together"), jsonOutput, "")
+			}
 			configPath, err := defaultPathFn()
 			if err != nil {
-				return err
+				return writeMutationError(cmd, err, jsonOutput, "")
 			}
 			if err := ensureConfigExistsFn(configPath); err != nil {
-				return err
+				return writeMutationError(cmd, err, jsonOutput, "")
 			}
 			base, err := resolveSyncBase(configPath, args)
 			if err != nil {
-				return err
+				return writeMutationError(cmd, err, jsonOutput, "")
 			}
 			plan, err := buildSyncPlanFn(context.Background(), configPath, base)
 			if err != nil {
-				return err
+				return writeMutationError(cmd, err, jsonOutput, "sso:ListAccounts,sso:ListAccountRoles")
 			}
-			printSyncPlan(cmd.OutOrStdout(), plan, prune, dryRun)
-			if dryRun {
+			contract := contextSyncMutationPlan(plan, prune)
+			if !apply {
+				if jsonOutput {
+					return json.NewEncoder(cmd.OutOrStdout()).Encode(contract)
+				}
+				printSyncPlan(cmd.OutOrStdout(), plan, prune, true)
 				return nil
 			}
-			return applySyncPlanFn(configPath, plan, prune)
+			if confirmation != base.Name {
+				err := fmt.Errorf("%w: pass --confirm %s", errConfirmationMismatch, base.Name)
+				return writeMutationError(cmd, err, jsonOutput, "")
+			}
+			if err := applySyncPlanFn(configPath, plan, prune); err != nil {
+				return writeMutationError(cmd, err, jsonOutput, "")
+			}
+			if jsonOutput {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(MutationResult{
+					Version: "v1", Operation: contract.Operation, Resource: contract.Resource,
+					Changed: len(plan.Add) > 0 || prune && len(plan.Orphans) > 0, Before: contract.Before, After: contract.After,
+					RollbackHint: "restore the previous config file from backup or version control",
+				})
+			}
+			printSyncPlan(cmd.OutOrStdout(), plan, prune, false)
+			return nil
 		},
 	}
 	cmd.Flags().BoolVar(&prune, "prune", false, "remove sync-managed contexts whose SSO account/role is no longer visible")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show the sync plan without writing config")
+	cmd.Flags().BoolVar(&apply, "apply", false, "apply the sync plan")
+	cmd.Flags().StringVar(&confirmation, "confirm", "", "confirm execution by repeating the base context name")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "write the plan, result, or error as JSON")
 	return cmd
+}
+
+type contextSyncSnapshot struct {
+	Contexts []string `json:"contexts"`
+}
+
+func contextSyncMutationPlan(plan auth.ContextSyncPlan, prune bool) MutationPlan {
+	before := append(append([]string{}, plan.Keep...), plan.Orphans...)
+	after := append([]string{}, plan.Keep...)
+	for _, entry := range plan.Add {
+		after = append(after, entry.Name)
+	}
+	if !prune {
+		after = append(after, plan.Orphans...)
+	}
+	sort.Strings(before)
+	sort.Strings(after)
+	return MutationPlan{
+		Version: "v1", Operation: "context.sync", Resource: plan.Base,
+		Before: contextSyncSnapshot{Contexts: before}, After: contextSyncSnapshot{Contexts: after}, Confirmation: plan.Base,
+	}
+}
+
+func writeMutationError(cmd *cobra.Command, err error, jsonOutput bool, permission string) error {
+	if jsonOutput {
+		if encodeErr := json.NewEncoder(cmd.OutOrStdout()).Encode(mutationError(err, permission)); encodeErr != nil {
+			return encodeErr
+		}
+	}
+	return err
 }
 
 func resolveSyncBase(configPath string, args []string) (config.ContextInfo, error) {

--- a/internal/cli/context_sync_test.go
+++ b/internal/cli/context_sync_test.go
@@ -3,8 +3,12 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/aws/smithy-go"
 
 	"unic/internal/auth"
 	"unic/internal/config"
@@ -51,15 +55,15 @@ func baseSSOContexts() []config.ContextInfo {
 func runContextSync(t *testing.T, args ...string) (string, error) {
 	t.Helper()
 	cmd := NewRootCmd()
-	var out bytes.Buffer
+	var out, errOut bytes.Buffer
 	cmd.SetOut(&out)
-	cmd.SetErr(&out)
+	cmd.SetErr(&errOut)
 	cmd.SetArgs(append([]string{"context", "sync"}, args...))
 	err := cmd.Execute()
 	return out.String(), err
 }
 
-func TestContextSyncAppliesPlanAndPrintsSummary(t *testing.T) {
+func TestContextSyncPrintsPlanWithoutApplying(t *testing.T) {
 	plan := auth.ContextSyncPlan{
 		Base:    "dev-sso",
 		Add:     []config.ContextEntry{{Name: "dev-sso-333333333333-developerrole"}},
@@ -72,13 +76,13 @@ func TestContextSyncAppliesPlanAndPrintsSummary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !*applied || *pruned {
-		t.Fatalf("expected plan applied without prune, applied=%v pruned=%v", *applied, *pruned)
+	if *applied || *pruned {
+		t.Fatalf("expected plan only, applied=%v pruned=%v", *applied, *pruned)
 	}
 	for _, want := range []string{
 		"add:    dev-sso-333333333333-developerrole",
 		"orphan: dev-sso-222222222222-stale",
-		"sync dev-sso: 1 added, 1 kept, 1 orphaned",
+		"sync dev-sso: 1 added, 1 kept, 1 orphaned (dry run, nothing written)",
 		"use --prune",
 	} {
 		if !strings.Contains(out, want) {
@@ -108,7 +112,7 @@ func TestContextSyncPruneFlagPassesThrough(t *testing.T) {
 		Orphans: []string{"dev-sso-222222222222-stale"},
 	})
 
-	out, err := runContextSync(t, "--prune")
+	out, err := runContextSync(t, "--prune", "--apply", "--confirm", "dev-sso")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -117,6 +121,102 @@ func TestContextSyncPruneFlagPassesThrough(t *testing.T) {
 	}
 	if !strings.Contains(out, "remove: dev-sso-222222222222-stale") {
 		t.Fatalf("expected remove line in output, got:\n%s", out)
+	}
+}
+
+func TestContextSyncRejectsConfirmationMismatch(t *testing.T) {
+	applied, _ := stubSyncSeams(t, baseSSOContexts(), auth.ContextSyncPlan{Base: "dev-sso"})
+
+	if _, err := runContextSync(t, "--apply", "--confirm", "wrong"); err == nil || !strings.Contains(err.Error(), "confirmation mismatch") {
+		t.Fatalf("expected confirmation mismatch, got %v", err)
+	}
+	if *applied {
+		t.Fatal("confirmation mismatch must not apply")
+	}
+}
+
+func TestContextSyncJSONConfirmationMismatchHasStableCode(t *testing.T) {
+	stubSyncSeams(t, baseSSOContexts(), auth.ContextSyncPlan{Base: "dev-sso"})
+	out, err := runContextSync(t, "--json", "--apply", "--confirm", "wrong")
+	if err == nil {
+		t.Fatal("expected confirmation mismatch")
+	}
+	var got StructuredError
+	if decodeErr := json.Unmarshal([]byte(out), &got); decodeErr != nil {
+		t.Fatalf("invalid error JSON: %v\n%s", decodeErr, out)
+	}
+	if got.Code != "confirmation_mismatch" || got.Retryable {
+		t.Fatalf("unexpected error: %#v", got)
+	}
+}
+
+func TestContextSyncJSONPlanAndApplyResult(t *testing.T) {
+	plan := auth.ContextSyncPlan{Base: "dev-sso", Add: []config.ContextEntry{{Name: "new-context"}}}
+	applied, _ := stubSyncSeams(t, baseSSOContexts(), plan)
+
+	out, err := runContextSync(t, "--json")
+	if err != nil {
+		t.Fatalf("plan failed: %v", err)
+	}
+	var preview MutationPlan
+	if err := json.Unmarshal([]byte(out), &preview); err != nil {
+		t.Fatalf("invalid plan JSON: %v\n%s", err, out)
+	}
+	if preview.Version != "v1" || preview.Operation != "context.sync" || preview.Confirmation != "dev-sso" || *applied {
+		t.Fatalf("unexpected preview: %#v applied=%v", preview, *applied)
+	}
+
+	out, err = runContextSync(t, "--json", "--apply", "--confirm", "dev-sso")
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	var result MutationResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("invalid result JSON: %v\n%s", err, out)
+	}
+	if !result.Changed || result.RollbackHint == "" || !*applied {
+		t.Fatalf("unexpected result: %#v applied=%v", result, *applied)
+	}
+}
+
+func TestContextSyncJSONErrorsClassifyRetryAndPermission(t *testing.T) {
+	tests := []struct {
+		name       string
+		apiError   error
+		retryable  bool
+		permission bool
+	}{
+		{name: "retryable", apiError: &smithy.GenericAPIError{Code: "ThrottlingException", Message: "slow down", Fault: smithy.FaultClient}, retryable: true},
+		{name: "permission", apiError: &smithy.GenericAPIError{Code: "AccessDeniedException", Message: "denied", Fault: smithy.FaultClient}, permission: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stubSyncSeams(t, baseSSOContexts(), auth.ContextSyncPlan{})
+			orig := buildSyncPlanFn
+			buildSyncPlanFn = func(context.Context, string, config.ContextInfo) (auth.ContextSyncPlan, error) {
+				return auth.ContextSyncPlan{}, tt.apiError
+			}
+			t.Cleanup(func() { buildSyncPlanFn = orig })
+
+			out, err := runContextSync(t, "--json")
+			if err == nil {
+				t.Fatal("expected failure")
+			}
+			var got StructuredError
+			if decodeErr := json.Unmarshal([]byte(out), &got); decodeErr != nil {
+				t.Fatalf("invalid error JSON: %v\n%s", decodeErr, out)
+			}
+			if got.Retryable != tt.retryable || (got.RequiredPermission != "") != tt.permission {
+				t.Fatalf("unexpected error: %#v", got)
+			}
+		})
+	}
+}
+
+func TestMutationErrorHandlesOrdinaryErrors(t *testing.T) {
+	got := mutationError(errors.New("broken"), "")
+	if got.Code != "operation_failed" || got.Message != "broken" || got.Retryable {
+		t.Fatalf("unexpected error: %#v", got)
 	}
 }
 

--- a/internal/cli/context_sync_test.go
+++ b/internal/cli/context_sync_test.go
@@ -190,6 +190,7 @@ func TestContextSyncJSONErrorsClassifyRetryAndPermission(t *testing.T) {
 		permission bool
 	}{
 		{name: "retryable", apiError: &smithy.GenericAPIError{Code: "ThrottlingException", Message: "slow down", Fault: smithy.FaultClient}, retryable: true},
+		{name: "service unavailable", apiError: &smithy.GenericAPIError{Code: "ServiceUnavailableException", Message: "try later", Fault: smithy.FaultClient}, retryable: true},
 		{name: "permission", apiError: &smithy.GenericAPIError{Code: "AccessDeniedException", Message: "denied", Fault: smithy.FaultClient}, permission: true},
 	}
 	for _, tt := range tests {

--- a/internal/cli/context_sync_test.go
+++ b/internal/cli/context_sync_test.go
@@ -82,7 +82,7 @@ func TestContextSyncPrintsPlanWithoutApplying(t *testing.T) {
 	for _, want := range []string{
 		"add:    dev-sso-333333333333-developerrole",
 		"orphan: dev-sso-222222222222-stale",
-		"sync dev-sso: 1 added, 1 kept, 1 orphaned (dry run, nothing written)",
+		"sync dev-sso: 1 added, 1 kept, 1 orphaned (preview, nothing written)",
 		"use --prune",
 	} {
 		if !strings.Contains(out, want) {
@@ -103,6 +103,9 @@ func TestContextSyncDryRunDoesNotApply(t *testing.T) {
 	}
 	if !strings.Contains(out, "dry run, nothing written") {
 		t.Fatalf("expected dry-run marker in output, got:\n%s", out)
+	}
+	if strings.Contains(out, "preview, nothing written") {
+		t.Fatalf("explicit dry run should not use the default preview marker, got:\n%s", out)
 	}
 }
 

--- a/internal/cli/mutation.go
+++ b/internal/cli/mutation.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/aws/smithy-go"
+)
+
+var errConfirmationMismatch = errors.New("confirmation mismatch")
+
+// MutationPlan is the stable contract returned before a non-interactive change.
+type MutationPlan struct {
+	Version      string `json:"version"`
+	Operation    string `json:"operation"`
+	Resource     string `json:"resource"`
+	Before       any    `json:"before"`
+	After        any    `json:"after"`
+	Confirmation string `json:"confirmation"`
+}
+
+// MutationResult is the stable contract returned after applying a plan.
+type MutationResult struct {
+	Version      string `json:"version"`
+	Operation    string `json:"operation"`
+	Resource     string `json:"resource"`
+	Changed      bool   `json:"changed"`
+	Before       any    `json:"before"`
+	After        any    `json:"after"`
+	RollbackHint string `json:"rollback_hint,omitempty"`
+}
+
+// StructuredError is the machine-readable error contract for automation.
+type StructuredError struct {
+	Code               string `json:"code"`
+	Message            string `json:"message"`
+	Retryable          bool   `json:"retryable"`
+	RequiredPermission string `json:"required_permission,omitempty"`
+}
+
+func mutationError(err error, permission string) StructuredError {
+	result := StructuredError{Code: "operation_failed", Message: err.Error()}
+	if errors.Is(err, errConfirmationMismatch) {
+		result.Code = "confirmation_mismatch"
+		return result
+	}
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return result
+	}
+
+	result.Code = apiErr.ErrorCode()
+	code := strings.ToLower(result.Code)
+	result.Retryable = apiErr.ErrorFault() == smithy.FaultServer || strings.Contains(code, "throttl") || strings.Contains(code, "timeout")
+	if strings.Contains(code, "accessdenied") || strings.Contains(code, "unauthorized") || strings.Contains(code, "forbidden") {
+		result.RequiredPermission = permission
+	}
+	return result
+}

--- a/internal/cli/mutation.go
+++ b/internal/cli/mutation.go
@@ -51,7 +51,7 @@ func mutationError(err error, permission string) StructuredError {
 
 	result.Code = apiErr.ErrorCode()
 	code := strings.ToLower(result.Code)
-	result.Retryable = apiErr.ErrorFault() == smithy.FaultServer || strings.Contains(code, "throttl") || strings.Contains(code, "timeout")
+	result.Retryable = apiErr.ErrorFault() == smithy.FaultServer || strings.Contains(code, "throttl") || strings.Contains(code, "timeout") || strings.Contains(code, "serviceunavailable")
 	if strings.Contains(code, "accessdenied") || strings.Contains(code, "unauthorized") || strings.Contains(code, "forbidden") {
 		result.RequiredPermission = permission
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -16,10 +16,11 @@ var (
 
 func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "unic",
-		Short:   "AWS DevOps TUI tool",
-		Long:    "unic is a TUI tool for browsing and managing AWS resources in the terminal.",
-		Version: Version,
+		Use:          "unic",
+		Short:        "AWS DevOps TUI tool",
+		Long:         "unic is a TUI tool for browsing and managing AWS resources in the terminal.",
+		Version:      Version,
+		SilenceUsage: true,
 	}
 
 	cmd.PersistentFlags().StringVarP(&profile, "profile", "p", "", "AWS profile to use")


### PR DESCRIPTION
### Summary

- add shared v1 plan, result, and structured error contracts for non-interactive mutations
- make `context sync` preview-only by default and require `--apply --confirm <base-context>` before writing configuration
- add JSON output with retryability and required-permission metadata, plus safe automation documentation

### Related Issues

Closes #334

### Validation

- `make test`
- `make build`
- `go vet ./...`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed
- [x] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented