### PR TITLE
fix: derive local build version from Git

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 APP_NAME := unic
-VERSION  := 0.1.3
+VERSION  ?= $(shell git describe --tags --always --dirty 2>/dev/null)
+VERSION  := $(if $(VERSION),$(patsubst v%,%,$(VERSION)),dev)
 DIST_DIR := dist
 CMD_PATH := ./cmd/unic
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,6 +8,8 @@ go test ./...
 make build
 ```
 
+`make build` derives the CLI version from `git describe`; use an explicit override such as `make build VERSION=0.3.1` for reproducible packaging outside a tagged checkout.
+
 ## Machine-readable command discovery
 
 Use the registered Cobra command tree and domain catalog as the source of truth for automation contracts:


### PR DESCRIPTION
### Summary

- derive local build versions from the nearest Git tag instead of stale `0.1.3`
- preserve explicit `VERSION=...` overrides for reproducible packaging
- document the local version behavior

### Related Issues

Closes #338

### Validation

- `make test`
- `make build`
- `go vet ./...`
- `./unic --version`
- `make -n build VERSION=0.3.1`

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed (not required)
- [x] Relevant `docs/` pages updated
- [x] Tests/validation included
- [x] Breaking changes documented (none)
