### PR TITLE
feat: package MCP integrations for AI clients

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "unic",
+  "version": "0.1.0",
+  "description": "Inspect AWS resources and plan unic context changes through a local MCP server.",
+  "author": {
+    "name": "DevopsArtFactory",
+    "url": "https://github.com/DevopsArtFactory"
+  },
+  "homepage": "https://github.com/DevopsArtFactory/unic",
+  "repository": "https://github.com/DevopsArtFactory/unic",
+  "license": "MIT",
+  "keywords": ["aws", "cloud", "infrastructure", "unic", "mcp"]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "name": "unic",
+  "version": "0.1.0",
+  "description": "Inspect AWS resources and plan unic context changes through a local MCP server.",
+  "author": {
+    "name": "DevopsArtFactory",
+    "url": "https://github.com/DevopsArtFactory"
+  },
+  "homepage": "https://github.com/DevopsArtFactory/unic",
+  "repository": "https://github.com/DevopsArtFactory/unic",
+  "license": "MIT",
+  "keywords": ["aws", "cloud", "infrastructure", "unic", "mcp"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "unic AWS",
+    "shortDescription": "Inspect AWS safely with unic",
+    "longDescription": "Discover unic capabilities, inspect supported AWS resources, and preview context synchronization through a local MCP server.",
+    "developerName": "DevopsArtFactory",
+    "category": "Developer Tools",
+    "capabilities": ["AWS resource inspection", "Command discovery", "Context sync preview"],
+    "websiteURL": "https://github.com/DevopsArtFactory/unic",
+    "defaultPrompt": [
+      "Show the AWS capabilities available through unic.",
+      "List my AWS Backup vaults with unic.",
+      "Preview a unic context sync without changing config."
+    ],
+    "brandColor": "#FF9900"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /dist/
 /unic
+/unic-mcp
 .claude/reports/
 # SSM session-manager-plugin temp files (ecs exec session state)
 cs.json

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,25 @@
 version: 2
 
 builds:
-  - main: ./cmd/unic
+  - id: unic
+    main: ./cmd/unic
     binary: unic
+    ldflags:
+      - -s -w
+      - -X unic/internal/cli.Version={{.Version}}
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+  - id: unic-mcp
+    main: ./cmd/unic-mcp
+    binary: unic-mcp
     ldflags:
       - -s -w
       - -X unic/internal/cli.Version={{.Version}}
@@ -18,7 +35,10 @@ builds:
         goarch: arm64
 
 archives:
-  - format: tar.gz
+  - ids:
+      - unic
+      - unic-mcp
+    format: tar.gz
     name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
     format_overrides:
       - goos: windows
@@ -34,9 +54,10 @@ brews:
     description: "Go-based TUI tool for browsing and managing AWS resources in the terminal"
     license: "MIT"
     install: |
-      bin.install "unic"
+      bin.install "unic", "unic-mcp"
     test: |
       system "#{bin}/unic", "--version"
+      assert_predicate bin/"unic-mcp", :executable?
 
 changelog:
   sort: asc

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "unic": {
+      "type": "stdio",
+      "command": "unic-mcp",
+      "args": []
+    }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 APP_NAME := unic
+MCP_APP_NAME := unic-mcp
 VERSION  ?= $(shell git describe --tags --always --dirty 2>/dev/null)
 VERSION  := $(if $(VERSION),$(patsubst v%,%,$(VERSION)),dev)
 DIST_DIR := dist
@@ -15,6 +16,7 @@ all: build
 ## Build for current platform (debug)
 build:
 	go build -ldflags="-X unic/internal/cli.Version=$(VERSION)" -o $(APP_NAME) $(CMD_PATH)
+	go build -ldflags="-X unic/internal/cli.Version=$(VERSION)" -o $(MCP_APP_NAME) ./cmd/unic-mcp
 
 ## Build for current platform (release, stripped)
 release:
@@ -71,7 +73,7 @@ archive: build-all
 ## ── Clean ───────────────────────────────────────────────
 
 clean:
-	rm -f $(APP_NAME)
+	rm -f $(APP_NAME) $(MCP_APP_NAME)
 	rm -rf $(DIST_DIR)
 	go clean
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ brew tap DevopsArtFactory/unic
 brew install unic
 ```
 
+Homebrew and release archives install both the `unic` TUI and the `unic-mcp` stdio server.
+
 ### Install Script
 
 ```bash
@@ -144,25 +146,56 @@ For automation, `unic resources backup-vaults --json` lists AWS Backup vaults us
 
 ### MCP server
 
-Build or install the stdio MCP server for local AI agents:
+`unic-mcp` exposes unic's read-only automation commands to local AI agents. Install it with Homebrew or the install script above, then confirm it is on `PATH`:
 
 ```bash
-go install ./cmd/unic-mcp
+command -v unic-mcp
 ```
 
-Example client configuration:
+It reads the existing unic and AWS configuration from the server process environment. Keep AWS credentials in the standard AWS credential chain; do not put credentials in MCP configuration.
+
+#### Codex
+
+Install this repository as a Codex plugin, or register the server directly:
+
+```bash
+codex mcp add unic -- unic-mcp
+codex mcp get unic
+```
+
+#### Claude Code and Claude Desktop
+
+Claude Code can load the repository plugin or register the same server directly:
+
+```bash
+claude mcp add unic --scope user -- unic-mcp
+claude mcp get unic
+```
+
+For Claude Desktop and other JSON-configured MCP clients, use:
 
 ```json
 {
   "mcpServers": {
     "unic": {
-      "command": "unic-mcp"
+      "command": "unic-mcp",
+      "args": []
     }
   }
 }
 ```
 
-The server exposes capability discovery, command schemas, AWS Backup vault listing, and SSO context-sync planning through the same versioned CLI contracts described above. It reads the existing unic/AWS configuration from the server process environment. The context-sync tool is preview-only: it never passes `--apply` or writes configuration.
+#### Kiro
+
+In Kiro, open **Powers**, choose **Add Custom Power**, and import this repository from GitHub. The root `plugin.json`, `mcp.json`, and `skills/` directory follow the Agent Plugins format used by Kiro Powers.
+
+The server provides `get_capabilities`, `get_command_schema`, `list_backup_vaults`, and `plan_context_sync`. Example prompts:
+
+- `Show the AWS capabilities available through unic.`
+- `List my AWS Backup vaults in ap-northeast-2.`
+- `Preview a unic context sync without changing config.`
+
+The context-sync tool is preview-only: it never passes `--apply` or writes configuration. If a client cannot start the server, verify `unic-mcp` is on the client's `PATH` and that the required AWS profile or SSO session is available in the client process environment.
 
 ## Configuration
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -25,6 +25,8 @@ Read-only automation commands live under `internal/cli/`; keep their `--json` ou
 
 The stdio MCP entry point lives at `cmd/unic-mcp` and delegates tool calls to those same CLI commands through `internal/cli.ExecuteAutomation`. Keep the MCP layer limited to protocol handling and argument mapping; AWS and config behavior belongs in the existing CLI, auth, and service packages. MCP mutation tools remain preview-only until their trust boundary is reviewed.
 
+The repository root is also the portable agent-plugin package. Keep shared MCP guidance in `skills/unic-aws`, Kiro metadata in `plugin.json` and `mcp.json`, and client-specific manifests in `.codex-plugin`, `.claude-plugin`, and `.mcp.json`. All clients must launch the released `unic-mcp` binary from `PATH`; do not add client-specific MCP implementations.
+
 ## Branch Naming
 
 Use [`branch-naming-harness.md`](branch-naming-harness.md) for branch names.

--- a/install.sh
+++ b/install.sh
@@ -43,16 +43,17 @@ curl -sSfL "$URL" -o "${TMPDIR}/${ARCHIVE}"
 # Extract
 tar -xzf "${TMPDIR}/${ARCHIVE}" -C "$TMPDIR"
 
-# Install
+# Install both the TUI and MCP server.
 if [ -w "$INSTALL_DIR" ]; then
-  mv "${TMPDIR}/unic" "${INSTALL_DIR}/unic"
+  install -m 0755 "${TMPDIR}/unic" "${INSTALL_DIR}/unic"
+  install -m 0755 "${TMPDIR}/unic-mcp" "${INSTALL_DIR}/unic-mcp"
 else
   echo "Installing to ${INSTALL_DIR} (requires sudo)..."
-  sudo mv "${TMPDIR}/unic" "${INSTALL_DIR}/unic"
+  sudo install -m 0755 "${TMPDIR}/unic" "${INSTALL_DIR}/unic"
+  sudo install -m 0755 "${TMPDIR}/unic-mcp" "${INSTALL_DIR}/unic-mcp"
 fi
 
-chmod +x "${INSTALL_DIR}/unic"
-
 echo "unic ${TAG} installed to ${INSTALL_DIR}/unic"
+echo "unic-mcp ${TAG} installed to ${INSTALL_DIR}/unic-mcp"
 echo ""
 echo "Run 'unic' to get started."

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "unic": {
+      "type": "stdio",
+      "command": "unic-mcp",
+      "args": []
+    }
+  }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "unic",
+  "version": "0.1.0",
+  "description": "Inspect AWS resources and plan unic context changes through a local MCP server.",
+  "author": {
+    "name": "DevopsArtFactory",
+    "url": "https://github.com/DevopsArtFactory"
+  },
+  "keywords": ["aws", "cloud", "infrastructure", "unic", "mcp"],
+  "homepage": "https://github.com/DevopsArtFactory/unic",
+  "repository": "https://github.com/DevopsArtFactory/unic",
+  "license": "MIT"
+}

--- a/skills/unic-aws/SKILL.md
+++ b/skills/unic-aws/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: unic-aws
+description: Use unic to discover supported AWS operations, inspect AWS Backup vaults, or preview SSO context synchronization through MCP.
+---
+
+# unic AWS
+
+Use the `unic` MCP server for supported AWS inspection and context planning.
+
+1. Call `get_capabilities` when the requested service or operation is unclear.
+2. Call `get_command_schema` before composing an automation command contract.
+3. Call `list_backup_vaults` with optional `profile` and `region` arguments to inspect AWS Backup.
+4. Call `plan_context_sync` to preview SSO context changes. It never applies or writes configuration.
+
+The server inherits local unic and AWS configuration from its process environment. Never request, store, or place AWS credentials in plugin configuration. Report structured permission errors and partial-result warnings to the user.


### PR DESCRIPTION
## Summary

- distribute unic-mcp beside unic in release archives, Homebrew, source builds, and the install script
- add a portable Kiro Power plus Codex and Claude Code plugin manifests sharing one MCP server and skill
- document installation, AWS credential inheritance, example prompts, and troubleshooting

Closes #342

## Verification

- make test
- make build
- Codex plugin validator
- claude plugin validate .
- MCP initialize, tools/list, and get_capabilities smoke test
- GoReleaser v2.18 snapshot release; verified both binaries in macOS, Linux, and Windows archives

## Note

- GoReleaser reports pre-existing deprecation warnings for archive format and Homebrew formula fields; snapshot packaging still succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MCP server for inspecting AWS resources and planning Unic context changes.
  * Added integrations for Codex, Claude, Kiro, and other MCP-compatible clients.
  * Added AWS discovery and context-planning capabilities, including backup vault inspection and permission-aware results.
  * Releases and Homebrew installations now include both the Unic TUI and MCP server.

* **Bug Fixes**
  * Installers now verify both binaries before replacing existing installations.

* **Documentation**
  * Added setup instructions, supported tools, example prompts, and troubleshooting guidance for MCP clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->