### PR TITLE
feat: add stdio MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,28 @@ Use `unic context order` to open reorder mode, choose a context with `↑/↓` o
 
 For automation, `unic resources backup-vaults --json` lists AWS Backup vaults using the active context (or `--profile` / `--region`) without starting the TUI. The versioned JSON envelope contains `data`, partial-result `warnings`, and pagination metadata; stdout contains only JSON. Without `--json`, the command prints a compact table and sends warnings to stderr. This CLI is a secondary scripting surface; interactive workflows remain TUI-first.
 
+### MCP server
+
+Build or install the stdio MCP server for local AI agents:
+
+```bash
+go install ./cmd/unic-mcp
+```
+
+Example client configuration:
+
+```json
+{
+  "mcpServers": {
+    "unic": {
+      "command": "unic-mcp"
+    }
+  }
+}
+```
+
+The server exposes capability discovery, command schemas, AWS Backup vault listing, and SSO context-sync planning through the same versioned CLI contracts described above. It reads the existing unic/AWS configuration from the server process environment. The context-sync tool is preview-only: it never passes `--apply` or writes configuration.
+
 ## Configuration
 
 Primary config path:

--- a/cmd/unic-mcp/main.go
+++ b/cmd/unic-mcp/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"unic/internal/cli"
+	"unic/internal/mcp"
+)
+
+func main() {
+	server := mcp.New(cli.Version, cli.ExecuteAutomation)
+	if err := server.Serve(context.Background(), os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -21,6 +21,8 @@ Discovery output is deterministic, versioned JSON. New executable commands shoul
 
 Read-only automation commands live under `internal/cli/`; keep their `--json` output versioned and deterministic, write only JSON to stdout, and cover human and JSON output paths with CLI tests.
 
+The stdio MCP entry point lives at `cmd/unic-mcp` and delegates tool calls to those same CLI commands through `internal/cli.ExecuteAutomation`. Keep the MCP layer limited to protocol handling and argument mapping; AWS and config behavior belongs in the existing CLI, auth, and service packages. MCP mutation tools remain preview-only until their trust boundary is reviewed.
+
 ## Branch Naming
 
 Use [`branch-naming-harness.md`](branch-naming-harness.md) for branch names.

--- a/internal/cli/automation.go
+++ b/internal/cli/automation.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+)
+
+// ExecuteAutomation runs an existing machine-readable CLI command and returns
+// its stdout. It keeps automation adapters on the same command contracts as
+// the unic CLI instead of duplicating their business logic.
+func ExecuteAutomation(ctx context.Context, args ...string) ([]byte, error) {
+	cmd := NewRootCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetArgs(args)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	err := cmd.ExecuteContext(ctx)
+	return stdout.Bytes(), err
+}

--- a/internal/cli/automation_test.go
+++ b/internal/cli/automation_test.go
@@ -1,0 +1,21 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestExecuteAutomationUsesExistingJSONCommand(t *testing.T) {
+	output, err := ExecuteAutomation(context.Background(), "schema", "context", "sync", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var contract commandContract
+	if err := json.Unmarshal(output, &contract); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if contract.Path != "unic context sync" {
+		t.Fatalf("path = %q", contract.Path)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -305,7 +305,10 @@ func decodeArguments(raw json.RawMessage, target any) error {
 
 func toolError(err error) map[string]any {
 	structured := map[string]any{"code": "operation_failed", "message": err.Error(), "retryable": false}
-	encoded, _ := json.Marshal(structured)
+	encoded, marshalErr := json.Marshal(structured)
+	if marshalErr != nil {
+		encoded = []byte(`{"code":"operation_failed","message":"failed to encode error","retryable":false}`)
+	}
 	return map[string]any{
 		"content":           []map[string]string{{"type": "text", "text": string(encoded)}},
 		"structuredContent": structured,

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,0 +1,321 @@
+// Package mcp exposes unic's existing automation commands over MCP stdio.
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const ProtocolVersion = "2025-11-25"
+
+type Executor func(context.Context, ...string) ([]byte, error)
+
+type Server struct {
+	version string
+	execute Executor
+}
+
+func New(version string, execute Executor) *Server {
+	return &Server{version: version, execute: execute}
+}
+
+type request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type response struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type tool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	InputSchema map[string]any `json:"inputSchema"`
+	Annotations annotations    `json:"annotations"`
+}
+
+type annotations struct {
+	ReadOnlyHint    bool `json:"readOnlyHint"`
+	DestructiveHint bool `json:"destructiveHint"`
+	IdempotentHint  bool `json:"idempotentHint"`
+	OpenWorldHint   bool `json:"openWorldHint"`
+}
+
+var tools = []tool{
+	{
+		Name: "get_capabilities", Description: "List unic AWS features and automation commands.",
+		InputSchema: objectSchema(nil, nil),
+		Annotations: annotations{ReadOnlyHint: true, IdempotentHint: true},
+	},
+	{
+		Name: "get_command_schema", Description: "Describe one unic automation command contract.",
+		InputSchema: objectSchema(map[string]any{
+			"command": map[string]any{"type": "string", "description": "Command path, for example: context sync"},
+		}, []string{"command"}),
+		Annotations: annotations{ReadOnlyHint: true, IdempotentHint: true},
+	},
+	{
+		Name: "list_backup_vaults", Description: "List AWS Backup vaults using unic's active or selected AWS context.",
+		InputSchema: objectSchema(map[string]any{
+			"profile": map[string]any{"type": "string", "description": "Optional unic context or AWS profile"},
+			"region":  map[string]any{"type": "string", "description": "Optional AWS region"},
+		}, nil),
+		Annotations: annotations{ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: true},
+	},
+	{
+		Name: "plan_context_sync", Description: "Preview an SSO context sync plan. This tool never writes configuration.",
+		InputSchema: objectSchema(map[string]any{
+			"base_context": map[string]any{"type": "string", "description": "Optional SSO base context"},
+			"prune":        map[string]any{"type": "boolean", "default": false, "description": "Show orphaned managed contexts as removals"},
+		}, nil),
+		Annotations: annotations{ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: true},
+	},
+}
+
+func objectSchema(properties map[string]any, required []string) map[string]any {
+	if properties == nil {
+		properties = map[string]any{}
+	}
+	schema := map[string]any{"type": "object", "properties": properties, "additionalProperties": false}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return schema
+}
+
+// Serve reads newline-delimited JSON-RPC messages and writes MCP responses.
+func (s *Server) Serve(ctx context.Context, in io.Reader, out io.Writer) error {
+	scanner := bufio.NewScanner(in)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	encoder := json.NewEncoder(out)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		res, reply := s.handle(ctx, line)
+		if reply {
+			if err := encoder.Encode(res); err != nil {
+				return err
+			}
+		}
+	}
+	return scanner.Err()
+}
+
+func (s *Server) handle(ctx context.Context, message []byte) (response, bool) {
+	var req request
+	if err := json.Unmarshal(message, &req); err != nil {
+		return errorResponse(nil, -32700, "Parse error"), true
+	}
+	if req.JSONRPC != "2.0" || req.Method == "" || (!validID(req.ID) && len(req.ID) > 0) {
+		return errorResponse(nil, -32600, "Invalid Request"), true
+	}
+	if len(req.ID) == 0 {
+		return response{}, false
+	}
+
+	res := response{JSONRPC: "2.0", ID: req.ID}
+	switch req.Method {
+	case "initialize":
+		var params struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		}
+		if err := decodeParams(req.Params, &params); err != nil || params.ProtocolVersion == "" {
+			return errorResponse(req.ID, -32602, "Invalid initialize parameters"), true
+		}
+		if !supportedProtocol(params.ProtocolVersion) {
+			return errorResponse(req.ID, -32602, "Unsupported protocol version"), true
+		}
+		res.Result = map[string]any{
+			"protocolVersion": params.ProtocolVersion,
+			"capabilities":    map[string]any{"tools": map[string]any{"listChanged": false}},
+			"serverInfo":      map[string]string{"name": "unic", "version": s.version},
+			"instructions":    "Use unic tools to discover capabilities and query AWS. Context sync is preview-only and never changes configuration.",
+		}
+	case "ping":
+		res.Result = map[string]any{}
+	case "tools/list":
+		res.Result = map[string]any{"tools": tools}
+	case "tools/call":
+		result, rpcErr := s.callTool(ctx, req.Params)
+		if rpcErr != nil {
+			res.Error = rpcErr
+		} else {
+			res.Result = result
+		}
+	default:
+		res.Error = &rpcError{Code: -32601, Message: "Method not found"}
+	}
+	return res, true
+}
+
+func supportedProtocol(version string) bool {
+	switch version {
+	case "2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05":
+		return true
+	default:
+		return false
+	}
+}
+
+func validID(id json.RawMessage) bool {
+	if len(id) == 0 {
+		return false
+	}
+	var value any
+	if json.Unmarshal(id, &value) != nil {
+		return false
+	}
+	switch value.(type) {
+	case string, float64:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *Server) callTool(ctx context.Context, raw json.RawMessage) (any, *rpcError) {
+	var call struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if err := decodeParams(raw, &call); err != nil || call.Name == "" {
+		return nil, &rpcError{Code: -32602, Message: "Invalid tool call parameters"}
+	}
+
+	args, err := toolArgs(call.Name, call.Arguments)
+	if err != nil {
+		if errors.Is(err, errUnknownTool) {
+			return nil, &rpcError{Code: -32602, Message: err.Error()}
+		}
+		return toolError(err), nil
+	}
+	output, executeErr := s.execute(ctx, args...)
+	output = bytes.TrimSpace(output)
+	if len(output) == 0 {
+		if executeErr == nil {
+			executeErr = errors.New("unic command returned no JSON")
+		}
+		return toolError(executeErr), nil
+	}
+
+	var structured map[string]any
+	if err := json.Unmarshal(output, &structured); err != nil {
+		return toolError(fmt.Errorf("unic command returned invalid JSON: %w", err)), nil
+	}
+	return map[string]any{
+		"content":           []map[string]string{{"type": "text", "text": string(output)}},
+		"structuredContent": structured,
+		"isError":           executeErr != nil,
+	}, nil
+}
+
+var errUnknownTool = errors.New("unknown tool")
+
+func toolArgs(name string, raw json.RawMessage) ([]string, error) {
+	switch name {
+	case "get_capabilities":
+		if err := decodeArguments(raw, &struct{}{}); err != nil {
+			return nil, err
+		}
+		return []string{"capabilities", "--json"}, nil
+	case "get_command_schema":
+		var args struct {
+			Command string `json:"command"`
+		}
+		if err := decodeArguments(raw, &args); err != nil {
+			return nil, err
+		}
+		command := strings.Fields(args.Command)
+		if len(command) == 0 {
+			return nil, errors.New("command is required")
+		}
+		return append(append([]string{"schema"}, command...), "--json"), nil
+	case "list_backup_vaults":
+		var args struct {
+			Profile string `json:"profile"`
+			Region  string `json:"region"`
+		}
+		if err := decodeArguments(raw, &args); err != nil {
+			return nil, err
+		}
+		result := []string{"resources", "backup-vaults", "--json"}
+		if args.Profile != "" {
+			result = append(result, "--profile", args.Profile)
+		}
+		if args.Region != "" {
+			result = append(result, "--region", args.Region)
+		}
+		return result, nil
+	case "plan_context_sync":
+		var args struct {
+			BaseContext string `json:"base_context"`
+			Prune       bool   `json:"prune"`
+		}
+		if err := decodeArguments(raw, &args); err != nil {
+			return nil, err
+		}
+		result := []string{"context", "sync"}
+		if args.BaseContext != "" {
+			result = append(result, args.BaseContext)
+		}
+		result = append(result, "--json")
+		if args.Prune {
+			result = append(result, "--prune")
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("%w %q", errUnknownTool, name)
+	}
+}
+
+func decodeParams(raw json.RawMessage, target any) error {
+	if len(raw) == 0 {
+		raw = []byte("{}")
+	}
+	return json.Unmarshal(raw, target)
+}
+
+func decodeArguments(raw json.RawMessage, target any) error {
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		raw = []byte("{}")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	return decoder.Decode(target)
+}
+
+func toolError(err error) map[string]any {
+	structured := map[string]any{"code": "operation_failed", "message": err.Error(), "retryable": false}
+	encoded, _ := json.Marshal(structured)
+	return map[string]any{
+		"content":           []map[string]string{{"type": "text", "text": string(encoded)}},
+		"structuredContent": structured,
+		"isError":           true,
+	}
+}
+
+func errorResponse(id json.RawMessage, code int, message string) response {
+	if len(id) == 0 {
+		id = json.RawMessage("null")
+	}
+	return response{JSONRPC: "2.0", ID: id, Error: &rpcError{Code: code, Message: message}}
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -72,6 +72,9 @@ func TestToolFailureReturnsStructuredToolError(t *testing.T) {
 		t.Fatal(err)
 	}
 	responses := decodeResponses(t, output.String())
+	if len(responses) == 0 {
+		t.Fatal("expected a response")
+	}
 	result := responses[0].Result.(map[string]any)
 	if result["isError"] != true {
 		t.Fatalf("expected tool error: %#v", result)
@@ -88,6 +91,9 @@ func TestServerRejectsMalformedRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 	responses := decodeResponses(t, output.String())
+	if len(responses) == 0 {
+		t.Fatal("expected a response")
+	}
 	if responses[0].Error == nil || responses[0].Error.Code != -32700 {
 		t.Fatalf("unexpected response: %#v", responses[0])
 	}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,113 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestServerLifecycleAndTools(t *testing.T) {
+	var calls [][]string
+	execute := func(_ context.Context, args ...string) ([]byte, error) {
+		calls = append(calls, args)
+		return []byte(`{"schema_version":"v1","data":[]}`), nil
+	}
+	input := strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}`,
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`,
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_backup_vaults","arguments":{"profile":"prod","region":"us-east-1"}}}`,
+	}, "\n")
+	var output bytes.Buffer
+	if err := New("test", execute).Serve(context.Background(), strings.NewReader(input), &output); err != nil {
+		t.Fatal(err)
+	}
+
+	responses := decodeResponses(t, output.String())
+	if len(responses) != 3 {
+		t.Fatalf("got %d responses, want 3: %s", len(responses), output.String())
+	}
+	if got := responses[0].Result.(map[string]any)["protocolVersion"]; got != ProtocolVersion {
+		t.Fatalf("protocolVersion = %v", got)
+	}
+	listed := responses[1].Result.(map[string]any)["tools"].([]any)
+	if len(listed) != 4 {
+		t.Fatalf("listed %d tools", len(listed))
+	}
+	wantCall := []string{"resources", "backup-vaults", "--json", "--profile", "prod", "--region", "us-east-1"}
+	if !reflect.DeepEqual(calls, [][]string{wantCall}) {
+		t.Fatalf("calls = %#v", calls)
+	}
+	result := responses[2].Result.(map[string]any)
+	if result["isError"] != false || result["structuredContent"].(map[string]any)["schema_version"] != "v1" {
+		t.Fatalf("unexpected tool result: %#v", result)
+	}
+}
+
+func TestPlanContextSyncNeverAddsApply(t *testing.T) {
+	args, err := toolArgs("plan_context_sync", json.RawMessage(`{"base_context":"dev","prune":true}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"context", "sync", "dev", "--json", "--prune"}
+	if !reflect.DeepEqual(args, want) {
+		t.Fatalf("args = %#v, want %#v", args, want)
+	}
+	for _, arg := range args {
+		if arg == "--apply" {
+			t.Fatal("preview-only MCP tool must not apply changes")
+		}
+	}
+}
+
+func TestToolFailureReturnsStructuredToolError(t *testing.T) {
+	execute := func(context.Context, ...string) ([]byte, error) { return nil, errors.New("boom") }
+	input := `{"jsonrpc":"2.0","id":"x","method":"tools/call","params":{"name":"get_capabilities","arguments":{}}}`
+	var output bytes.Buffer
+	if err := New("test", execute).Serve(context.Background(), strings.NewReader(input), &output); err != nil {
+		t.Fatal(err)
+	}
+	responses := decodeResponses(t, output.String())
+	result := responses[0].Result.(map[string]any)
+	if result["isError"] != true {
+		t.Fatalf("expected tool error: %#v", result)
+	}
+	structured := result["structuredContent"].(map[string]any)
+	if structured["code"] != "operation_failed" || structured["message"] != "boom" {
+		t.Fatalf("unexpected structured error: %#v", structured)
+	}
+}
+
+func TestServerRejectsMalformedRequest(t *testing.T) {
+	var output bytes.Buffer
+	if err := New("test", nil).Serve(context.Background(), strings.NewReader("not-json\n"), &output); err != nil {
+		t.Fatal(err)
+	}
+	responses := decodeResponses(t, output.String())
+	if responses[0].Error == nil || responses[0].Error.Code != -32700 {
+		t.Fatalf("unexpected response: %#v", responses[0])
+	}
+}
+
+func decodeResponses(t *testing.T, output string) []responseForTest {
+	t.Helper()
+	var responses []responseForTest
+	decoder := json.NewDecoder(strings.NewReader(output))
+	for decoder.More() {
+		var response responseForTest
+		if err := decoder.Decode(&response); err != nil {
+			t.Fatal(err)
+		}
+		responses = append(responses, response)
+	}
+	return responses
+}
+
+type responseForTest struct {
+	Result any       `json:"result"`
+	Error  *rpcError `json:"error"`
+}


### PR DESCRIPTION
### Summary

- add a dependency-free stdio MCP server with initialize, ping, tool discovery, and tool calls
- expose capability discovery, command schemas, AWS Backup vault queries, and preview-only context-sync plans
- reuse the existing versioned CLI contracts and document local agent setup

### Related Issues

Closes #339

### Validation

- `make test`
- `make build`
- `go build ./cmd/unic-mcp`
- `go vet ./...`
- stdio initialize and `get_command_schema` smoke test

### Checklist

- [x] Scope is focused
- [x] Branch name follows `docs/branch-naming-harness.md`
- [x] Documentation harness reviewed (`docs/documentation-harness.md`)
- [x] README updated if user-facing behavior changed
- [x] Relevant `docs/` pages updated if architecture, auth, config, or workflow changed
- [x] Tests/validation included
- [x] Breaking changes documented
